### PR TITLE
chore(release): PyPI packaging readiness

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,174 @@
+# Releasing tracemill
+
+This repo publishes **two** independent distributions to PyPI. This document is
+the operational runbook and go/no-go checklist for cutting a release.
+
+> **Status:** the first PyPI release is **prepared but BLOCKED**. Do not push a
+> release tag until the two gating items in [§7](#7-gono-go-checklist) are merged.
+
+---
+
+## 1. The two distributions
+
+| Distribution | Source | Contents | Publish workflow | Tag |
+|---|---|---|---|---|
+| `tracemill` | root `pyproject.toml` | code + small data (classify/mappings/gates YAML, phase/boundary/title heads, `potion-base-8M` `.safetensors`) | `.github/workflows/publish.yml` | `v*` |
+| `tracemill-title-model` | `packages/tracemill-title-model` | pure-data ONNX span titler (`encoder.onnx`, `decoder.onnx`, `tokenizer.json`) | `.github/workflows/publish-title-model.yml` | `title-model-v*` |
+
+`tracemill` depends on `tracemill-title-model>=0.2`. The titler weights are a
+separate distribution so the core wheel stays code-first and the ~95 MB model
+only re-releases when it is retrained (rarely), on its own tag.
+
+Both weight classes (`.safetensors` in `tracemill`, `.onnx` in
+`tracemill-title-model`) are tracked with **Git LFS** — see [§4](#4-git-lfs--weight-integrity).
+
+## 2. Versioning strategy
+
+- **Scheme:** [SemVer](https://semver.org/). Both distributions are pre-1.0
+  (`0.MINOR.PATCH`); while `0.x`, a **MINOR** bump may carry breaking changes and
+  a **PATCH** bump is reserved for backwards-compatible fixes. Cut `1.0.0` once the
+  public API (SDK `Pipeline`/`GatePolicy`/`Verdict`, the `tracemill` CLI surface,
+  and the YAML config schema) is committed to stability.
+- **Initial versions:** `tracemill` `0.1.0`; `tracemill-title-model` `0.2.0`
+  (already ahead — it iterated during model development).
+- **Independent lifecycles:** the two versions move independently. A code-only
+  release bumps `tracemill` and reuses the existing model. A retrain bumps
+  `tracemill-title-model` and, if the new weights require it, widens the
+  `tracemill` dependency floor.
+- **Single source of truth:** each version lives only in its own
+  `pyproject.toml`. The CLI reports it via `importlib.metadata`
+  (`click.version_option(package_name="tracemill")`) — never hard-code a version
+  string elsewhere.
+- **Model dependency pin:** `tracemill` requires `tracemill-title-model>=0.2`.
+  The model is a pure-data package with a stable three-file head contract
+  (`encoder.onnx`/`decoder.onnx`/`tokenizer.json`), so a compatible retrain is
+  drop-in. If a future retrain changes that on-disk contract, raise the floor
+  (e.g. `>=0.3`) in the same PR that ships the new model.
+
+## 3. Release order (critical)
+
+Because `tracemill` depends on `tracemill-title-model`, a fresh model release
+must land on PyPI **before** the code release that requires it:
+
+1. (Only if the model changed) tag `title-model-vX.Y.Z` → wait for
+   `Publish title model` to finish and the version to be visible on PyPI.
+2. Tag `vA.B.C` → `Publish` builds and uploads `tracemill`.
+
+If the model is unchanged, step 1 is skipped and `tracemill` resolves the
+already-published model.
+
+## 4. Git LFS & weight integrity
+
+The model binaries are Git LFS objects. If a publish job checks out the repo
+**without** LFS smudging, the working tree holds ~133-byte pointer files instead
+of real weights, and the build would happily bake those pointers into a wheel
+that imports but cannot load its model.
+
+Two guards prevent that:
+
+- **`lfs: true`** on every `actions/checkout` in both publish workflows (and in CI).
+- **`scripts/verify_no_lfs_pointers.py`** runs after `python -m build` in both
+  workflows. It opens every built artifact, asserts each `*.onnx` / `*.safetensors`
+  member is a real binary (not an LFS pointer, not implausibly small), and
+  `--require`s that the expected weight suffix is present at all (catching a
+  "weights dropped out entirely" regression):
+  - `publish.yml` → `--require .safetensors`
+  - `publish-title-model.yml` → `--require .onnx`
+
+A pointer stub or a missing-weights build therefore **fails loudly before publish**.
+
+## 5. PyPI Trusted Publishing (OIDC)
+
+Both workflows authenticate with **PyPI Trusted Publishing** — no API tokens or
+secrets. Each declares `permissions: id-token: write` and `environment: pypi`,
+and uses `pypa/gh-action-pypi-publish`.
+
+One-time PyPI setup (per distribution, done in the PyPI project's
+*Publishing* settings — or as a pending publisher before the first upload):
+
+| Field | Value |
+|---|---|
+| Owner | `dfinson` |
+| Repository | `tracemill` |
+| Workflow (tracemill) | `publish.yml` |
+| Workflow (title-model) | `publish-title-model.yml` |
+| Environment | `pypi` |
+
+Also create a GitHub Environment named `pypi` on the repo (optionally with
+required reviewers) so releases are gated.
+
+## 6. Local pre-flight (dry run — never uploads)
+
+Run from the repo root. This mirrors exactly what CI builds and verifies, minus
+the upload step:
+
+```bash
+# Build both distributions
+uv build --sdist --wheel --out-dir dist
+uv build packages/tracemill-title-model --out-dir dist
+
+# Integrity gate — must exit 0
+uv run --no-project python scripts/verify_no_lfs_pointers.py dist \
+  --require .onnx --require .safetensors
+
+# Optional: confirm metadata renders
+uv run --no-project --with twine twine check dist/*
+```
+
+Expected: the tracemill wheel carries the classify/mappings/gates YAML, the
+phase/boundary/title heads, `py.typed`, and the `potion-base-8M` `.safetensors`;
+the title-model wheel carries the ONNX triad; the tracemill **sdist** stays lean
+(~29 MB — it deliberately excludes `packages/`, `tests/`, and `research/`, so it
+never bundles the titler weights and never approaches PyPI's 100 MiB per-file cap).
+
+## 7. Go/No-Go checklist
+
+**Blockers (must be TRUE before any tag is pushed):**
+
+- [ ] **F2 — governance durability fix merged.** The `SessionRegistry.ensure()`
+      `_db=None` gate-state path can no-op `persist_no_commit`, losing durability.
+      Tracked as duck-round finding **F2**; a first release must not ship it.
+- [ ] **Docs-refresh PR merged.** README/SPEC are being reconciled with delivery
+      in a separate session; the release readme pointer must reflect that.
+
+**Packaging readiness (verified by this PR):**
+
+- [x] `tracemill` metadata complete: name, version, description, readme, license
+      (SPDX `MIT` → `License-Expression`), authors, requires-python
+      (`>=3.11,<3.14`), classifiers (Dev Status 4-Beta, Python 3.11/3.12/3.13,
+      Typing :: Typed), keywords, `project.urls`.
+- [x] `tracemill-title-model` metadata complete (authors, classifiers, urls).
+- [x] Dependencies verified **torch-free / CPU-only** — no `torch`, `nvidia-*`,
+      `cuda`, or `onnxruntime-gpu` in the resolved graph.
+- [x] `tracemill` CLI entry point (`tracemill = "tracemill.cli:main"`) resolves.
+- [x] Package **data ships in the wheel** (all classify/mappings/gates YAML,
+      schema, phase/boundary/title heads, `potion-base-8M` weights).
+- [x] `py.typed` shipped (PEP 561).
+- [x] LFS weights are real bytes; `verify_no_lfs_pointers` wired into both
+      workflows and passing.
+- [x] Core sdist trimmed (no redundant weights; well under the 100 MiB cap) and
+      proven to build a complete wheel from itself.
+- [x] Trusted-publishing workflows in place for both distributions with
+      `lfs: true` checkouts.
+
+**Release steps (once blockers clear):**
+
+1. [ ] Final `main` is green (Test on 3.11/3.12/3.13, Lint).
+2. [ ] Bump versions if needed; update this checklist.
+3. [ ] (If model changed) push `title-model-vX.Y.Z`; confirm on PyPI + GH release mirror.
+4. [ ] Push `vA.B.C`; confirm `Publish` succeeds and `pip install tracemill` pulls
+       the model automatically.
+5. [ ] Smoke test in a clean env: `pip install tracemill && tracemill --version`.
+
+## 8. Fallback: GitHub-release model mirror
+
+`publish-title-model.yml` also uploads the model wheel as a GitHub Release asset
+under the `title-model-v*` tag. If PyPI is unavailable, users repair/fetch the
+weights with:
+
+```bash
+tracemill download-model --source gh
+```
+
+The mirror URL that `download-model` targets is exactly the asset the workflow
+uploads, so the primary (PyPI) and fallback (GitHub) paths stay in lockstep.

--- a/packages/tracemill-title-model/pyproject.toml
+++ b/packages/tracemill-title-model/pyproject.toml
@@ -8,13 +8,28 @@ version = "0.2.0"
 description = "Pretrained int8 ONNX titler weights for tracemill (activity/step span head)"
 readme = "README.md"
 license = "MIT"
+authors = [{ name = "David Finson", email = "davidfinson@microsoft.com" }]
 requires-python = ">=3.11,<3.14"
+keywords = ["tracemill", "onnx", "titler", "model-weights"]
+# No legacy license classifier: `license = "MIT"` emits a PEP 639 License-Expression.
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 # Pure data distribution: no runtime imports of its own. The onnxruntime /
 # tokenizers stack that *reads* these files ships as a tracemill dependency.
 dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/dfinson/tracemill"
+Repository = "https://github.com/dfinson/tracemill"
+Issues = "https://github.com/dfinson/tracemill/issues"
 Release = "https://github.com/dfinson/tracemill/releases"
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,37 @@ build-backend = "hatchling.build"
 [project]
 name = "tracemill"
 version = "0.1.0"
-description = "Agent event observation pipeline with pluggable storage backends"
+description = "Framework-agnostic, CPU-only pipeline that mills AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"
 license = "MIT"
+authors = [{ name = "David Finson", email = "davidfinson@microsoft.com" }]
 requires-python = ">=3.11,<3.14"
+keywords = [
+    "agent",
+    "observability",
+    "governance",
+    "ai-agents",
+    "llm",
+    "tracing",
+    "coding-agents",
+    "risk-scoring",
+]
+# NOTE: no legacy "License :: OSI Approved :: MIT License" classifier — the SPDX
+# `license = "MIT"` above emits Metadata 2.4 `License-Expression: MIT` (PEP 639),
+# and hatchling rejects a license expression combined with a license classifier.
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
+]
 dependencies = [
     "alembic>=1.13",
     "click>=8.1",
@@ -47,6 +74,12 @@ s3 = [
 [project.scripts]
 tracemill = "tracemill.cli:main"
 
+[project.urls]
+Homepage = "https://github.com/dfinson/tracemill"
+Repository = "https://github.com/dfinson/tracemill"
+Issues = "https://github.com/dfinson/tracemill/issues"
+Changelog = "https://github.com/dfinson/tracemill/releases"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
@@ -70,6 +103,21 @@ packages = ["src/tracemill"]
 # (a hard dependency), NOT in this wheel. Only the tiny non-model data files
 # (boilerplate list, phase/boundary heads) are force-included here.
 artifacts = ["src/tracemill/phase/data/*.joblib", "src/tracemill/phase/data/potion-base-8M/*", "src/tracemill/boundary/data/*.joblib", "src/tracemill/title/data/*.json"]
+
+[tool.hatch.build.targets.sdist]
+# Keep the core sdist lean and safely under PyPI's 100 MiB per-file cap: ship only
+# what's needed to build the wheel. `only-include` (not `include`) is a strict
+# allowlist, so it also drops hatchling's default "every README.md/pyproject.toml
+# in the tree" selection. Excludes packages/ — the titler weights ship as their own
+# `tracemill-title-model` distribution, so bundling them here would add ~95 MB of
+# redundant ONNX and push the sdist past the limit — plus tests/, research/, and
+# docs/ fixtures that a source build of the wheel does not require.
+only-include = [
+    "src/tracemill",
+    "pyproject.toml",
+    "README.md",
+    "LICENSE",
+]
 
 # During development, resolve the model package from the in-repo path so an
 # editable `uv sync` serves the real weights without a PyPI/GitHub round-trip.


### PR DESCRIPTION
## Summary

Audits and hardens **both** distributions for tracemill's first PyPI release. **Prep only — no tag is pushed and nothing is published.** The actual release stays **blocked** pending the governance durability fix (**F2**) and the docs-refresh PR merge (see the checklist in `RELEASING.md`).

Scope kept to packaging: `pyproject.toml`, `packages/tracemill-title-model`, and release docs. No workflow edits (audited clean), no `src/` code changes (only an empty PEP 561 marker).

## Audit outcome

| Area | Result |
|---|---|
| torch-free / CPU-only | ✅ Verified — no `torch`/`nvidia-*`/`cuda`/`onnxruntime-gpu` in the resolved graph or `Requires-Dist` |
| Package data in wheel | ✅ All `classify`/`mappings`/`gates` YAML, schema, phase/boundary/title heads, and `potion-base-8M` `.safetensors` ship |
| LFS weights | ✅ Real bytes (35/58 MB ONNX, 30 MB safetensors); `verify_no_lfs_pointers` wired into both publish workflows and passing |
| Publish workflows | ✅ `publish.yml` (`v*`) and `publish-title-model.yml` (`title-model-v*`): trusted publishing (OIDC), `lfs: true` checkout, guard + `--require`; GH-release model mirror matches `download-model --source gh` |
| CLI entry point | ✅ `tracemill = "tracemill.cli:main"` resolves |

## Fixes in this PR

- **`tracemill` metadata:** refreshed description; added `authors`, `keywords`, `classifiers` (Dev Status 4-Beta, Python 3.11/3.12/3.13, `Typing :: Typed`), and `[project.urls]`. Deliberately **no** legacy `License ::` classifier — the SPDX `license = "MIT"` emits `License-Expression: MIT` (PEP 639) and hatchling rejects combining the two.
- **`tracemill-title-model` metadata:** added `authors`, `keywords`, `classifiers`, and `Repository`/`Issues` URLs.
- **`py.typed`** (PEP 561) so typed consumers (memrelay, CodePlane) get hints.
- **Lean sdist:** the core sdist was **99 MB** because it bundled the ~95 MB titler ONNX via the `packages/` subtree — dangerously close to PyPI's 100 MiB per-file cap. Switched to a strict `only-include` allowlist → **28.7 MB**, and verified it still **builds a complete wheel from itself**.
- **`RELEASING.md`:** version strategy, tag + release-order conventions, LFS integrity guard, trusted-publishing setup, local pre-flight, and a go/no-go checklist.

## Verification

- `uv run python -m pytest -q` → **1885 passed, 4 skipped**
- `ruff check .` + `ruff format --check .` (pinned 0.15.20) → clean
- Built both distributions; `verify_no_lfs_pointers.py dist --require .onnx --require .safetensors` → all weight members real binaries
- Metadata inspected in the built wheels (classifiers/authors/urls/`License-Expression` present, no duplicate license classifier)

## Version strategy

SemVer, both pre-1.0 with independent lifecycles: `tracemill` `0.1.0`, `tracemill-title-model` `0.2.0`. Versions single-sourced from each `pyproject.toml` (CLI reads `importlib.metadata`). Model releases must land on PyPI **before** the code release that depends on them. Details in `RELEASING.md`.

> ⚠️ **Do not tag a release from this PR.** Publish is gated on F2 + the docs-refresh merge.