### PR TITLE
docs: rewrite SPEC.md to reflect actual architecture

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,970 +2,1096 @@
 
 *Agent event observation pipeline with pluggable storage backends.*
 
-Mills raw agent traces into structured output.
+Mills raw agent traces into structured, classified, risk-scored output.
 
 ---
 
 ## §1 — What It Is
 
-A standalone Python library that observes AI agent sessions and routes structured events to pluggable storage backends. It is the observation-to-storage pipeline — the plumbing layer between "agent did something" and "that knowledge lives somewhere useful."
+A standalone Python library that **observes AI agent sessions** across any framework and routes structured events to pluggable storage backends. It is the observation-to-storage pipeline — the plumbing layer between "agent did something" and "that knowledge lives somewhere useful."
 
-The library doesn't decide what to do with agent events. It parses them, enriches them, and delivers them to sinks that consumers provide. Known consumers:
+tracemill is framework-agnostic. Adding support for a new agent framework requires only a YAML mapping file — no Python code. It ships with 15 bundled mappings covering the most common agent frameworks and supports arbitrary extensions via user-defined mappings.
 
-- **CodePlane** routes events to SQLite + OTEL for its control plane UI.
-- **memrelay** routes events to Graphiti for persistent agent memory.
-- A hypothetical third project might route to PostgreSQL, Elasticsearch, Langfuse, or a custom analytics pipeline.
+The library handles the full data lifecycle:
+1. **Sources** transport raw data from files, HTTP endpoints, SSE streams, SQLite databases, or replays
+2. **Parsers** pre-process non-structured formats (markdown logs, chunked data) into structured dicts
+3. **Adapters** parse raw input into a common `SessionEvent` type using declarative YAML mappings
+4. **Enricher** adds metadata: tool pairing, duration computation, multi-dimensional classification, risk scoring, phase detection, visibility assignment
+5. **Pipeline** routes enriched events to one or more storage sinks with error isolation
+6. **Sinks** write to storage backends or call custom handlers
 
-**tracemill does not:**
-- Manage processes, spawn adapters, or handle lifecycle
-- Poll filesystems or tail files
-- Query storage (sinks write only — consumers query their own backends)
-- Contain domain logic (no jobs, approvals, memory retrieval, MCP)
-- Do networking (no HTTP, sockets, SSE)
+Known consumers:
+- **CodePlane** routes events to SQLite + OTEL for its control plane UI
+- **memrelay** routes events to Graphiti for persistent agent memory
+- A hypothetical third project might route to PostgreSQL, Elasticsearch, Langfuse, or a custom analytics pipeline
+
+### Extraction Lineage
+
+tracemill was extracted from CodePlane as a standalone library. CodePlane's observation logic was tightly coupled to its UI; tracemill decouples the pipeline so any consumer can subscribe to agent events without importing CodePlane's domain concerns.
 
 ---
 
 ## §2 — Architecture
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    INPUT ADAPTERS                            │
-│                                                             │
-│  MappedJsonAdapter (YAML-driven)    OtelSpanAdapter (MAF spans)  │
-│                                                             │
-│  Each adapter: raw bytes/files → SessionEvent stream        │
-│  Defensive parsing. Unknown fields ignored. Never crash.    │
-└────────────────────────────┬────────────────────────────────┘
-                             │ SessionEvent
-                             ▼
-┌─────────────────────────────────────────────────────────────┐
-│                    EVENT PIPELINE                            │
-│                                                             │
-│  ┌─────────────┐   ┌──────────────┐   ┌────────────────┐   │
-│  │  Enricher   │──▶│  Classifier  │──▶│  Telemetry     │   │
-│  │             │   │              │   │  Instruments   │   │
-│  │ tool pairing│   │ tool category│   │  (OTEL)        │   │
-│  │ duration    │   │ visibility   │   │  counters      │   │
-│  │ intent      │   │ phase detect │   │  histograms    │   │
-│  └─────────────┘   └──────────────┘   └────────────────┘   │
-│                                                             │
-│  Emits enriched events to: registered StorageSinks          │
-└────────────────────────────┬────────────────────────────────┘
-                             │ EnrichedEvent
-                             ▼
-┌─────────────────────────────────────────────────────────────┐
-│                    STORAGE SINKS (pluggable)                 │
-│                                                             │
-│  Consumers implement StorageSink and register with pipeline │
-│                                                             │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌───────────┐  │
-│  │ SQLite   │  │ OTEL     │  │ Callback │  │ Custom    │  │
-│  │          │  │ Exporter │  │          │  │           │  │
-│  │ events   │  │ spans    │  │ testing  │  │ whatever  │  │
-│  │ spans    │  │ metrics  │  │ routing  │  │ you want  │  │
-│  │ counters │  │ traces   │  │          │  │           │  │
-│  └──────────┘  └──────────┘  └──────────┘  └───────────┘  │
-└─────────────────────────────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────┐
-│                    EVENT BUS (optional)                      │
-│                                                             │
-│  In-process async pub/sub. Subscribers are async callables. │
-│  Fan-out via asyncio.gather. Error-isolated.                │
-│  Use for side-effects: SSE broadcast, diff triggers, etc.   │
-└─────────────────────────────────────────────────────────────┘
-```
+`
+┌────────────────────────────────────────────────────────────────────────┐
+│                         SOURCES (Transport)                             │
+│                                                                        │
+│  FileWatchSource  FilePollSource  HttpPollSource  SSESource             │
+│  SqliteSource     ReplaySource                                         │
+│                                                                        │
+│  Each source: transport → async stream of RawRecord                    │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │ RawRecord (payload: str)
+                                   ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                  PARSERS (Optional Pre-processing)                      │
+│                                                                        │
+│  CopilotPreParser (markdown + log lines → event dicts)                 │
+│  AiderPreParser   (markdown → event dicts)                             │
+│                                                                        │
+│  For frameworks that don't emit JSONL natively                         │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │ dict (normalized event)
+                                   ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                    ADAPTERS (Parsing → SessionEvent)                    │
+│                                                                        │
+│  MappedJsonAdapter (YAML-driven, 15 frameworks)                        │
+│  OtelSpanAdapter   (MAF OTel spans → SessionEvent)                     │
+│                                                                        │
+│  Preprocessors normalize complex event shapes before YAML mapping      │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │ SessionEvent
+                                   ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                      EVENT PIPELINE                                     │
+│                                                                        │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │                        ENRICHER                                   │  │
+│  │                                                                   │  │
+│  │  • Tool call pairing (start ↔ complete)                          │  │
+│  │  • Duration computation                                           │  │
+│  │  • Multi-dimensional classification (mechanism/effect/scope/      │  │
+│  │    role/action/capability/structure)                               │  │
+│  │  • Shell AST analysis (bash, PowerShell, cmd)                    │  │
+│  │  • MCP profile matching                                           │  │
+│  │  • Risk scoring (0-100 with MITRE ATT&CK mappings)               │  │
+│  │  • Phase detection (planning/implementation/verification/         │  │
+│  │    exploration/review)                                            │  │
+│  │  • Visibility assignment (visible/system/collapsed)               │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+│                                                                        │
+│  Error-isolated fan-out to all registered sinks                        │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │ Enriched SessionEvent
+                                   ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                       STORAGE SINKS                                     │
+│                                                                        │
+│  CallbackSink (user-provided async functions)                          │
+│  ⬜ SqliteSink     ⬜ JsonlSink     ⬜ S3Sink     ⬜ OtelSink          │
+│                                                                        │
+│  Sinks implement: on_event(), on_span(), on_usage(), flush(), close()  │
+└────────────────────────────────────────────────────────────────────────┘
+`
+
+### Data Flow Summary
+
+`
+Source → [Parser] → Adapter → Enricher → Pipeline → Sink(s)
+`
+
+The pipeline supports three record types flowing through sinks:
+- `SessionEvent` — the primary event type (all enrichment applies here)
+- `TelemetrySpan` — derived span data (start/end pairs)
+- `UsageRecord` — LLM token/cost accounting
 
 ---
 
-## §3 — Core Abstractions
+## §3 — Core Types
 
-```python
-# --- Events ---
+All domain objects inherit from `FrozenModel` (immutable Pydantic model). All configuration/schema objects inherit from `StrictModel` (rejects unknown fields).
 
-class SessionEvent(BaseModel):
-    """The universal event type. Every adapter produces these."""
-    id: str                      # UUID4
-    kind: str                    # open string — use EventKind.* constants
-    session_id: str
-    timestamp: datetime
-    payload: dict[str, Any]      # kind-specific data (see §3.1)
-    metadata: EventMetadata
+### Base Models (`models.py`)
 
+`python
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+class FrozenModel(BaseModel):
+    model_config = ConfigDict(frozen=True)
+`
+
+### EventKind (`types.py`)
+
+An **open string registry** class with 75+ `Final` constants. Grammar:
+
+`
+<domain>[.<object>].<phase>
+`
+
+Any string is a valid `kind` value (forward-compatible), but canonical kinds are defined as constants for autocomplete, documentation, and filtering.
+
+**Domains:** session, turn, message, tool, llm, planning, reasoning, agent, file, command, mcp, hook, permission, input, checkpoint, memory, knowledge, browser, guardrail, skill, workflow, task, telemetry
+
+**Phases:** started, completed, failed, chunk, progress, requested, received, granted, denied, created, restored, skipped
+
+`python
 class EventKind:
-    """Open string registry with canonical constants.
-    Grammar: <domain>[.<object>].<phase>
-    Any string is valid — adapters may emit custom kinds."""
+    SESSION_STARTED: Final = "session.started"
+    TOOL_CALL_STARTED: Final = "tool.call.started"
+    TOOL_CALL_COMPLETED: Final = "tool.call.completed"
+    LLM_CALL_STARTED: Final = "llm.call.started"
+    # ... 75+ constants total
+    RAW: Final = "raw"  # catch-all for unmapped events
 
-    SESSION_STARTED = "session.started"
-    SESSION_ENDED = "session.ended"
-    MESSAGE_USER = "message.user"
-    MESSAGE_ASSISTANT = "message.assistant"
-    TOOL_CALL_STARTED = "tool.call.started"
-    TOOL_CALL_COMPLETED = "tool.call.completed"
-    USAGE = "usage"
-    ERROR = "error"
-    RAW = "raw"
-    # ... 50+ canonical kinds (see §3.2)
+KNOWN_KINDS: frozenset[str]  # all canonical kinds for validation/filtering
+`
 
-class EventMetadata(BaseModel):
-    """Contextual information attached to every event."""
+### IngestionMode
 
-    # Provenance
-    source_framework: str | None     # "copilot", "claude", "aider", "cline", etc.
-    source_adapter: str | None       # adapter class that produced this event
-    ingestion_mode: IngestionMode    # "stream" | "file_watch" | "poll" | "replay"
-    raw_kind: str | None             # original framework event type
+`python
+IngestionMode = Literal["stream", "file_watch", "poll", "replay", "sqlite"]
+`
+
+### EventMetadata
+
+`python
+class EventMetadata(FrozenModel):
+    # Source provenance
+    source_framework: str | None        # "copilot", "claude", "aider", etc.
+    ingestion_mode: IngestionMode | None
+    raw_kind: str | None                # original framework-specific event type
 
     # Correlation
-    span_id: str | None              # unique ID for this lifecycle span
-    parent_id: str | None            # links child events to parent
-    correlation_id: str | None       # groups related events
-    run_id: str | None               # top-level run/session identifier
+    span_id: str | None
+    parent_id: str | None
+    correlation_id: str | None
+    run_id: str | None
 
     # Ordering
-    sequence: int | None             # monotonic ordering within a stream
-    namespace: tuple[str, ...] | None  # scope path (subgraph, subagent)
-    partial: bool = False            # True if streaming chunk
+    sequence: int | None
+    namespace: tuple[str, ...] | None   # scope path (subgraph, subagent)
+    partial: bool = False               # True for streaming chunks
 
-    # Classification (populated by Enricher)
-    visibility: str = "visible"      # "visible", "system", "collapsed"
-    phases: frozenset[str] | None
+    # Enrichment (set by Enricher)
+    repo: str | None
+    turn_id: str | None
+    visibility: Visibility = Visibility.VISIBLE
+    phases: frozenset[Phase] | None
     classification: Classification | None
     tool_display: str | None
     tool_intent: str | None
     duration_ms: float | None
+`
 
-# --- Adapters ---
+### SessionEvent
 
+`python
+class SessionEvent(FrozenModel):
+    id: str                              # UUID4, auto-generated
+    kind: str                            # open string (use EventKind constants)
+    session_id: str
+    timestamp: datetime
+    payload: dict[str, Any]
+    raw_event: dict[str, Any] | None     # original event data, verbatim
+    metadata: EventMetadata
+`
+
+### TelemetrySpan
+
+`python
+class TelemetrySpan(FrozenModel):
+    name: str
+    session_id: str
+    start_time: datetime
+    end_time: datetime
+    attributes: dict[str, Any]
+`
+
+### UsageRecord
+
+`python
+class UsageRecord(FrozenModel):
+    session_id: str
+    timestamp: datetime
+    model: str
+    input_tokens: int       # >= 0
+    output_tokens: int      # >= 0
+    cost_usd: float | None  # >= 0
+`
+
+---
+
+## §4 — Sources
+
+The async transport layer. Each source implements the `Source` ABC: an async context manager that yields `RawRecord` objects via `__aiter__`.
+
+### Source ABC (`sources/base.py`)
+
+`python
+@dataclass(slots=True)
+class RawRecord:
+    payload: str
+    source_name: str
+    mode: IngestionMode
+    sequence: int | None = None
+    received_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+class Source(ABC):
+    name: str
+    async def __aenter__(self) -> "Source": ...
+    async def __aexit__(self, ...): ...
+    def __aiter__(self) -> AsyncIterator[RawRecord]: ...
+`
+
+### Implementations
+
+| Source | Mode | Description |
+|--------|------|-------------|
+| `FileWatchSource` | `file_watch` | OS-native events via watchdog. Handles rotation, truncation, creation. |
+| `FilePollSource` | `poll` | Fixed-interval polling. For network mounts where inotify is unavailable. |
+| `HttpPollSource` | `poll` | HTTP polling with ETag/Last-Modified conditional requests. Retry with exponential backoff. Cursor-based pagination. |
+| `SSESource` | `stream` | WHATWG-compliant Server-Sent Events. Reconnect with backoff, Last-Event-ID. |
+| `SqliteSource` | `sqlite` | Poll a SQLite table for new rows via monotonic cursor column. WAL mode for concurrent reads. |
+| `ReplaySource` | `replay` | One-shot file read, line-by-line. For testing and batch reprocessing. |
+
+All sources:
+- Are single-consumer (no concurrent iteration)
+- Detect file rotation/truncation where applicable
+- Run I/O in background threads to avoid blocking the event loop
+- Validate resources on `__aenter__`
+
+---
+
+## §5 — Adapters
+
+Adapters parse raw bytes/strings into `SessionEvent` streams.
+
+### Adapter ABC (`adapters/base.py`)
+
+`python
 class Adapter(ABC):
-    """Parses raw agent output into SessionEvents.
-    May track session_id across calls (stateful for session context)."""
+    def parse(self, raw: bytes | str) -> Iterator[SessionEvent]: ...
 
-    @abstractmethod
-    def parse(self, raw: bytes | str) -> Iterator[SessionEvent]:
-        """Parse raw input and yield zero or more SessionEvents.
-        Must never raise — log warnings for unparseable input and continue."""
-        ...
+class JsonLineAdapter(Adapter):
+    """Handles bytes→str, JSON parsing, dict validation."""
+    def parse_dict(self, obj: dict[str, Any]) -> Iterator[SessionEvent]: ...
+`
 
-# --- Enrichment ---
+### MappedJsonAdapter (`adapters/mapped_json.py`)
 
+The primary adapter — data-driven via YAML mappings. No custom Python code needed per framework.
+
+`python
+class MappedJsonAdapter(JsonLineAdapter):
+    def __init__(self, mapping: FrameworkMapping, session_id: str): ...
+    def parse_dict(self, obj: dict) -> Iterator[SessionEvent]: ...
+
+    @classmethod
+    def from_yaml(cls, yaml_path: str, session_id: str) -> "MappedJsonAdapter": ...
+`
+
+Features:
+- Dot-path field extraction (`foo.bar.0.baz`)
+- Literal values (`literal:some_value`)
+- Timestamp heuristic parsing (ISO, unix seconds, milliseconds, nanoseconds)
+- Preprocessor dispatch for non-flat event schemas
+- Default kind for unmapped event types
+
+### OtelSpanAdapter (`adapters/otel.py`)
+
+For Microsoft 365 Agents SDK (MAF) which emits OTel spans instead of JSON lines.
+
+`python
+class OtelSpanAdapter(Adapter):
+    def __init__(self, ingestion_mode: IngestionMode, session_id: str): ...
+    def parse_span(self, span: dict[str, Any]) -> Iterator[SessionEvent]: ...
+    def parse(self, raw: str) -> Iterator[SessionEvent]: ...
+`
+
+Features:
+- Both snake_case and camelCase OTel JSON keys
+- Duration computation from start/end nanoseconds
+- Attribute extraction via YAML-configured rules (`maf.yaml`)
+- Status code → error kind mapping
+
+---
+
+## §6 — YAML Mapping System
+
+The declarative configuration format that drives `MappedJsonAdapter`.
+
+### Schema (`FrameworkMapping`)
+
+`yaml
+framework: copilot               # framework identifier
+framework_version: "1.x"        # format version this mapping targets
+ingestion_mode: file_watch       # must be explicit
+type_field: type                 # dot-path to event type discriminator
+timestamp_field: timestamp       # dot-path to timestamp
+default_kind: raw                # kind for unmapped event types
+preprocessor: claude             # optional: registered preprocessor name
+
+events:
+  session.start:                 # raw event type value
+    kind: session.started        # canonical EventKind
+    payload:                     # field_name → dot-path extraction
+      model: data.selectedModel
+      cwd: data.context.cwd
+`
+
+### Bundled Mappings (15 files in `src/tracemill/mappings/`)
+
+| File | Framework | Notes |
+|------|-----------|-------|
+| `copilot.yaml` | GitHub Copilot CLI | JSONL session events |
+| `copilot_markdown.yaml` | Copilot CLI | For CopilotPreParser output |
+| `claude.yaml` | Claude Code (Anthropic) | Uses `claude` preprocessor |
+| `cline.yaml` | Cline (VS Code) | Uses `cline` preprocessor |
+| `aider.yaml` | Aider | JSONL mode |
+| `aider_markdown.yaml` | Aider | For AiderPreParser output |
+| `crewai.yaml` | CrewAI | Multi-agent framework |
+| `goose.yaml` | Goose (Block) | Uses `goose` preprocessor |
+| `langgraph.yaml` | LangGraph | LangChain orchestration |
+| `maf.yaml` | Microsoft 365 Agents SDK | OTel span mapping (used by OtelSpanAdapter) |
+| `opencode.yaml` | OpenCode | CLI coding agent |
+| `openhands.yaml` | OpenHands (All-Hands AI) | Uses `openhands` preprocessor |
+| `pydantic_ai.yaml` | PydanticAI | Uses `pydantic_ai` preprocessor |
+| `smolagents.yaml` | SmoLAgents (HuggingFace) | Uses `smolagents` preprocessor |
+| `sweagent.yaml` | SWE-Agent (Princeton) | SWE-bench agent |
+
+### Mapping Resolution (`config/mappings.py`)
+
+Search order (first match wins):
+1. User-specified dirs (from `config.mappings_dirs`)
+2. `~/.tracemill/mappings/` (default user dir)
+3. Bundled mappings (`src/tracemill/mappings/`)
+
+User mappings override bundled ones with the same name.
+
+---
+
+## §7 — Preprocessors
+
+Preprocessors normalize raw dicts into flat dicts suitable for type_field-based YAML mapping. They handle compound discriminators, nested structures, and field-presence-based typing.
+
+### Registry Pattern (`preprocessors/registry.py`)
+
+`python
+PreprocessorFn = Callable[[dict[str, Any]], list[dict[str, Any]]]
+
+@register_preprocessor("claude")
+def preprocess_claude(obj: dict) -> list[dict]: ...
+`
+
+### Registered Preprocessors (6)
+
+| Name | Module | Framework | Purpose |
+|------|--------|-----------|---------|
+| `claude` | `preprocessors/claude.py` | Claude Code | Normalizes nested content blocks |
+| `cline` | `preprocessors/cline.py` | Cline | Handles VS Code extension format |
+| `goose` | `preprocessors/goose.py` | Goose | Normalizes Block's event shape |
+| `openhands` | `preprocessors/openhands.py` | OpenHands | Handles action/observation dicts |
+| `pydantic_ai` | `preprocessors/pydantic_ai.py` | PydanticAI | Normalizes streaming parts |
+| `smolagents` | `preprocessors/smolagents.py` | SmoLAgents | Handles HuggingFace format |
+
+Each preprocessor:
+- Takes a single raw dict
+- Returns a list of flat dicts (one input may expand to multiple events)
+- Is referenced by name in the YAML mapping's `preprocessor` field
+
+---
+
+## §8 — Parsers
+
+Custom pre-parsers for frameworks that don't emit JSONL natively. These convert unstructured formats (markdown, log files) into structured event dicts that can then flow through `MappedJsonAdapter`.
+
+### Base Class (`parsers/base.py`)
+
+`python
+class MarkdownPreParser(ABC):
+    """Tree-sitter markdown AST parser with incremental support."""
+
+    def parse_file(self, path: Path) -> Iterator[dict[str, Any]]: ...
+    def parse_text(self, text: str) -> Iterator[dict[str, Any]]: ...
+    def parse_chunk(self, chunk: str) -> Iterator[dict[str, Any]]: ...
+    def flush(self) -> Iterator[dict[str, Any]]: ...
+`
+
+Features:
+- Full-file and incremental (chunked) parsing modes
+- Hold-back of final event until next chunk confirms structural closure
+- Block extraction via tree-sitter queries
+- Sorted-by-position processing
+
+### CopilotPreParser (`parsers/copilot.py`)
+
+Handles two Copilot CLI data sources:
+1. **Markdown parsing** (`parse_turn`): Extracts tool calls and structured blocks from `session-store.db` assistant_response text
+2. **Log line parsing** (`parse_log_line`): Extracts structured API events from `process-*.log` files
+
+Emits events suitable for `copilot_markdown.yaml` mapping.
+
+### AiderPreParser (`parsers/aider.py`)
+
+Converts `.aider.chat.history.md` into structured event dicts:
+- Session start detection from `# aider chat started at ...` headings
+- User message / slash command extraction from `####` headings
+- Tool output sub-classification (version, model, repo, usage, edits, commits, errors)
+- SEARCH/REPLACE block extraction for file edits
+- AI response content from paragraphs/setext headings
+
+Emits events suitable for `aider_markdown.yaml` mapping.
+
+---
+
+## §9 — Enrichment
+
+The `Enricher` (`enricher.py`) is a stateful per-session processor that sits inside the pipeline. It transforms raw events before they reach sinks.
+
+### Enricher API
+
+`python
 class Enricher:
-    """Stateful per-session. Pairs tool start/complete, computes duration,
-    classifies intent. Bounded memory (one session's worth of pending pairs)."""
+    def __init__(
+        self,
+        custom_classifications: dict[str, Classification] | None = None,
+        config: ClassifyConfig | None = None,
+        config_path: Path | str | None = None,
+    ) -> None: ...
 
-    def process(self, event: SessionEvent) -> SessionEvent | None:
-        """Enrich a single event. Returns None if event is buffered (e.g., tool_start
-        waiting for its tool_complete pair). Returns enriched event when ready."""
-        ...
+    def process(self, event: SessionEvent) -> SessionEvent | list[SessionEvent] | None: ...
+    def flush(self) -> list[SessionEvent]: ...
+`
 
-# --- Storage Sinks ---
+### Enrichment Steps
 
-class StorageSink(ABC):
-    """Where enriched events land. Implement per backend."""
+1. **Tool call pairing**: Buffers `TOOL_CALL_STARTED` events, pairs them with matching `TOOL_CALL_COMPLETED` by `tool_call_id`. Merges payloads. Emits orphan starts on displacement or flush.
 
-    async def on_event(self, event: SessionEvent) -> None: ...
-    async def on_span(self, span: TelemetrySpan) -> None: ...
-    async def on_usage(self, usage: UsageRecord) -> None: ...
+2. **Duration computation**: Calculates `metadata.duration_ms` from timestamp difference of start/complete pairs.
+
+3. **Classification dispatch**: For `TOOL_CALL_STARTED` and unpaired `TOOL_CALL_COMPLETED`:
+   - Shell tools → deep tree-sitter AST analysis (bash, PowerShell, cmd)
+   - Native tools → static classification via engine lookup
+   - MCP tools → profile-based classification
+   - Scope refinement from file paths in payload
+
+4. **Risk scoring**: Computes a 0-100 risk score:
+   - Shell commands: structural + flag modifiers + injection patterns + pipeline taint + context
+   - Native/MCP tools: intent base + scope + capability escalation + context
+
+5. **Visibility assignment**: Sets `metadata.visibility` based on event kind (system events, bookkeeping → SYSTEM; similar repeated events → COLLAPSED).
+
+6. **Phase detection**: Derives `metadata.phases` from classification dimensions.
+
+### Return Semantics
+
+- Returns `None` → event is buffered (waiting for pair)
+- Returns `SessionEvent` → enriched event ready for sinks
+- Returns `list[SessionEvent]` → displaced orphan + new buffer (rare)
+
+---
+
+## §10 — Classification Engine
+
+A YAML-driven, multi-dimensional classification system for tool invocations. Located in the `classify/` package (14 modules + 9 data files).
+
+### Dimensions (`classify/core.py`)
+
+| Dimension | Question | Root Values |
+|-----------|----------|-------------|
+| `Mechanism` | What resource domain? | filesystem, process, network, database, delegation, communication, unknown |
+| `Effect` | What state change? | read_only, mutating, destructive |
+| `Scope` | What's being operated on? | artifact, state, data, configuration, knowledge, identity, message |
+| `Role` | What archetype of tool? | validator, retriever, transformer, generator, modifier, executor, communicator, orchestrator, observer, persistence |
+| `Action` | What verb? | validate, retrieve, transform, generate, execute, deliver, configure, analyze, persist, modify, remove |
+| `Capability` | What permissions needed? | filesystem_read, filesystem_write, network_inbound, network_outbound, subprocess, uses_credentials, elevated_privilege, human_interaction |
+| `Structure` | Composition pattern? | sequential, parallel, conditional, interactive |
+
+### Coding Domain Extensions (`classify/coding.py`)
+
+Dot-path subtypes that extend root dimensions for software engineering:
+
+- `CodingMechanism`: process.shell, process.repl, process.debug, network.http, database.sql, delegation.agent, communication.user, etc.
+- `CodingScope`: artifact.source_code, artifact.test_code, configuration.dependency, state.repository, etc.
+- `CodingRole`: validator.linter, validator.test_runner, transformer.compiler, executor.script_runner, persistence.version_control, etc.
+- `CodingAction`: validate.lint, validate.test, transform.compile, persist.commit, deliver.deploy, etc.
+- `ShellDialect`: bash, powershell, cmd, zsh, fish, posix_sh
+- `ShellStructure`: piped, redirected
+
+### Classification Dataclass
+
+`python
+@dataclass(frozen=True)
+class Classification:
+    mechanism: str
+    effect: str | None = None
+    scope: frozenset[str] = frozenset()
+    role: frozenset[str] = frozenset()
+    action: frozenset[str] = frozenset()
+    capability: frozenset[str] = frozenset()
+    structure: frozenset[str] = frozenset()
+    shell_dialect: str | None = None
+    binaries: tuple[str, ...] = ()
+    phase_map: tuple[PhaseSegment, ...] = ()
+`
+
+### Shell Classification (`classify/shell.py`, `classify/powershell.py`, `classify/cmd.py`)
+
+Deep AST-based classification of shell commands:
+- **Bash**: tree-sitter-bash parser. Handles compound commands, pipes, redirects, conditionals. Detects structural patterns.
+- **PowerShell**: tree-sitter-powershell parser. Handles cmdlets and native commands.
+- **cmd.exe**: Lightweight tokenization (no mature tree-sitter grammar). Splits on & and &&.
+
+Shared infrastructure:
+- Transparent wrapper unwrapping (env, sudo, nohup, etc.)
+- Binary classification via rule tables
+- Subcommand and flag analysis
+- Activity detection (verification, delivery, setup, investigation, implementation)
+- Per-command phase grouping into `phase_map`
+
+### MCP Classification (`classify/mcp.py`)
+
+Profile-based classification for MCP (Model Context Protocol) tools:
+
+`python
+@dataclass(frozen=True)
+class McpServerProfile:
+    namespace_aliases: tuple[str, ...]  # e.g., ("github", "gh")
+    mechanism: str
+    role: frozenset[str]
+    default_effect: str | None
+    scope: frozenset[str]
+    action: frozenset[str]
+    capability: frozenset[str]
+    tool_overrides: dict[str, McpToolOverride]
+`
+
+Namespace extraction from `mcp__<server>__<tool>` naming convention.
+
+### Risk Scoring (`classify/risk.py`)
+
+Produces a 0-100 risk score with confidence level and MITRE ATT&CK technique mappings.
+
+`python
+@dataclass(frozen=True, slots=True)
+class RiskAssessment:
+    score: int        # 0-100
+    level: str        # safe / caution / danger / critical
+    confidence: str   # high / medium / low
+    factors: tuple[str, ...]
+    mitre: tuple[str, ...]
+    version: str
+`
+
+Scoring layers:
+1. **Structural**: Effect × scope (from Classification)
+2. **Flag modifiers**: Per-binary flag rules (from `risk.yaml`)
+3. **Injection patterns**: Regex-matched evasion/injection patterns (capped)
+4. **Pipeline taint**: Source→sink flow escalation through pipe operators
+5. **Context**: Project-relative path targeting adjustments
+
+### ClassificationEngine (`classify/config.py`)
+
+Immutable pre-built runtime indexes constructed once from config:
+
+`python
+class ClassificationEngine:
+    canonical_tools: dict[str, str]
+    tool_classifications: dict[str, Classification]
+    verb_inference: dict[str, tuple[str, str]]
+    shell_rules: tuple[Rule, ...]
+    rules_by_binary: dict[str, tuple[Rule, ...]]
+    binary_info: dict[str, BinaryInfo]
+    mcp_profiles: tuple[McpServerProfile, ...]
+    mcp_alias_index: dict[str, McpServerProfile]
+    risk_config: dict[str, Any] | None
+    # ... plus lookup tables for npm scripts, interpreter modules, git subcmds, etc.
+`
+
+### Classification Data Files (`classify/data/`)
+
+| File | Content |
+|------|---------|
+| `canonical_tools.yaml` | Tool name aliases (many→one normalization) |
+| `verb_inference.yaml` | Verb prefix → (effect, action) mappings |
+| `binary_info.yaml` | Static metadata about known binaries (role, network, destructive) |
+| `shell_defaults.yaml` | Activity→dimension default mappings |
+| `shell_rules.yaml` | Declarative binary+subcmd+flag→classification rules |
+| `effect_overrides.yaml` | Per-binary flag/subcmd effect override rules |
+| `mcp_profiles.yaml` | MCP server classification profiles |
+| `tool_classifications.yaml` | Full classifications for known native tools |
+| `risk.yaml` | Risk scoring weights, flag modifiers, injection patterns, taint rules |
+
+### Workflow Dimensions (`classify/workflow.py`)
+
+Derived/presentation concerns separate from semantic classification:
+
+`python
+class Phase(StrEnum):
+    PLANNING, IMPLEMENTATION, VERIFICATION, EXPLORATION, REVIEW
+
+class Visibility(StrEnum):
+    VISIBLE, SYSTEM, COLLAPSED
+`
+
+### Dimension Registry (`classify/registry.py`)
+
+Validates and queries hierarchical dot-path classification values:
+
+`python
+class DimensionRegistry:
+    def register_dimension(self, name: str, enum_cls: type[StrEnum]) -> None: ...
+    def extend_dimension(self, name: str, enum_cls: type[StrEnum]) -> None: ...
+    def validate(self, dimension: str, value: str) -> bool: ...
+    def children_of(self, dimension: str, ancestor: str) -> frozenset[str]: ...
+    def is_descendant_of(self, dimension: str, value: str, ancestor: str) -> bool: ...
+`
+
+---
+
+## §11 — Pipeline
+
+`EventPipeline` (`pipeline.py`) routes events, spans, and usage records to multiple storage sinks with error isolation.
+
+`python
+class EventPipeline:
+    def __init__(self, sinks: list[StorageSink], enricher: Enricher | None = None) -> None: ...
+
+    async def push(self, event: SessionEvent) -> None: ...
+    async def push_span(self, span: TelemetrySpan) -> None: ...
+    async def push_usage(self, usage: UsageRecord) -> None: ...
     async def flush(self) -> None: ...
     async def close(self) -> None: ...
+`
 
-# --- Pipeline ---
+### Behavior
 
-class EventPipeline:
-    """Orchestrates: adapter output → enrichment → sinks."""
-
-    def __init__(self, sinks: list[StorageSink], enricher: Enricher | None = None):
-        ...
-
-    async def push(self, event: SessionEvent) -> None:
-        """Enrich and fan-out to all registered sinks.
-        Sinks are error-isolated — one failing sink does not block others."""
-        ...
-
-# --- Event Bus (optional) ---
-
-class EventBus:
-    """In-process pub/sub for side-effects. Not required for storage flow."""
-
-    def subscribe(self, handler: Callable[[SessionEvent], Awaitable[None]]) -> None: ...
-    async def publish(self, event: SessionEvent) -> None: ...
-```
-
-### §3.1 — Event Kind Taxonomy
-
-Event kinds use dot-notation: `<domain>[.<object>].<phase>`. Any string is valid (forward-compatible), but canonical kinds are registered in `KNOWN_KINDS`.
-
-| Domain | Canonical Kinds |
-|---|---|
-| **session** | `session.started`, `session.ended`, `session.paused`, `session.resumed`, `session.idle`, `session.info`, `session.warning` |
-| **turn** | `turn.started`, `turn.ended`, `turn.skipped` |
-| **message** | `message.user`, `message.assistant`, `message.system`, `message.assistant.chunk` |
-| **tool** | `tool.call.started`, `tool.call.completed`, `tool.call.failed`, `tool.result.chunk`, `tool.progress`, `tool.validation.failed` |
-| **llm** | `llm.call.started`, `llm.call.completed`, `llm.call.failed`, `llm.output.chunk`, `llm.thinking.chunk` |
-| **planning** | `planning.started`, `planning.completed`, `planning.failed`, `reasoning.started`, `reasoning.completed` |
-| **agent** | `agent.spawned`, `agent.completed`, `agent.failed`, `agent.handoff` |
-| **file** | `file.created`, `file.edited`, `file.deleted`, `file.read` |
-| **command** | `command.started`, `command.output`, `command.completed`, `command.failed` |
-| **mcp** | `mcp.connection.started`, `mcp.connection.completed`, `mcp.connection.failed` |
-| **hook** | `hook.started`, `hook.completed`, `hook.failed` |
-| **permission** | `permission.requested`, `permission.granted`, `permission.denied` |
-| **input** | `input.requested`, `input.received` |
-| **checkpoint** | `checkpoint.created`, `checkpoint.restored` |
-| **memory** | `memory.query.started`, `memory.query.completed`, `memory.save.started`, `memory.save.completed` |
-| **knowledge** | `knowledge.query.started`, `knowledge.query.completed` |
-| **browser** | `browser.launched`, `browser.action`, `browser.result` |
-| **guardrail** | `guardrail.started`, `guardrail.passed`, `guardrail.failed` |
-| **skill** | `skill.invoked` |
-| **workflow** | `workflow.started`, `workflow.completed`, `workflow.failed`, `task.started`, `task.completed`, `task.failed` |
-| **telemetry** | `usage`, `error`, `abort` |
-| **catch-all** | `raw` (unmapped events with `payload["original_type"]`) |
-
-Unknown/unmapped event types from any framework are emitted as `raw` with the original type preserved in `payload["original_type"]`.
-
-### §3.2 — Payload Contracts
-
-Each event family has minimum expected payload keys:
-
-| Kind Family | Required Payload Keys |
-|---|---|
-| `tool.call.started` | `tool_call_id`, `tool_name`, `arguments` |
-| `tool.call.completed` | `tool_call_id`, `success`, `result` |
-| `message.*` | `content` |
-| `usage` | `input_tokens`, `output_tokens` |
-| `session.started` | `model` |
-| `error` | `message` |
-| `agent.spawned` | `agent_id` or `extras` |
-| `raw` | `original_type`, `extras` |
-
-Additional keys are optional and framework-specific. Sinks must handle missing keys gracefully.
-
-### §3.3 — Ingestion Modes
-
-| Mode | Description | Guarantees |
-|---|---|---|
-| `stream` | Live SDK callback/async stream | Real-time timestamps, strong ordering |
-| `file_watch` | Tailing JSONL/SQLite on disk | File-provided timestamps, per-file ordering |
-| `poll` | Periodic API/DB checks | Possible gaps, need dedup watermarks |
-| `replay` | Historical playback of recorded events | Original timestamps preserved |
+- **Enrichment**: If an enricher is configured, events pass through `enricher.process()` before reaching sinks. Enricher failures fall through gracefully (raw event passed to sinks).
+- **Error isolation**: Each sink call is wrapped in `asyncio.gather(return_exceptions=True)`. One failing sink does not block others.
+- **Fan-out**: All sinks receive every event concurrently.
+- **Flush**: Drains enricher buffer (unpaired tool starts), then flushes all sinks.
+- **Close**: Flush + close all sinks (also error-isolated).
 
 ---
 
-## §4 — Adapters
+## §12 — Storage Sinks
 
-Each adapter handles one agent SDK's output format. Adapters leverage their respective **SDK packages** for deserialization — avoiding fragile hand-rolled JSON parsing. A consumer feeds raw data to the adapter and receives structured events back.
+### StorageSink ABC (`sinks/base.py`)
 
-### Dependencies
+`python
+class StorageSink(ABC):
+    @abstractmethod
+    async def on_event(self, event: SessionEvent) -> None: ...
+    async def on_span(self, span: TelemetrySpan) -> None: ...   # default no-op
+    async def on_usage(self, usage: UsageRecord) -> None: ...   # default no-op
+    async def flush(self) -> None: ...                          # default no-op
+    async def close(self) -> None: ...                          # default no-op
+`
 
-| Package | Version | Purpose |
-| --- | --- | --- |
-| `pydantic` | `>=2.0` | Data models, config validation |
-| `pyyaml` | `>=6.0` | YAML mapping and config parsing |
-| `tree-sitter` | `>=0.24` | Shell command classification |
-| `tree-sitter-bash` | `>=0.24` | Bash grammar for classifier |
-| `tree-sitter-powershell` | `>=0.24` | PowerShell grammar for classifier |
+### Implementations
 
-No framework SDK dependencies. All frameworks are parsed via declarative YAML mappings.
-
-### Adapter Table
-
-| Adapter | Input | Mechanism | Interface |
-| --- | --- | --- | --- |
-| `MappedJsonAdapter` + `copilot.yaml` | Copilot `events.jsonl` | YAML dot-path extraction | `parse(raw)` |
-| `MappedJsonAdapter` + `claude.yaml` | Claude session JSONL | YAML + `claude` preprocessor | `parse(raw)` |
-| `MappedJsonAdapter` + `*.yaml` | Any YAML-mapped framework | YAML dot-path extraction | `parse(raw)` |
-| `OtelSpanAdapter` | OTel span JSON | YAML span mapping (`maf.yaml`) | `parse(raw)` / `parse_span(dict)` |
-
-### Unified Interface
-
-Adapters expose one usage pattern:
-
-- **`parse(raw: bytes | str)`** -- Accepts a raw JSON line, maps via YAML dot-paths, and yields `SessionEvent`s.
-
-New frameworks are added by writing a YAML mapping file (no Python code required). Complex event shapes (e.g., Claude's nested content blocks) use a preprocessor to flatten into individual dicts before YAML mapping.
-
-### Adapter Contract
-
-- **Never crash.** JSON parse failures are caught and logged at debug level. Unknown event types map to `default_kind` (either `raw` or silently skipped when `default_kind: ""`). Completely unparseable input yields zero events.
-- **Constructor session_id.** The `session_id` is set at construction time and applied to all events.
-- **Yield zero or more events.** A single line of input may produce zero events (noise/skipped) or multiple events (Claude assistant messages with multiple content blocks, via preprocessor).
-
-### Copilot Event Type Mapping
-
-Defined in `mappings/copilot.yaml`. Wire format: `{type, id, timestamp, data: {...}}`.
-
-| Wire Type | Canonical Kind |
-| --- | --- |
-| `session.start` | `session.started` |
-| `session.shutdown` | `session.ended` |
-| `user.message` | `message.user` |
-| `assistant.message` | `message.assistant` |
-| `tool.execution_start` | `tool.call.started` |
-| `tool.execution_complete` | `tool.call.completed` |
-| `assistant.usage` | `telemetry.usage` |
-| `session.error` | `session.error` |
-
-Plus 20+ additional mappings for turn, hook, agent, permission, skill, and input events. Unmapped types emit as `raw`.
-
-### Claude Message Type Mapping
-
-Defined in `mappings/claude.yaml` with `claude` preprocessor. Wire format varies by message type.
-
-| Preprocessed Block Type | Canonical Kind |
-| --- | --- |
-| `user.text` | `message.user` |
-| `assistant.text` | `message.assistant` |
-| `assistant.tool_use` | `tool.call.started` |
-| `assistant.tool_result` | `tool.call.completed` |
-| `assistant.thinking` | `llm.thinking.chunk` |
-| `result` | `telemetry.usage` |
-| `system` | Silently skipped (`default_kind: ""`) |
-
-### §4.1 — Target Framework Coverage
-
-The event taxonomy is designed to accommodate all major agent frameworks:
-
-| Framework | Ingestion Mode | Status |
-|---|---|---|
-| **GitHub Copilot** | `file_watch` (events.jsonl) | ✅ YAML-mapped (`copilot.yaml`) |
-| **Claude Code** | `file_watch` (session JSONL) | ✅ YAML-mapped (`claude.yaml` + preprocessor) |
-| **Aider** | `file_watch` (markdown logs) | ✅ YAML-mapped (`aider_markdown.yaml` + AiderPreParser) |
-| **OpenHands** | `file_watch` (JSON per event) | ✅ YAML-mapped (`openhands.yaml` + preprocessor) |
-| **SWE-agent** | `file_watch` (trajectory JSON) | ✅ YAML-mapped (`sweagent.yaml`) |
-| **Cline / Roo Code** | `file_watch` (VS Code storage) | ✅ YAML-mapped (`cline.yaml` + preprocessor) |
-| **CrewAI** | `file_watch` (event logs) | ✅ YAML-mapped (`crewai.yaml`) |
-| **LangGraph** | `file_watch` (event logs) | ✅ YAML-mapped (`langgraph.yaml`) |
-| **MS Agent Framework** | `stream` (OTel spans) | ✅ YAML-mapped (`maf.yaml` + OtelSpanAdapter) |
-| **Pydantic AI** | `file_watch` (event logs) | ✅ YAML-mapped (`pydantic_ai.yaml` + preprocessor) |
-| **Goose** | `file_watch` (session logs) | ✅ YAML-mapped (`goose.yaml` + preprocessor) |
-| **Smolagents** | `file_watch` (step logs) | ✅ YAML-mapped (`smolagents.yaml` + preprocessor) |
-| **OpenCode** | `file_watch` (SSE logs) | ✅ YAML-mapped (`opencode.yaml`) |
-
-New adapters implement `Adapter.parse()` and map framework events → canonical `EventKind` strings.
+| Sink | Status | Description |
+|------|--------|-------------|
+| `CallbackSink` | ✅ Done | Delegates to user-provided async callables. Full implementation. |
+| `SqliteSink` | ⬜ Planned | Config model exists (`SqliteSinkConfig`). No implementation yet. |
+| `JsonlSink` | ⬜ Planned | Config model exists (`JsonlSinkConfig`). No implementation yet. |
+| `S3Sink` | ⬜ Planned | Config model exists (`S3SinkConfig`). No implementation yet. |
+| `OtelSink` | ⬜ Planned | No config model or implementation. |
 
 ---
 
-## §5 — Enrichment
+## §13 — Configuration
 
-The enricher is **stateful per session** (not per event). State is bounded: at most one pending tool start per `tool_call_id`. Memory grows with concurrent tool executions (usually <10), not with session length.
+### Root Config (`config/models.py`)
 
-### 5.1 Tool Pairing
+`python
+class TracemillConfig(StrictModel):
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    mappings_dirs: list[Path] = []           # additional mapping search paths
+    pipelines: list[PipelineConfig] = []     # named source→adapter→sinks pipelines
+    sdk: SDKConfig = SDKConfig()             # in-process push mode settings
 
-Buffers `tool_start` events. When a matching `tool_complete` arrives (same `tool_call_id`), the enricher:
-1. Computes `duration_ms` from the timestamps
-2. Merges the start's arguments with the complete's result (preserving start's `_enrichment` data)
-3. Emits a single enriched `tool_complete` event with full context
+class SDKConfig(StrictModel):
+    batch_size: int = 64
+    flush_interval: float = 5.0
+    max_queue_size: int = 10000
+`
 
-Unpaired tool starts (no matching complete within the session) are emitted as-is when `flush()` is called at session end, with `duration_ms = None`.
+### PipelineConfig
 
-### 5.2 Pluggable Classification System
+`python
+class PipelineConfig(StrictModel):
+    name: str                    # unique pipeline identifier
+    source: SourceConfig         # discriminated union
+    adapter: AdapterConfig       # discriminated union
+    sinks: list[SinkConfig]      # at least one sink required
+`
 
-Classification is driven by a `ClassificationEngine` loaded from YAML data files. The engine provides:
+### Discriminated Unions
 
-- **Binary info** (`binary_info.yaml`): 294 entries mapping CLI binaries to roles, effects, scopes, and capabilities
-- **Shell rules** (`shell_rules.yaml`): 95 pattern-matching rules for compound shell commands
-- **MCP profiles** (`mcp_profiles.yaml`): 50 MCP server profiles with tool-level overrides and verb inference
-- **Canonical tools** (`canonical_tools.yaml`): Native tool → classification mapping
-- **Risk scoring** (`risk.yaml`): 4-layer risk assessment with CVSS/CWSS-anchored weights
-- **Verb inference** (`verb_inference.yaml`): MCP tool name → effect/action mapping
-- **Effect overrides** (`effect_overrides.yaml`): Flag-based effect escalation rules
-- **Shell defaults** (`shell_defaults.yaml`): Default shell classification values
+**Sources** (discriminator: `type`):
+`FileWatchSourceConfig`, `FilePollSourceConfig`, `HttpPollSourceConfig`, `SSESourceConfig`, `ReplaySourceConfig`
 
-Custom configurations can extend or override built-in defaults. YAML files merge per-key for dicts and prepend for lists.
+> Note: `SqliteSource` is implemented but not yet exposed in the config union. It is used programmatically (e.g., by CopilotPreParser) rather than instantiated from `tracemill.yaml`.
 
-### 5.3 Classification Dimensions
+**Adapters** (discriminator: `type`):
+`MappedJsonAdapterConfig`, `OtelSpanAdapterConfig`
 
-Every classified event carries a `Classification` dataclass with:
+**Sinks** (discriminator: `type`):
+`SqliteSinkConfig`, `JsonlSinkConfig`, `S3SinkConfig`
 
-| Dimension | Type | Description |
-| --- | --- | --- |
-| `mechanism` | `str` | How the tool operates: `process.shell`, `filesystem.local`, `network.http`, etc. |
-| `effect` | `str \| None` | Side-effect level: `null`, `read_only`, `mutating`, `destructive` |
-| `role` | `frozenset[str]` | Semantic roles from `CodingRole` enum: `validator.test_runner`, `modifier.file_editor`, etc. |
-| `action` | `frozenset[str]` | Actions from `CodingAction` enum: `validate.test`, `modify.write`, `retrieve.search`, etc. |
-| `scope` | `frozenset[str]` | Artifact scopes from `CodingScope` enum: `artifact.source_code`, `configuration.dependency`, etc. |
-| `capability` | `frozenset[str]` | Required capabilities: `filesystem_read`, `filesystem_write`, `network`, `subprocess` |
+### Loading Precedence (`config/loader.py`)
 
-### 5.4 Shell Classification
+From highest to lowest priority:
+1. Constructor kwargs passed to `load_config()`
+2. Environment variables (`TRACEMILL_*` prefix, `__` for nesting)
+3. `TRACEMILL_CONFIG` env var (explicit path override)
+4. Project-local: `./tracemill.yaml`
+5. User-global: `~/.tracemill/config.yaml`
+6. Built-in defaults
 
-Shell commands are classified via tree-sitter AST parsing (bash dialect). The classifier:
-1. Parses the command into an AST via tree-sitter
-2. Extracts individual commands from compound statements (`;`, `&&`, `||`, `|`)
-3. Unwraps transparent wrappers (`env`, `sudo`, `nohup`, `nice`, etc.)
-4. Looks up the binary in `binary_info.yaml` for base classification
-5. Applies subcmd-specific rules (e.g., `git push` vs `git log`)
-6. Detects flag modifiers (`--force`, `--recursive`, `--privileged`)
-7. Infers scope from file targets in the command
+### Bootstrap
 
-PowerShell and cmd.exe commands use dedicated classifiers dispatched by tool name.
+On first config access, `~/.tracemill/` is auto-created with:
+- `config.yaml` (default configuration template)
+- `mappings/` (directory for user custom mappings)
 
-### 5.5 MCP Tool Classification
+No separate `tracemill init` command needed.
 
-MCP tools (prefixed `mcp__<namespace>__<tool>`) are classified via server profiles:
-1. Extract namespace from tool name
-2. Match against registered `McpServerProfile` aliases
-3. Apply profile defaults (mechanism, role, scope, capability, effect)
-4. Apply per-tool overrides if defined
-5. Run verb inference from tool name suffix (e.g., `delete_` → destructive)
-6. Verb inference upgrades effect when inferred effect is more dangerous than profile default
-7. Filesystem tools with mutating/destructive verbs get capability and role upgrades
+### Environment Variables
 
-### 5.6 Risk Scoring
-
-Every tool event receives a 0-100 risk score with 4 layers (shell) or 2 layers (native/MCP):
-
-**Shell commands (4-layer additive model):**
-1. **Structural** (0-60): Base score from effect × scope matrix
-2. **Flag modifiers** (±15 each): `--force`, `--recursive`, `--no-verify`, `--privileged`, etc.
-3. **Injection/evasion patterns** (0-20 cap): GTFOBins usage, encoding chains, eval injection
-4. **Pipeline taint** (0-30): Source→sink analysis across all adjacent pipe segments
-
-**Context adjustment** (±20): Project-relative targeting reduces score; path escape (`../`, absolute paths outside project) increases score.
-
-**Native/MCP tools (2-layer model):**
-1. Scope sensitivity from target file analysis
-2. Effect-based base scoring
-
-Risk levels: `safe` (0-20), `low` (21-40), `moderate` (41-60), `elevated` (61-80), `critical` (81-100).
-
-### 5.7 Visibility Classification
-
-Determines whether an event is meaningful to downstream consumers:
-
-| Visibility | Meaning | Examples |
-| --- | --- | --- |
-| `visible` | User-facing, meaningful work | File edits, shell commands, messages |
-| `internal` | Agent machinery, not interesting | `report_intent`, heartbeats, progress |
-| `collapsed` | Repeated retries → summarize as one | Future: sequence tracking |
-
-### 5.8 Phase Detection
-
-Heuristic phase assignment based on event kind and tool classification:
-- **planning**: Messages without tool calls, or `report_intent` / `internal` category tools
-- **implementation**: `file_write` or `shell` category tools
-- **verification**: Shell tools with test/lint/build keywords (`pytest`, `ruff`, `npm test`, `cargo test`)
-- **review**: Git category tools
-
-Phase is stored in `payload["_enrichment"]["phase"]` as a hint, not a guarantee.
+- `TRACEMILL_CONFIG` — explicit config file path
+- `TRACEMILL_LOG_LEVEL` — scalar override
+- `TRACEMILL_SDK__BATCH_SIZE` — nested override (double underscore = nesting)
 
 ---
 
-## §6 — Storage Sinks
+## §14 — Telemetry / OTEL
 
-The sink interface is intentionally minimal. Implementations decide their own batching, buffering, and error strategies.
+🚧 **Stub** — the `telemetry/` package exists with an empty `__init__.py`.
 
-### 6.1 Built-in Sinks
-
-#### SQLiteSink
-
-**Optional dependency:** `aiosqlite`
-
-Stores events, spans, and usage records in a SQLite database. Schema:
-
-```sql
-CREATE TABLE events (
-    id TEXT PRIMARY KEY,
-    session_id TEXT NOT NULL,
-    kind TEXT NOT NULL,
-    timestamp TEXT NOT NULL,
-    payload TEXT NOT NULL,  -- JSON
-    metadata TEXT NOT NULL, -- JSON
-    created_at TEXT DEFAULT (datetime('now'))
-);
-
-CREATE TABLE spans (
-    id TEXT PRIMARY KEY,
-    session_id TEXT NOT NULL,
-    name TEXT NOT NULL,
-    start_time TEXT NOT NULL,
-    end_time TEXT NOT NULL,
-    attributes TEXT NOT NULL, -- JSON
-    created_at TEXT DEFAULT (datetime('now'))
-);
-
-CREATE TABLE usage (
-    id TEXT PRIMARY KEY,
-    session_id TEXT NOT NULL,
-    timestamp TEXT NOT NULL,
-    model TEXT NOT NULL,
-    input_tokens INTEGER NOT NULL,
-    output_tokens INTEGER NOT NULL,
-    cost_usd REAL,
-    created_at TEXT DEFAULT (datetime('now'))
-);
-
-CREATE INDEX idx_events_session ON events(session_id);
-CREATE INDEX idx_events_kind ON events(kind);
-CREATE INDEX idx_spans_session ON spans(session_id);
-CREATE INDEX idx_usage_session ON usage(session_id);
-```
-
-Uses raw `sqlite3` or `aiosqlite`. No SQLAlchemy dependency.
-
-Buffering: accumulates events in memory, flushes on `flush()` or when buffer exceeds 100 events. Uses `executemany` for batch inserts.
-
-#### OTELSink
-
-**Optional dependency:** `opentelemetry-sdk`
-
-Exports spans and metrics via standard OpenTelemetry exporters. Accepts a configured `TracerProvider` and `MeterProvider`, or creates defaults.
-
-- Each tool execution becomes an OTEL span
-- Usage records update token counters
-- Supports any OTEL-compatible collector (Jaeger, Grafana, Datadog, Langfuse)
-
-#### CallbackSink
-
-No dependencies. Calls user-provided async functions for each event type. Primary use: testing and custom routing.
-
-```python
-sink = CallbackSink(
-    on_event=my_event_handler,
-    on_span=my_span_handler,    # optional
-    on_usage=my_usage_handler,  # optional
-)
-```
-
-### 6.2 Consumer-Provided Sinks
-
-Consumers implement `StorageSink` for their specific backends:
-
-```python
-from tracemill import StorageSink, SessionEvent
-
-class GraphitiSink(StorageSink):
-    """Example: assembles events into Graphiti episodes."""
-
-    async def on_event(self, event: SessionEvent) -> None:
-        self.buffer.append(event)
-        if self._should_flush(event):
-            episode = self._assemble_episode(self.buffer)
-            await self.graphiti.add_episode(**episode)
-            self.buffer.clear()
-```
-
-### 6.3 Multi-Sink Execution
-
-Multiple sinks run concurrently via `asyncio.gather`. Sinks are **error-isolated** — one failing sink logs the error and does not block others. The pipeline never drops events due to a single sink failure.
+**Planned:**
+- OpenTelemetry instrumentation (counters, histograms)
+- `OtelSink` that exports spans to a collector
+- Automatic span generation from tool call pairs
+- Pipeline-level metrics (events/sec, enrichment latency, sink write time)
 
 ---
 
-## §7 — OTEL Integration
+## §15 — EventBus
 
-The library owns OTEL instrument definitions and recording. Consumers don't think about OTEL — it happens automatically as a side-effect of the pipeline.
+⬜ **Planned** — not yet implemented or stubbed.
 
-### Instruments
-
-| Type | Name | What |
-| --- | --- | --- |
-| Counter | `tracemill.tokens.input` | Input tokens consumed |
-| Counter | `tracemill.tokens.output` | Output tokens generated |
-| Counter | `tracemill.cost.usd` | Estimated cost in USD |
-| Histogram | `tracemill.llm.duration_ms` | LLM response latency |
-| Histogram | `tracemill.tool.duration_ms` | Tool execution time |
-| Gauge | `tracemill.context.tokens` | Current context window usage |
-
-### Setup
-
-```python
-from tracemill.telemetry import setup_telemetry
-
-# Option 1: In-memory reader (for tests)
-reader = setup_telemetry(mode="memory")
-
-# Option 2: OTLP export
-setup_telemetry(mode="otlp", endpoint="http://localhost:4317")
-
-# Option 3: No telemetry (instruments are no-ops)
-setup_telemetry(mode="none")
-```
-
-Telemetry is opt-in. If no setup is called, instruments use no-op implementations (zero overhead).
+An optional pub/sub mechanism for in-process consumers that want to react to events without implementing a full sink. Lower-commitment than a sink: no flush/close lifecycle, no persistence contract.
 
 ---
 
-## §8 — Extraction from CodePlane
+## §16 — Formatting
 
-This library is extracted from [CodePlane](https://github.com/dfinson/codeplane), not written from scratch. Source mapping:
+🚧 **Stub** — the `formatting/` package exists with an empty `__init__.py`.
 
-| Library component | CodePlane source file | Adaptation needed |
-| --- | --- | --- |
-| `Enricher` | `backend/services/events/event_enricher.py` | None — already a pure stateful class |
-| `EventPipeline` | `backend/services/events/event_pipeline.py` | Remove `_db_*` methods, inject `StorageSink` list |
-| `density.py` | `backend/services/events/story/review.py` | None — pure functions |
-| `MappedJsonAdapter` + `copilot.yaml` | `backend/services/adapters/copilot_adapter.py` `.stream_events()` parsing | Decouple from subprocess management |
-| `MappedJsonAdapter` + `copilot.yaml` | `backend/services/watcher/copilot.py` `._process_new_events()` | Decouple from file tailing |
-| `EventBus` | `backend/services/events/event_bus.py` | None — already fully generic |
-| OTEL instruments | `backend/services/analytics/telemetry.py` | None — already standard OTEL |
-| `SQLiteSink` | `backend/persistence/telemetry_*_repo.py` | Consolidate into single sink, remove SQLAlchemy |
-
-**Critical:** Read each CodePlane source file before implementing its tracemill counterpart. The code exists and works — adapt it, don't reinvent it.
-
-CodePlane then depends on tracemill instead of owning the code. Its EventProcessor (which adds diff triggering, step tracking, and domain event translation) stays in CodePlane — those are consumer-specific concerns built on top of the generic pipeline.
-
-### §8.1 — Relationship to memrelay
-
-[memrelay](https://github.com/dfinson/memrelay) is the first standalone consumer of tracemill. It implements a `GraphitiSink` (a `StorageSink` subclass) that feeds enriched events into a Graphiti knowledge graph for persistent memory. memrelay uses tracemill's `MappedJsonAdapter` with `copilot.yaml` to parse Copilot CLI session files.
-
-The boundary is clean: tracemill handles parsing, enrichment, and pipeline orchestration. memrelay handles daemon lifecycle, Graphiti integration, MCP tools, and memory retrieval.
+**Planned:**
+- Human-readable event formatting for terminal/log display
+- Compact and verbose output modes
+- Color and structured output for debugging
 
 ---
 
-## §9 — Repository Structure
+## §17 — CI / CD
 
-```
+### Workflows (`.github/workflows/`)
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `ci-lint.yml` | Push / PR | `ruff check` + `ruff format --check` |
+| `ci-test.yml` | Push / PR | `pytest` with Python 3.11, 3.12, 3.13 matrix |
+| `publish.yml` | Release tag | Build + publish to PyPI |
+| `tool-surface-audit.yml` | Weekly | Audit tool classification coverage |
+| `weekly-compat-audit.yml` | Weekly | Compatibility checks against framework updates |
+
+### Branch Protection
+
+- Required: `ci-lint` and `ci-test` pass on all matrix versions
+- Copilot agent setup: `copilot-setup-steps.yml`
+
+---
+
+## §18 — Repository Structure
+
+`
 tracemill/
-├── pyproject.toml              # Optional extras: [sqlite], [otel], [all]
-├── README.md
-├── SPEC.md                     # This document
-├── LICENSE                     # MIT
-│
+├── .github/
+│   ├── copilot-setup-steps.yml
+│   └── workflows/
+│       ├── ci-lint.yml
+│       ├── ci-test.yml
+│       ├── publish.yml
+│       ├── tool-surface-audit.yml
+│       └── weekly-compat-audit.yml
 ├── src/tracemill/
-│   ├── __init__.py             # Public API: Pipeline, Enricher, SessionEvent, EventKind
-│   ├── types.py                # SessionEvent, EventKind, EventMetadata, Sink protocol
-│   ├── pipeline.py             # EventPipeline: enricher integration, sink fan-out
-│   ├── enricher.py             # Enricher: tool pairing, classification, risk, phase, visibility
-│   │
-│   └── classify/               # Pluggable classification engine
-│       ├── __init__.py         # Public API: classify_shell, classify_tool, get_default_engine
-│       ├── config.py           # ClassificationEngine, ClassifyConfig, YAML loading
-│       ├── core.py             # Classification dataclass, classify_tool dispatch
-│       ├── coding.py           # CodingRole, CodingAction, CodingScope, CodingMechanism enums
-│       ├── shell.py            # Tree-sitter bash classifier with wrapper unwrapping
-│       ├── powershell.py       # PowerShell cmdlet classifier
-│       ├── cmd.py              # Windows cmd.exe classifier
-│       ├── mcp.py              # MCP server profile matching with verb inference
-│       ├── tools.py            # Native tool classification via canonical registry
-│       ├── rules.py            # Shell rule matching and activity derivation
-│       ├── risk.py             # 4-layer risk scoring (structural, flags, injection, taint)
-│       ├── phases.py           # Phase map generation from classification
-│       ├── registry.py         # Tool classification registry
-│       ├── workflow.py         # Workflow activity classification
-│       │
-│       └── data/               # YAML configuration files
-│           ├── binary_info.yaml       # 294 CLI binary classifications
-│           ├── shell_rules.yaml       # 95 shell command pattern rules
-│           ├── mcp_profiles.yaml      # 50 MCP server profiles
-│           ├── canonical_tools.yaml   # Native tool → classification map
-│           ├── risk.yaml              # Risk scoring weights and rules
-│           ├── verb_inference.yaml    # MCP verb → effect/action map
-│           ├── effect_overrides.yaml  # Flag-based effect escalation
-│           ├── shell_defaults.yaml    # Default shell classification
-│           └── tool_classifications.yaml  # Tool category defaults
-│
-└── tests/
-    ├── conftest.py             # Shared fixtures (RecordingSink)
-    └── unit/
-        ├── test_types.py
-        ├── test_enricher.py        # 1200+ lines, comprehensive enricher tests
-        ├── test_callback_sink.py
-        ├── test_classification.py  # Binary + shell rule classification
-        ├── test_classify.py        # Integration: classify_tool dispatch
-        ├── test_classify_shells.py # PS, cmd, quoted tokens, wrapper unwrapping
-        ├── test_mcp.py             # MCP profile matching, verb inference
-        └── test_risk.py            # Risk scoring, context paths, taint
-```
+│   ├── __init__.py              # Public API surface
+│   ├── models.py                # StrictModel, FrozenModel bases
+│   ├── types.py                 # EventKind, SessionEvent, EventMetadata, etc.
+│   ├── pipeline.py              # EventPipeline fan-out
+│   ├── enricher.py              # Stateful enrichment (pairing, classification, risk)
+│   ├── adapters/
+│   │   ├── __init__.py
+│   │   ├── base.py              # Adapter, JsonLineAdapter ABCs
+│   │   ├── mapped_json.py       # MappedJsonAdapter (YAML-driven)
+│   │   └── otel.py              # OtelSpanAdapter (MAF spans)
+│   ├── sources/
+│   │   ├── __init__.py
+│   │   ├── base.py              # Source ABC, RawRecord
+│   │   ├── file_watch.py        # FileWatchSource (watchdog)
+│   │   ├── file_poll.py         # FilePollSource (interval)
+│   │   ├── http_poll.py         # HttpPollSource (ETag/conditional)
+│   │   ├── sse.py               # SSESource (WHATWG spec)
+│   │   ├── sqlite.py            # SqliteSource (row polling)
+│   │   └── replay.py            # ReplaySource (one-shot)
+│   ├── sinks/
+│   │   ├── __init__.py
+│   │   ├── base.py              # StorageSink ABC
+│   │   └── callback.py          # CallbackSink
+│   ├── parsers/
+│   │   ├── __init__.py
+│   │   ├── base.py              # MarkdownPreParser ABC
+│   │   ├── copilot.py           # CopilotPreParser
+│   │   └── aider.py             # AiderPreParser
+│   ├── preprocessors/
+│   │   ├── __init__.py          # Registry + all imports
+│   │   ├── registry.py          # register/get_preprocessor
+│   │   ├── claude.py
+│   │   ├── cline.py
+│   │   ├── goose.py
+│   │   ├── openhands.py
+│   │   ├── pydantic_ai.py
+│   │   └── smolagents.py
+│   ├── classify/
+│   │   ├── __init__.py          # Public API re-exports
+│   │   ├── core.py              # Mechanism, Effect, Scope, Role, Action, etc.
+│   │   ├── coding.py            # CodingMechanism, CodingScope, CodingRole, etc.
+│   │   ├── config.py            # ClassifyConfig, ClassificationEngine, loader
+│   │   ├── workflow.py          # Phase, Visibility
+│   │   ├── shell.py             # Bash shell classifier (tree-sitter)
+│   │   ├── powershell.py        # PowerShell classifier (tree-sitter)
+│   │   ├── cmd.py               # cmd.exe classifier (tokenization)
+│   │   ├── tools.py             # Native tool classification
+│   │   ├── mcp.py               # MCP profile-based classification
+│   │   ├── rules.py             # Declarative rule matching, ShellActivity
+│   │   ├── risk.py              # Risk scoring (0-100, MITRE mappings)
+│   │   ├── phases.py            # Phase derivation logic
+│   │   ├── registry.py          # DimensionRegistry
+│   │   └── data/                # YAML config files (9 files)
+│   │       ├── binary_info.yaml
+│   │       ├── canonical_tools.yaml
+│   │       ├── effect_overrides.yaml
+│   │       ├── mcp_profiles.yaml
+│   │       ├── risk.yaml
+│   │       ├── shell_defaults.yaml
+│   │       ├── shell_rules.yaml
+│   │       ├── tool_classifications.yaml
+│   │       └── verb_inference.yaml
+│   ├── config/
+│   │   ├── __init__.py
+│   │   ├── models.py            # TracemillConfig, PipelineConfig, unions
+│   │   ├── loader.py            # Hierarchical config loading
+│   │   ├── defaults.py          # Default config template
+│   │   └── mappings.py          # Mapping file resolver
+│   ├── mappings/                # Bundled YAML mappings (15 files)
+│   │   ├── __init__.py
+│   │   ├── aider.yaml
+│   │   ├── aider_markdown.yaml
+│   │   ├── claude.yaml
+│   │   ├── cline.yaml
+│   │   ├── copilot.yaml
+│   │   ├── copilot_markdown.yaml
+│   │   ├── crewai.yaml
+│   │   ├── goose.yaml
+│   │   ├── langgraph.yaml
+│   │   ├── maf.yaml
+│   │   ├── opencode.yaml
+│   │   ├── openhands.yaml
+│   │   ├── pydantic_ai.yaml
+│   │   ├── smolagents.yaml
+│   │   └── sweagent.yaml
+│   ├── telemetry/
+│   │   └── __init__.py          # 🚧 Stub
+│   └── formatting/
+│       └── __init__.py          # 🚧 Stub
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py
+│   ├── fixtures/
+│   │   ├── gen_fixtures.py          # Fixture data generation script
+│   │   ├── aider_chat_history.md
+│   │   ├── claude_session.jsonl
+│   │   ├── copilot_session.jsonl
+│   │   └── malformed.jsonl
+│   ├── unit/
+│   │   ├── __init__.py
+│   │   ├── test_adapters.py
+│   │   ├── test_aider_preparser.py
+│   │   ├── test_callback_sink.py
+│   │   ├── test_classification.py
+│   │   ├── test_classify.py
+│   │   ├── test_classify_shells.py
+│   │   ├── test_enricher.py
+│   │   ├── test_mapped_json.py
+│   │   ├── test_mcp.py
+│   │   ├── test_otel_adapter.py
+│   │   ├── test_pipeline.py
+│   │   ├── test_risk.py
+│   │   └── test_types.py
+│   ├── integration/
+│   │   ├── __init__.py
+│   │   ├── test_aider_contract.py
+│   │   ├── test_new_mappings.py
+│   │   ├── test_opencode_e2e.py
+│   │   ├── test_pipeline_e2e.py
+│   │   ├── test_yaml_comprehensive_e2e.py
+│   │   └── test_yaml_e2e_real_data.py
+│   ├── test_config.py
+│   ├── test_copilot_preparser.py
+│   └── test_sqlite_source.py
+├── scripts/
+│   └── check_framework_compat.py  # Weekly compat audit helper
+├── pyproject.toml
+├── README.md
+├── SPEC.md
+├── LICENSE
+└── uv.lock
+`
 
 ---
 
-## §10 — pyproject.toml
+## §19 — Design Constraints
 
-```toml
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+1. **Pure observation** — tracemill observes, enriches, and delivers. It never modifies agent behavior, injects prompts, or manages processes.
 
-[project]
-name = "tracemill"
-version = "0.1.0"
-description = "Agent event observation pipeline with pluggable storage backends"
-readme = "README.md"
-license = "MIT"
-requires-python = ">=3.11"
-dependencies = [
-    "pydantic>=2.0",
-]
+2. **Framework-agnostic** — new framework support = new YAML file. No Python code changes required for standard JSON-line formats.
 
-[project.optional-dependencies]
-sqlite = ["aiosqlite>=0.19"]
-otel = [
-    "opentelemetry-api>=1.20",
-    "opentelemetry-sdk>=1.20",
-]
-all = [
-    "tracemill",
-]
-dev = [
-    "pytest>=8.0",
-    "pytest-asyncio>=0.23",
-    "ruff>=0.4",
-]
+3. **Defensive parsing** — adapters/parsers never crash. Unknown fields are ignored. Malformed input is logged and skipped.
 
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-testpaths = ["tests"]
+4. **Immutable domain objects** — all events flowing through the pipeline are frozen Pydantic models. Enrichment produces new copies.
 
-[tool.ruff]
-target-version = "py311"
-line-length = 100
+5. **Error isolation** — one failing sink cannot block others. One malformed event cannot crash the pipeline.
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/tracemill"]
-```
+6. **Async-native** — sources, pipeline, and sinks are async. I/O runs in background threads where needed.
+
+7. **No global mutable state** — config is loaded explicitly (with caching for convenience). The default engine is a module-level singleton but can be reset/replaced.
+
+8. **Hierarchical classification** — dot-path taxonomy supports both flat queries (`has_action("validate")`) and precise queries (`has_action("validate.lint")`).
+
+9. **Data-driven rules** — classification rules, risk scoring weights, MCP profiles, and binary metadata are all externalized to YAML files. Users can override any rule without touching Python code.
+
+10. **Open-closed EventKind** — the kind registry is open. Any string is a valid kind. New frameworks can introduce new kinds without code changes. Canonical kinds provide autocomplete and filtering.
 
 ---
 
-## §11 — Design Constraints
+## §20 — Testing Strategy
 
-1. **Zero heavy dependencies.** Core requires only Pydantic. `opentelemetry-api` for OTEL is an optional extra. No SQLAlchemy — `SQLiteSink` uses raw `sqlite3` / `aiosqlite`.
-2. **Adapters are defensive.** Unknown fields ignored, missing fields produce partial events with warnings, never crash on malformed input.
-3. **Pipeline is async-native.** All sink methods are `async`. Synchronous consumers can use `asyncio.run()` or the provided sync wrapper.
-4. **Stateless adapters, stateful enricher, stateless sinks.** Clear ownership of state. Enricher state is per-session and bounded. Sinks handle their own buffering internally.
-5. **No process management.** The library never spawns processes, opens sockets, or manages lifecycle. Consumers own all I/O.
-6. **Sinks are error-isolated.** A crash in one sink must never affect other sinks or the pipeline itself.
+### Unit Tests (`tests/unit/`)
 
----
+13 test modules covering:
+- Type construction and validation (`test_types.py`)
+- Adapter parsing logic (`test_adapters.py`, `test_mapped_json.py`, `test_otel_adapter.py`)
+- Parser output (`test_aider_preparser.py`)
+- Sink behavior (`test_callback_sink.py`)
+- Classification correctness (`test_classification.py`, `test_classify.py`, `test_classify_shells.py`, `test_mcp.py`)
+- Enricher pairing/flush logic (`test_enricher.py`)
+- Risk scoring (`test_risk.py`)
+- Pipeline fan-out and error isolation (`test_pipeline.py`)
 
-## §12 — Testing Strategy
+### Integration Tests (`tests/integration/`)
 
-### Unit Tests
+6 test modules covering:
+- End-to-end pipeline flow (`test_pipeline_e2e.py`)
+- YAML mapping validation against real framework data (`test_yaml_e2e_real_data.py`, `test_yaml_comprehensive_e2e.py`)
+- New mapping contract tests (`test_new_mappings.py`)
+- Aider parser contract (`test_aider_contract.py`)
+- OpenCode mapping (`test_opencode_e2e.py`)
 
-- **types.py**: Serialization roundtrips, enum coverage, optional field handling
-- **enricher.py**: Tool pairing (happy path, orphaned start, duplicate complete), duration calculation, classification, visibility assignment, phase detection, flush behavior
-- **pipeline.py**: Single sink, multi-sink, error isolation (one sink throws, others still receive), empty sink list
-- **adapters**: Parse known-good JSON lines, handle malformed input gracefully, unknown fields ignored, missing fields handled
-- **formatting**: Density classification, budget calculation edge cases
+### Top-Level Tests
 
-### Integration Tests
+- `test_config.py` — configuration loading, precedence, env var overrides
+- `test_copilot_preparser.py` — CopilotPreParser markdown + log line parsing
+- `test_sqlite_source.py` — SqliteSource polling behavior
 
-- **Pipeline → SQLiteSink**: Push events through pipeline, verify they land in SQLite with correct schema
-- **Pipeline → CallbackSink**: Verify all events reach the callback in order
-- **Pipeline → multiple sinks**: Verify fan-out works, error isolation works
-- **Full roundtrip**: Raw JSONL input → adapter → pipeline → SQLiteSink → verify DB contents
+### Test Infrastructure
 
-### Fixtures
-
-Capture real `events.jsonl` output from actual Copilot CLI and Claude sessions. Store in `tests/fixtures/`. These are the ground truth for adapter tests.
-
-Include `malformed.jsonl` with:
-- Truncated JSON
-- Missing required fields
-- Unknown event types
-- Empty lines
-- Non-JSON content
+- `pytest-asyncio` with `asyncio_mode = "auto"`
+- Fixtures in `tests/fixtures/` (sample event data)
+- Python 3.11 / 3.12 / 3.13 CI matrix
 
 ---
 
-## §13 — CI / CD
+## §21 — Implementation Status & Roadmap
 
-### Overview
+### ✅ Done
 
-Three GitHub Actions workflows: **lint**, **test**, and **publish**. Lint and test run on every PR and push to `main`. Publish runs on version tags.
+| Subsystem | Status | Notes |
+|-----------|--------|-------|
+| Core types | ✅ Complete | SessionEvent, EventKind (75+ constants), EventMetadata, TelemetrySpan, UsageRecord |
+| Base models | ✅ Complete | StrictModel, FrozenModel |
+| Source ABC + 6 implementations | ✅ Complete | file_watch, file_poll, http_poll, SSE, sqlite, replay |
+| Adapter ABC + 2 implementations | ✅ Complete | MappedJsonAdapter, OtelSpanAdapter |
+| YAML mapping system | ✅ Complete | 15 bundled mappings, resolver, user override support |
+| Preprocessor registry + 6 preprocessors | ✅ Complete | claude, cline, goose, openhands, pydantic_ai, smolagents |
+| Parser system + 2 parsers | ✅ Complete | CopilotPreParser, AiderPreParser (tree-sitter based) |
+| Enricher | ✅ Complete | Tool pairing, duration, classification dispatch, risk, visibility, phase |
+| Classification engine | ✅ Complete | Multi-dimensional taxonomy, shell AST (bash/PS/cmd), MCP profiles, tool lookup |
+| Risk scoring | ✅ Complete | Structural + flags + injection + taint + context. MITRE mappings. |
+| EventPipeline | ✅ Complete | Fan-out, error isolation, enricher integration |
+| CallbackSink | ✅ Complete | User-provided async handlers |
+| Configuration system | ✅ Complete | Hierarchical loading, env overrides, discriminated unions, bootstrap |
+| Classify data files (9 YAMLs) | ✅ Complete | Binary info, rules, profiles, risk config |
+| CI/CD | ✅ Complete | Lint, test matrix, publish, weekly audits |
+| Test suite | ✅ Complete | 13 unit + 6 integration + 3 top-level test modules |
 
-### 13.1 Lint (`ci-lint.yml`)
+### ⬜ Planned (Not Yet Implemented)
 
-Single job, runs on `ubuntu-latest`, Python 3.13 (latest stable).
+| Item | Priority | Dependencies | Notes |
+|------|----------|--------------|-------|
+| **SqliteSink** | High | None | Config model exists. Needs write implementation with WAL, schema migration, and batch inserts. |
+| **JsonlSink** | High | None | Config model exists. Needs append-only file writing with optional size-based rotation. |
+| **OtelSink** | Medium | `telemetry/` | Export spans to OTEL collector. Requires `opentelemetry-sdk` optional dependency. |
+| **S3Sink** | Low | None | Config model exists. Needs `boto3` optional dependency, buffered upload, key formatting. |
+| **Telemetry instrumentation** | Medium | `opentelemetry-sdk` | Counters, histograms for pipeline metrics. |
+| **Formatting** | Low | None | Human-readable event display for terminal/debugging. |
+| **CLI runner** | Medium | All sinks | `tracemill run` command that instantiates pipelines from config and runs until interrupted. |
+| **EventBus** | Low | None | Optional pub/sub for in-process lightweight consumers. |
+| **SDK push mode** | Medium | Sinks | In-process event push (no file watch). Uses SDKConfig batch/flush settings. |
 
-```yaml
-steps:
-  - uses: actions/checkout@v4
-  - uses: actions/setup-python@v5
-    with: { python-version: "3.13" }
-  - run: pip install ruff
-  - run: ruff check .
-  - run: ruff format --check .
-```
+### Implementation Order (Recommended)
 
-Triggers: `pull_request` (all branches), `push` to `main`.
-
-Fast feedback — fails in <30s on style/lint issues before tests even start.
-
-### 13.2 Test (`ci-test.yml`)
-
-Matrix job across Python versions and dependency configurations:
-
-| Axis | Values |
-| --- | --- |
-| `python-version` | `3.11`, `3.12`, `3.13` |
-| `install-extras` | `dev` (core-only), `all,dev` (full surface) |
-
-This 3×2 matrix (6 jobs) catches:
-- **Core-only jobs** ensure optional imports never leak into core paths
-- **Full jobs** exercise SQLite + OTEL sink code
-- **Version spread** ensures compatibility across the supported range
-
-```yaml
-steps:
-  - uses: actions/checkout@v4
-  - uses: actions/setup-python@v5
-    with: { python-version: "${{ matrix.python-version }}" }
-  - run: pip install -e ".[${{ matrix.install-extras }}]"
-  - run: pytest --tb=short -q
-```
-
-Triggers: `pull_request` (all branches), `push` to `main`.
-
-Tests that require optional dependencies (aiosqlite, opentelemetry) must be skipped gracefully in core-only runs using `pytest.importorskip()` or conditional skip markers.
-
-### 13.3 Build Verification
-
-An additional job in `ci-test.yml` (outside the matrix) that builds the wheel and verifies it installs cleanly:
-
-```yaml
-steps:
-  - uses: actions/checkout@v4
-  - uses: actions/setup-python@v5
-    with: { python-version: "3.13" }
-  - run: pip install hatchling build
-  - run: python -m build
-  - run: pip install dist/*.whl
-  - run: python -c "import tracemill; print(tracemill.__name__)"
-```
-
-Catches packaging issues (missing files in `hatch.build.targets.wheel.packages`, broken `__init__.py` exports).
-
-### 13.4 Publish (`publish.yml`)
-
-Runs on tag pushes matching `v*`. Uses PyPI trusted publishing (no API tokens stored in secrets):
-
-```yaml
-on:
-  push:
-    tags: ["v*"]
-
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.13" }
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
-```
-
-Requires one-time setup: configure a "pypi" environment in GitHub repo settings and register the repo as a trusted publisher on PyPI.
-
-### 13.5 Copilot Agent Setup
-
-`.github/copilot-setup-steps.yml` — ensures the Copilot coding agent can run lint + tests when working on PRs:
-
-```yaml
-steps:
-  - uses: actions/setup-python@v5
-    with: { python-version: "3.13" }
-  - run: pip install -e ".[all,dev]"
-```
-
-### 13.6 Branch Protection
-
-`main` branch should require:
-- All CI checks passing (lint + test matrix) before merge
-- At least one approving review (or Copilot review for automated PRs)
-- Linear history (squash merge preferred)
+`
+1. SqliteSink         → enables CodePlane integration
+2. JsonlSink          → enables local file-based storage
+3. CLI runner          → enables standalone operation from tracemill.yaml
+4. Telemetry package   → enables observability of tracemill itself
+5. OtelSink           → enables distributed tracing export
+6. SDK push mode       → enables embedded library usage without files
+7. Formatting          → enables debugging / CLI display
+8. S3Sink             → enables cloud archival
+9. EventBus           → enables lightweight in-process consumers
+`
 
 ---
 
-## §14 — Implementation Plan
+## §22 — Success Criteria
 
-### Step 1: Types + Pipeline Skeleton
+The library is "done" when:
 
-- `types.py` with `SessionEvent`, `EventKind`, `EventMetadata`, `TelemetrySpan`, `UsageRecord`
-- `StorageSink` ABC in `sinks/base.py`
-- `Adapter` ABC in `adapters/base.py`
-- `EventPipeline` with sink fan-out (no enrichment yet)
-- `CallbackSink` for testing
-- Unit tests for types, pipeline fan-out, error isolation
-
-**Gate:** `EventPipeline` accepts `SessionEvent`, fans out to `CallbackSink`, error-isolated.
-
-### Step 2: Enricher + Classification System ✅
-
-- `enricher.py` — Tool pairing with duration tracking, tool classification dispatch, visibility, phase detection, risk scoring
-- `classify/` package — Pluggable YAML-based classification engine:
-  - `config.py` — `ClassificationEngine` with YAML loading, pre-indexed lookups
-  - `core.py` — `Classification` dataclass, `classify_tool()` dispatch
-  - `shell.py` — Tree-sitter AST-based bash classifier with wrapper unwrapping
-  - `powershell.py` — PowerShell cmdlet classifier
-  - `cmd.py` — Windows cmd.exe classifier
-  - `mcp.py` — MCP server profile matching with verb inference and effect escalation
-  - `tools.py` — Native tool classification via canonical tool registry
-  - `rules.py` — Shell rule matching and activity derivation
-  - `risk.py` — 4-layer risk scoring (structural, flags, injection, taint)
-  - `phases.py` — Phase map generation from classification dimensions
-  - `coding.py` — `CodingRole`, `CodingAction`, `CodingScope`, `CodingMechanism` enums
-  - `registry.py` — Tool classification registry
-  - `workflow.py` — Workflow activity classification
-- `classify/data/` — 8 YAML data files (294 binaries, 95 shell rules, 50 MCP profiles)
-- Wire enricher into pipeline `push()`/`flush()`/`close()`
-- 458 unit tests covering all enricher behaviors, classification, risk scoring
-
-**Gate:** Tool start/complete pairing works, duration computed, multi-dimensional classification assigned, risk scored, MCP tools classified with verb inference.
-
-### Step 3: Adapters
-
-- `MappedJsonAdapter` + `copilot.yaml` -- extract from CodePlane's `SessionStateWatcher._process_new_events()`
-- `MappedJsonAdapter` + `copilot.yaml` -- extract from CodePlane's `CopilotAdapter.stream_events()` parsing
-- `MappedJsonAdapter` + `claude.yaml` -- extract from CodePlane's `ClaudeAdapter` parsing
-- `MappedJsonAdapter` + `claude.yaml` -- extract from CodePlane's `ClaudeSessionStateWatcher`
-- Capture real session fixtures for each format
-- Defensive parsing tests (malformed input)
-
-**Gate:** All adapters parse their respective fixture files correctly.
-
-### Step 4: SQLiteSink
-
-- Schema creation (events, spans, usage tables)
-- Buffered batch inserts
-- `flush()` and `close()` lifecycle
-- Integration test: pipeline → SQLiteSink → verify DB contents
-
-**Gate:** Full roundtrip — JSONL → adapter → pipeline → enricher → SQLiteSink → queryable DB.
-
-### Step 5: OTEL Integration
-
-- Instrument definitions in `telemetry/instruments.py`
-- Setup helper in `telemetry/setup.py` (memory, OTLP, none modes)
-- `OTELSink` implementation
-- Recording during enrichment
-- Tests with in-memory reader
-
-**Gate:** Events flow through pipeline, OTEL spans/metrics are recorded and exportable.
-
-### Step 6: EventBus + Formatting
-
-- `EventBus` — extract from CodePlane's `event_bus.py` (already generic)
-- `formatting/density.py` — extract from CodePlane's story review
-- `formatting/budget.py` — token-budgeted output assembly
-- Tests
-
-**Gate:** Full library surface implemented, all tests pass. Ship v0.1.0.
-
----
-
-## §15 — Success Criteria
-
-### v0.1.0
-
-- All four adapters parse real session data correctly
-- Enricher pairs tools, classifies, assigns visibility
-- Pipeline fans out to multiple sinks concurrently, error-isolated
-- SQLiteSink stores events in queryable format
-- OTELSink exports standard spans/metrics
-- Zero heavy dependencies (core = Pydantic only)
-- Defensive parsing — never crashes on malformed input
-- >90% test coverage on core modules
-- CI green: lint, test matrix (3 Python versions × core/full), build verification
-- Published to PyPI as `tracemill` via trusted publishing on tag push
-
-### v0.2.0
-
-- CodePlane migrated to depend on tracemill (replaces internal event pipeline)
-- memrelay uses tracemill for all event processing
-- Additional adapters (Gemini, etc.) contributed by consumers
-- Performance benchmarks (events/second throughput)
+1. **Three sink implementations** (SQLite, JSONL, Callback) are production-quality with tests
+2. **CLI runner** can start all pipelines from `tracemill.yaml` and run indefinitely
+3. **Any JSONL-emitting framework** can be added with only a YAML file (no code)
+4. **Non-JSONL frameworks** (Copilot SQLite, Aider markdown) work via parser + mapping
+5. **Classification** is stable: tool taxonomy covers 95%+ of observed tool calls without `unknown`
+6. **Risk scoring** produces meaningful differentiation (not all-50s)
+7. **End-to-end latency** from event ingestion to sink write is < 10ms p99 for in-memory sinks
+8. **Zero-crash guarantee**: malformed input, failed sinks, and unexpected data never crash the pipeline
+9. **Config bootstrap**: first `pip install tracemill` + any config access creates `~/.tracemill/` with working defaults
+10. **CI green**: lint + tests pass on Python 3.11, 3.12, 3.13


### PR DESCRIPTION
The existing SPEC.md was written before any code existed and described a much simpler library than what was actually built. It claimed "no networking," "no filesystem polling," and documented 4 hardcoded adapters -- all now false. The spec was actively misleading for contributors and agents.

## Approach

Read all 54 Python source files, 24 YAML configs, tests, and CI workflows, then rewrote SPEC.md from scratch to document what actually exists.

## What changed

Single file replacement: `SPEC.md` (971 lines removed, 1097 lines added). Key sections now cover:

- **Sources** (6 async transport implementations)
- **Adapters** (YAML-driven MappedJsonAdapter + OtelSpanAdapter)
- **15 bundled framework mappings** with preprocessor dispatch
- **Classification engine** (14 modules, 9 data files, shell AST analysis, risk scoring)
- **Parsers** (CopilotPreParser, AiderPreParser with tree-sitter)
- **Configuration system** (hierarchical loading, discriminated unions)
- **Implementation status** clearly marking done vs. planned items

## Red-team validation

Cross-referenced every source file against the spec. Fixed: unit test count (13 not 14), added SqliteSource config note, expanded repository tree with missing files (scripts/, fixtures/, __init__.py files).