### PR TITLE
Add CI/CD workflows per SPEC.md §13

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,5 @@
+steps:
+  - uses: actions/setup-python@v5
+    with:
+      python-version: "3.13"
+  - run: pip install -e ".[all,dev]"

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install ruff
+      - run: ruff check .
+      - run: ruff format --check .

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+        install-extras: ["dev", "all,dev"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[${{ matrix.install-extras }}]"
+      - run: pytest --tb=short -q
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install hatchling build
+      - run: python -m build
+      - run: pip install dist/*.whl
+      - run: python -c "import tracemill; print(tracemill.__name__)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The repo had no automated CI/CD. This adds GitHub Actions workflows so that every PR and push to main gets linted and tested, and tagged releases publish to PyPI automatically.

## Approach

Four files added under `.github/`:

- **ci-lint.yml** -- Runs `ruff check` and `ruff format --check` on PRs and main pushes (Python 3.13).
- **ci-test.yml** -- Matrix job testing Python 3.11/3.12/3.13 with both minimal (`dev`) and full (`all,dev`) extras. A parallel `build` job verifies the wheel installs and imports cleanly.
- **publish.yml** -- Builds and publishes to PyPI on `v*` tags using trusted publishing (OIDC, no API tokens).
- **copilot-setup-steps.yml** -- Configures the Copilot coding agent environment with Python 3.13 and all extras.

## Notes

- `publish.yml` explicitly sets `contents: read` alongside `id-token: write` because GitHub defaults unspecified permissions to `none` when the `permissions` key is present.
- No caching or artifact steps for now -- keeping workflows minimal per spec.