### PR TITLE
Fix YAML mapping drift flagged by weekly audit (#37, #39, #40)

### DIFF
--- a/src/tracemill/mappings/opencode.yaml
+++ b/src/tracemill/mappings/opencode.yaml
@@ -1,6 +1,7 @@
 # OpenCode event mapping for MappedJsonAdapter
 # Targets: opencode >= 1.2, < 2.0 (SSE event stream from GET /event/subscribe)
-# Source: anomalyco/opencode packages/core/src/session-event.ts (tag github-v1.2.24)
+# Source: anomalyco/opencode packages/schema/src/session-event.ts (canonical Event.define schemas)
+#         anomalyco/opencode packages/core/src/session/event.ts (re-export of @opencode-ai/schema/session-event)
 #         anomalyco/opencode packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
 #         anomalyco/opencode packages/opencode/src/event-v2-bridge.ts
 #
@@ -267,5 +268,7 @@ events:
     kind: workflow.compaction.completed
     payload:
       session_id: properties.sessionID
+      message_id: properties.messageID
+      reason: properties.reason
       text: properties.text
-      include: properties.include
+      recent: properties.recent

--- a/src/tracemill/mappings/pydantic_ai.yaml
+++ b/src/tracemill/mappings/pydantic_ai.yaml
@@ -130,7 +130,7 @@ events:
   stream.part_end:
     kind: message.assistant
     payload:
-      content: content
+      content: part.content
   # FinalResultEvent (event_kind="final_result") — signal-only, no content payload.
   # Indicates which tool call produced the final result; actual data was in prior PartStart/Delta.
   stream.final_result:

--- a/src/tracemill/preprocessors/continue_dev.py
+++ b/src/tracemill/preprocessors/continue_dev.py
@@ -18,10 +18,15 @@ def preprocess_continue(obj: dict[str, Any]) -> list[dict[str, Any]]:
       "title": "...",
       "history": [
         {"message": {"role": "user", "content": "..."}},
-        {"message": {"role": "assistant", "content": "...", "tool_calls": [...]}},
-        {"message": {"role": "tool", "tool_call_id": "...", "content": "..."}}
+        {"message": {"role": "assistant", "content": "...", "toolCalls": [...]}},
+        {"message": {"role": "tool", "toolCallId": "...", "content": "..."}}
       ]
     }
+
+    Note: Continue.dev persists camelCase keys (toolCalls, toolCallId) — its
+    internal TypeScript ChatMessage types are written to disk via JSON.stringify
+    with no rename. snake_case (tool_calls/tool_call_id) only appears on the
+    OpenAI provider wire format, not in the session file on disk.
 
     Each history entry becomes a normalized dict with:
     - block_type: "user.message", "assistant.message", "assistant.tool_use", "tool.result"
@@ -41,7 +46,10 @@ def preprocess_continue(obj: dict[str, Any]) -> list[dict[str, Any]]:
 
         role = message.get("role", "")
         content = message.get("content")
-        tool_calls = message.get("tool_calls")
+        # Continue.dev persists session JSON with camelCase keys (TypeScript
+        # JSON.stringify of its internal ChatMessage types). snake_case keys
+        # only appear on the OpenAI provider wire format, never on disk.
+        tool_calls = message.get("toolCalls")
 
         if role == "user":
             results.append(
@@ -92,7 +100,7 @@ def preprocess_continue(obj: dict[str, Any]) -> list[dict[str, Any]]:
                 {
                     "block_type": "tool.result",
                     "session_id": session_id,
-                    "tool_call_id": message.get("tool_call_id", ""),
+                    "tool_call_id": message.get("toolCallId", ""),
                     "content": content,
                 }
             )

--- a/tests/integration/test_opencode_e2e.py
+++ b/tests/integration/test_opencode_e2e.py
@@ -317,14 +317,18 @@ class TestOpenCodeMappings:
         pytest.param(
             _wire_event(
                 "session.next.compaction.ended",
+                messageID="msg-1",
+                reason="auto",
                 text="Condensed summary",
-                include=["turn-1", "turn-2"],
+                recent="turn-2",
             ),
             "workflow.compaction.completed",
             {
                 "session_id": "sess-abc",
+                "message_id": "msg-1",
+                "reason": "auto",
                 "text": "Condensed summary",
-                "include": ["turn-1", "turn-2"],
+                "recent": "turn-2",
             },
             id="session.next.compaction.ended",
         ),

--- a/tests/integration/test_yaml_comprehensive_e2e.py
+++ b/tests/integration/test_yaml_comprehensive_e2e.py
@@ -1842,7 +1842,7 @@ class TestPydanticAIMappings:
         pytest.param(
             {
                 "event_kind": "part_end",
-                "content": "Hello world",
+                "part": {"part_kind": "text", "content": "Hello world"},
                 "timestamp": "2024-06-15T10:00:15Z",
             },
             EventKind.MESSAGE_ASSISTANT,

--- a/tests/unit/test_continue_preprocessor.py
+++ b/tests/unit/test_continue_preprocessor.py
@@ -1,0 +1,89 @@
+"""Regression tests for the Continue.dev preprocessor.
+
+Continue.dev persists session JSON with camelCase keys (toolCalls, toolCallId)
+produced by JSON.stringify of its internal TypeScript ChatMessage types.
+snake_case (tool_calls/tool_call_id) only appears on the OpenAI provider wire
+format, never in the on-disk session file. These tests pin the preprocessor to
+the real on-disk shape so tool calls are not silently dropped.
+"""
+
+from __future__ import annotations
+
+from tracemill.preprocessors.continue_dev import preprocess_continue
+
+
+def _raw_session() -> dict:
+    """A raw Continue.dev session as written to ~/.continue/sessions/{id}.json."""
+    return {
+        "sessionId": "sess-1",
+        "title": "demo",
+        "history": [
+            {"message": {"role": "user", "content": "read app.ts"}},
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Reading the file.",
+                    "toolCalls": [
+                        {
+                            "id": "tc_001",
+                            "type": "function",
+                            "function": {
+                                "name": "readFile",
+                                "arguments": '{"filepath": "/src/app.ts"}',
+                            },
+                        }
+                    ],
+                }
+            },
+            {
+                "message": {
+                    "role": "tool",
+                    "toolCallId": "tc_001",
+                    "content": "export const x = 1;",
+                }
+            },
+        ],
+    }
+
+
+def test_camelcase_tool_call_is_emitted() -> None:
+    blocks = preprocess_continue(_raw_session())
+    tool_uses = [b for b in blocks if b["block_type"] == "assistant.tool_use"]
+    assert len(tool_uses) == 1, "camelCase toolCalls must not be dropped"
+    tc = tool_uses[0]
+    assert tc["tool_call_id"] == "tc_001"
+    assert tc["tool_name"] == "readFile"
+    assert tc["arguments"] == {"filepath": "/src/app.ts"}
+
+
+def test_camelcase_tool_result_correlates() -> None:
+    blocks = preprocess_continue(_raw_session())
+    results = [b for b in blocks if b["block_type"] == "tool.result"]
+    assert len(results) == 1
+    # camelCase toolCallId must populate tool_call_id for call/result correlation
+    assert results[0]["tool_call_id"] == "tc_001"
+
+
+def test_snake_case_is_not_read_from_disk() -> None:
+    """A snake_case session (provider-wire shape) must NOT yield tool calls.
+
+    This guards against silently re-introducing the snake_case bug: the on-disk
+    format is camelCase only.
+    """
+    session = {
+        "sessionId": "sess-2",
+        "history": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "x",
+                    "tool_calls": [
+                        {"id": "tc_x", "function": {"name": "n", "arguments": "{}"}}
+                    ],
+                }
+            },
+        ],
+    }
+    blocks = preprocess_continue(session)
+    tool_uses = [b for b in blocks if b["block_type"] == "assistant.tool_use"]
+    assert tool_uses == []


### PR DESCRIPTION
## Summary

The weekly framework-compatibility audit filed four `bug` drift issues. Each claim was **independently verified against the real upstream source** before acting. Three were real and are fixed here; one (#38) is a false positive and is left unchanged.

| Issue | Framework | Verdict | Change |
|-------|-----------|---------|--------|
| #37 | continue_dev | ✅ real bug | preprocessor reads camelCase `toolCalls`/`toolCallId` |
| #40 | pydantic_ai | ✅ real bug | `stream.part_end` maps `content: part.content` |
| #39 | opencode | ✅ real bug | `compaction.ended` `include` → `recent` (+`messageID`/`reason`) |
| #38 | codex | ❌ false positive | no change; see below |

## Details

**#37 continue_dev** — Continue.dev persists session JSON with camelCase keys (`toolCalls`, `toolCallId`) via `JSON.stringify` of its internal `ChatMessage` types (`core/index.d.ts`, `core/util/history.ts`). snake_case only appears on the OpenAI provider wire format. The preprocessor read snake_case → **every tool call was silently dropped** and tool results lost their `tool_call_id`. Verified against `continuedev/continue@main`.

**#40 pydantic_ai** — `PartEndEvent` has fields `index`, `part`, `next_part_kind`, `event_kind` — **no top-level `content`**; text lives at `part.content` (`pydantic_ai_slim/pydantic_ai/messages.py` L2638-2660). The mapping resolved a nonexistent top-level `content`, emitting empty assistant content. Fixed to `part.content` (consistent with the existing `stream.part_start` mapping).

**#39 opencode** — `session.next.compaction.ended` dropped `include`, replaced by `recent` (and gained `messageID`, `reason: "auto"|"manual"`). Verified against `anomalyco/opencode` `packages/schema/src/session-event.ts`. Two inaccuracies in the original issue were corrected: there is **no** schema version 1→2 bump, and the canonical source is the schema package, not the `packages/core/src/session/event.ts` re-export stub (header updated accordingly).

**#38 codex (not changed)** — `cwd` is `PathUri` *internally* upstream, but the rollout JSONL that tracemill ingests (`~/.codex/sessions/*.jsonl`) deliberately serializes `cwd` back to a **native path** via `inferred_native_path_string()` (`codex-rs/rollout-trace/src/protocol_event.rs`, test `exec_command_trace_payloads_use_inferred_native_cwd`). The drift only affects the in-memory wire format, not what tracemill reads. The cited commit `d1209bdd` is also misattributed. **Recommend closing #38.**

## Why the suite missed this

The integration fixtures fed **post-preprocessor** shapes (already-normalized `block_type` events; a synthetic `part_end` with a top-level `content`), so they validated mappings against tracemill's own assumptions instead of real upstream output. This PR:
- adds a **preprocessor-level** camelCase regression test for continue_dev (`tests/unit/test_continue_preprocessor.py`),
- corrects the pydantic_ai `part_end` fixture to carry `part: {part_kind, content}`,
- corrects the opencode `compaction.ended` fixture to `recent`/`messageID`/`reason`.

A follow-up to capture **real raw traces** per framework and build e2e tests from them is planned.

## Testing

`uv run pytest tests/` → **1709 passed, 4 skipped**.

Closes #37, #39, #40.
