### PR TITLE
Fix governance durability gap: writer path always operates on DB-backed state

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1370,7 +1370,7 @@ API; the SDK `Pipeline` composes it with the observation backbone.
 |---|---|---|
 | `SessionState` | Encapsulate one session's accumulators — **one** tool-call counter, budget dimensions, taint ledger, phase window, gate history. Mutated only through its own methods; exposes an immutable `snapshot()` and a detached `clone` for previews. | — |
 | `SystemStore` | Durability: idempotency reservations, atomic commit, crash recovery, audit persistence. | sqlite |
-| `SessionRegistry` | Residency: the one place sessions are created, found, and LRU-evicted; reservation bookkeeping. | `SystemStore` |
+| `SessionRegistry` | Residency: the one place sessions are created and found, keeping two separate scopes — **durable** observation state (DB-backed, the single writer's) and **ephemeral** gate state (`_db=None`, never cross-thread sqlite) — so the writer always persists and the gate never touches the DB; plus eviction and reservation bookkeeping. | `SystemStore` |
 | `ContextBuilder` | Bridge a raw hook payload / adapted `SessionEvent` into an `EnrichmentContext` (classification + shell-command analysis). | engine |
 | `Phase1` | The Phase-1 state-advance step — budget, taint (IFC), phase window, pressure — applied to whichever `SessionState` it is handed (the real one, or a clone). | budget, labeler |
 | `Assessor` | Turn `(snapshot, event)` into a `SessionMeta` — label + risk + recommendation + drift + MCP. Side-effect-free. | labeler, rules, engine |
@@ -1390,7 +1390,7 @@ flowchart TB
     SCO["Scorer<br/>(read-only preview)"]
     SH["Shield<br/>(enforcement)"]
   end
-  REG["SessionRegistry<br/>(residency + eviction)"]
+  REG["SessionRegistry<br/>(durable + gate residency)"]
   ST["SessionState<br/>(one counter, methods only)"]
   ASS["Assessor<br/>(label · risk · drift · recommend)"]
   POL["GatePolicy<br/>(Verdict strategy)"]

--- a/src/tracemill/governance/monitor.py
+++ b/src/tracemill/governance/monitor.py
@@ -123,8 +123,10 @@ class SessionMonitor:
             # Finalize: write session summary
             snapshot = state.snapshot()
             self._write_session_summary(session_id, snapshot)
-            # Evict session state to prevent unbounded memory growth
+            # Evict session state to prevent unbounded memory growth. Both
+            # residencies (durable + gate) are dropped on session end.
             self._registry.evict(session_id)
+            self._registry.evict_gate(session_id)
             self._write_failures.pop(session_id, None)
             # Clean up any lingering phase23 attempts for this session's events
             for key in self._phase23_session_keys.pop(session_id, set()):

--- a/src/tracemill/governance/registry.py
+++ b/src/tracemill/governance/registry.py
@@ -1,4 +1,21 @@
-"""Per-session residency for governance: the single owner of live SessionState."""
+"""Per-session residency for governance: the single owner of live SessionState.
+
+A session has two distinct residency scopes that must never be conflated, because
+the two governance channels have opposite durability and threading constraints:
+
+  * **Durable / observation residency** — owned by the ``SessionMonitor`` single
+    writer. States are rehydrated from the durable store, carry a live DB
+    connection, and their ``persist`` actually writes. Phase-1 mutations here
+    (budget, taint) must survive a restart.
+  * **Ephemeral / gate residency** — owned by the ``Shield`` enforcement gate,
+    which runs at the framework's input edge on arbitrary threads. Gate state is
+    created with ``_db=None`` and never touches SQLite, so it is safe to build
+    cross-thread; it only carries in-process gate context.
+
+Keeping these separate is the fix for the F2 durability gap: when the gate creates
+a session's state first, the writer must not be handed that non-durable
+``_db=None`` state (its persists would silently no-op). See :class:`SessionRegistry`.
+"""
 
 from __future__ import annotations
 
@@ -10,54 +27,84 @@ if TYPE_CHECKING:
 
 
 class SessionRegistry:
-    """Owns per-session residency — the one home for live SessionState.
+    """Owns per-session residency across two scopes: durable and gate-ephemeral.
 
-    Centralizing the residency map here means no two code paths can create
-    divergent state for the same session (the pipeline previously carried two
-    uncoordinated creation paths). Two creation strategies share this single
-    map, and both return an already-resident state when one exists:
+    Centralizing residency here means no two code paths create divergent state for
+    the same session. But the observation (writer) and gate channels have
+    incompatible needs, so each session keeps a state in whichever of two maps
+    matches the caller's channel — the writer never borrows the gate's state and
+    vice versa:
 
-      * ``get_or_create`` rehydrates from the durable store, so the observation
-        channel's crash recovery sees persisted budgets.
-      * ``ensure`` creates thread-safe ephemeral state (never touching SQLite
-        cross-thread), which the gate channel uses for enforcement context.
+      * ``_durable_states`` — the observation channel (single writer:
+        ``SessionMonitor``). ``get_or_create`` rehydrates from the durable store,
+        so entries are always DB-backed and their persists durably write.
+      * ``_gate_states`` — the gate channel (``Shield``). ``ensure`` creates
+        thread-safe ephemeral state (``_db=None``, never touching SQLite
+        cross-thread) for enforcement context.
+
+    Because the two channels hold *separate* ``SessionState`` objects per session,
+    their counters can never be mutated concurrently from different threads, and
+    the writer's ``persist_no_commit`` is guaranteed a live connection (the F2
+    durability invariant).
     """
 
     def __init__(self, store: "SystemStore") -> None:
         self._store = store
-        self._states: dict[str, "SessionState"] = {}
+        # Observation channel: DB-backed states (single writer: SessionMonitor).
+        self._durable_states: dict[str, "SessionState"] = {}
+        # Gate channel: ephemeral _db=None states (Shield enforcement).
+        self._gate_states: dict[str, "SessionState"] = {}
 
-    def __contains__(self, session_id: str) -> bool:
-        return session_id in self._states
-
-    def get(self, session_id: str) -> "SessionState | None":
-        """Return the resident state for a session, or None if not resident."""
-        return self._states.get(session_id)
+    # ── Durable / observation residency (the single writer) ──
 
     def get_or_create(self, session_id: str) -> "SessionState":
-        """Return the resident state, rehydrating from the store on a miss."""
+        """Return the durable, DB-backed state, rehydrating from the store on a miss.
+
+        Always yields a state with a live connection, so the writer's
+        ``persist_no_commit`` / ``persist`` durably write. Observation channel only.
+        """
         from tracemill.governance.state import SessionState
 
-        if session_id not in self._states:
-            self._states[session_id] = SessionState.load_from_db(session_id, self._store.connection)
-        return self._states[session_id]
+        if session_id not in self._durable_states:
+            self._durable_states[session_id] = SessionState.load_from_db(
+                session_id, self._store.connection
+            )
+        return self._durable_states[session_id]
+
+    def evict(self, session_id: str) -> "SessionState | None":
+        """Remove and return the durable (observation) state for a session, if any."""
+        return self._durable_states.pop(session_id, None)
+
+    # ── Ephemeral / gate residency (enforcement, thread-safe) ──
 
     def ensure(self, session_id: str) -> "SessionState":
-        """Return the resident state, creating fresh ephemeral state on a miss.
+        """Return the gate's ephemeral state, creating it (``_db=None``) on a miss.
 
         Never rehydrates from SQLite, so it is safe to call from any thread.
         Uses ``setdefault`` so concurrent callers converge on one instance.
         """
         from tracemill.governance.state import SessionState
 
-        if session_id not in self._states:
-            self._states.setdefault(session_id, SessionState(session_id=session_id))
-        return self._states[session_id]
+        if session_id not in self._gate_states:
+            self._gate_states.setdefault(session_id, SessionState(session_id=session_id))
+        return self._gate_states[session_id]
 
-    def replace(self, session_id: str, state: "SessionState") -> None:
-        """Install a state instance for a session (used after a forced reload)."""
-        self._states[session_id] = state
+    def get_gate(self, session_id: str) -> "SessionState | None":
+        """Return the gate's resident ephemeral state, or None if not resident."""
+        return self._gate_states.get(session_id)
 
-    def evict(self, session_id: str) -> "SessionState | None":
-        """Remove and return the resident state for a session, if any."""
-        return self._states.pop(session_id, None)
+    def evict_gate(self, session_id: str) -> "SessionState | None":
+        """Remove and return the gate's ephemeral state for a session, if any."""
+        return self._gate_states.pop(session_id, None)
+
+    # ── Read-only preview (Scorer) ──
+
+    def preview_state(self, session_id: str) -> "SessionState | None":
+        """Return a base state for a non-persisted preview, or None if unknown.
+
+        Prefers the durable observation state (so a preview reflects accumulated,
+        persisted budgets), falling back to the gate's ephemeral state. The caller
+        clones this via ``clone_detached`` and never mutates or persists it, so
+        returning either residency is side-effect-free.
+        """
+        return self._durable_states.get(session_id) or self._gate_states.get(session_id)

--- a/src/tracemill/governance/scorer.py
+++ b/src/tracemill/governance/scorer.py
@@ -179,8 +179,9 @@ class Scorer:
         session_id = ctx.event.session_id
 
         # Use cached state if available; otherwise start fresh (thread-safe,
-        # avoids cross-thread sqlite3 access for unknown sessions)
-        state = self._registry.get(session_id)
+        # avoids cross-thread sqlite3 access for unknown sessions). Prefers the
+        # durable observation state so the preview reflects accumulated budgets.
+        state = self._registry.preview_state(session_id)
         if state is None:
             state = SessionState(session_id=session_id)
 

--- a/src/tracemill/governance/shield.py
+++ b/src/tracemill/governance/shield.py
@@ -251,7 +251,7 @@ class Shield:
         """
         from tracemill.sdk.gate_types import GateContext
 
-        state = self._registry.get(session_id)
+        state = self._registry.get_gate(session_id)
         if state is None:
             return GateContext(session_id=session_id, tool_call_count=0, denied_count=0)
 

--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -15,6 +15,7 @@ from tracemill.governance.persistence import SystemStore
 from tracemill.governance.pipeline import GovernancePipeline, SessionMeta
 from tracemill.governance.results import RecommendedAction
 from tracemill.governance.rules import parse_rules
+from tracemill.governance.state import SessionState
 from tracemill.types import EventKind, EventMetadata, SessionEvent
 
 
@@ -369,3 +370,60 @@ class TestScoreDoesNotSuppressObservation:
             f"score:{event.id}",
             event.id,
         }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Gate-before-observe durability (F2): the writer must persist even when the
+# Shield created the session's ephemeral (_db=None) gate state first.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGateThenObserveDurability:
+    """Regression for F2: the observation writer must durably persist even when
+    the Shield gated the same session first.
+
+    The Shield's gate channel creates ephemeral ``SessionState(_db=None)`` for a
+    session — deliberately, so enforcement never does cross-thread sqlite. Before
+    the fix the ``SessionRegistry`` shared one residency map, so the
+    ``SessionMonitor``'s ``get_or_create`` was handed that same ``_db=None``
+    state; its ``persist_no_commit`` then silently no-op'd (it early-returns when
+    ``_db is None``) and the observed Phase-1 mutation never reached the DB. The
+    registry now keeps the gate (ephemeral) and observation (DB-backed)
+    residencies separate, so the writer always operates on a persistable state.
+    """
+
+    def test_gate_then_observe_persists_durably(self, pipeline, store):
+        session_id = "gate-then-observe"
+
+        # ── Gate first (Shield path): creates the ephemeral _db=None gate state,
+        # then advances the gate-channel counter at postflight.
+        payload = {
+            "tool_name": "bash",
+            "tool_input": {"command": "ls"},
+            "session_id": session_id,
+        }
+        trace, verdict = pipeline._score_and_gate_preflight(payload)
+        assert verdict.allowed
+        # Guard the assumption that both channels key on the same session id.
+        assert trace.session_id == session_id
+        pipeline._enforce_postflight(trace, session_id=trace.session_id, output={"result": "ok"})
+
+        # ── Observe the same session (SessionMonitor path — the single writer).
+        event = _make_event(
+            tool_name="bash",
+            arguments={"command": "ls"},
+            kind=EventKind.TOOL_CALL_COMPLETED,
+            session_id=session_id,
+        )
+        pipeline.observe_event(event)
+
+        # ── The observation must be DURABLE: a fresh read straight from the DB
+        # must reflect the advanced counter. Without the fix the writer mutated
+        # the gate's _db=None state, persist_no_commit no-op'd, no session_state
+        # row was written, and this reload returns 0.
+        reloaded = SessionState.load_from_db(session_id, store.connection)
+        assert reloaded.tool_call_count == 1
+
+        # ── And the writer's in-memory durable residency advanced exactly once —
+        # not twice from inheriting the gate's already-incremented counter.
+        assert pipeline.get_or_create_state(session_id).tool_call_count == 1


### PR DESCRIPTION
## The bug (F2)

`SessionRegistry` shared **one** `_states` residency map between the two governance channels:

- The **Shield** (gate enforcement) calls `registry.ensure()`, which deliberately creates ephemeral `SessionState(_db=None)` — the gate must never touch sqlite cross-thread.
- The **SessionMonitor** (the single writer) calls `registry.get_or_create()`, whose job is to return a **DB-backed** state.

In the gate-before-observe model, when the Shield gates a session **first**, `get_or_create` finds it already resident and returns the gate's `_db=None` state. The monitor then advances Phase-1 (budget/taint) and calls `state.persist_no_commit()`, which **early-returns when `_db is None`** → the durable write silently no-ops. On rehydrate the accumulated state is gone. The shared object also let the gate and monitor mutate the same counter from different threads (a latent double-count).

## The fix

Split the registry's single map into **two residency scopes**, so the writer and the gate never share a `SessionState`:

- `_durable_states` — the observation channel (single writer). `get_or_create`/`evict`. Always DB-backed via `load_from_db`, so its persists durably write.
- `_gate_states` — the gate channel. `ensure`/`get_gate`/`evict_gate`. Ephemeral `_db=None`, never touches sqlite.
- `preview_state` (durable-then-gate) for the Scorer's read-only preview base.
- Removed the now-ambiguous `get`/`replace`/`__contains__` (no remaining callers).

### Both invariants preserved
- **(a) Gate never does cross-thread sqlite** — `ensure` still returns `_db=None`; gate state is never attached to a connection, and the writer no longer borrows it.
- **(b) Writer always operates on DB-backed state** — `get_or_create` only ever reads/creates in `_durable_states` (rehydrated via `load_from_db`), so `persist_no_commit()` always has a live `_db`.
- **Bonus:** the two channels now hold separate objects per session, so the cross-thread double-count is eliminated by construction.

## Regression test

`tests/unit/test_bridge.py::TestGateThenObserveDurability` gates a session via the Shield, observes the same session via the SessionMonitor, then asserts the observation survives a fresh `SessionState.load_from_db(...)` (and that the in-memory durable counter advanced exactly once). It **fails without this change** (`reloaded.tool_call_count == 0`) and passes with it.

## Verification
- `uv run --no-progress python -m pytest -q -p no:cacheprovider` → **1886 passed, 4 skipped** (prior baseline 1885 + the new test).
- `ruff==0.15.20` `ruff check .` and `ruff format --check .` → clean.
- Also updated SPEC §22 to describe the two residency scopes.