### PR TITLE
fix(governance): promote gate-created ephemeral state so writer persistence survives

### DIFF
--- a/src/tracemill/governance/registry.py
+++ b/src/tracemill/governance/registry.py
@@ -14,11 +14,12 @@ class SessionRegistry:
 
     Centralizing the residency map here means no two code paths can create
     divergent state for the same session (the pipeline previously carried two
-    uncoordinated creation paths). Two creation strategies share this single
-    map, and both return an already-resident state when one exists:
+    uncoordinated creation paths). Two creation strategies share this single map:
 
-      * ``get_or_create`` rehydrates from the durable store, so the observation
-        channel's crash recovery sees persisted budgets.
+      * ``get_or_create`` returns a DB-backed state — rehydrating from the durable
+        store on a miss, and promoting a gate-created ephemeral resident to a
+        durable one — so the observation writer's persistence always reaches disk
+        and its crash recovery sees persisted budgets.
       * ``ensure`` creates thread-safe ephemeral state (never touching SQLite
         cross-thread), which the gate channel uses for enforcement context.
     """
@@ -35,12 +36,28 @@ class SessionRegistry:
         return self._states.get(session_id)
 
     def get_or_create(self, session_id: str) -> "SessionState":
-        """Return the resident state, rehydrating from the store on a miss."""
+        """Return a DB-backed resident state, rehydrating from the store on a miss.
+
+        This is the observation writer's path, so the returned state MUST be
+        DB-backed — its ``persist`` / ``persist_no_commit`` calls have to reach
+        SQLite. The gate channel's :meth:`ensure` may have already installed an
+        ephemeral, DB-less state for this session (the gate-before-observe
+        ordering); returning that instance would make every write silently no-op
+        and lose durability. In that case, promote it: load the durable
+        observation state from the store and carry the gate's in-memory
+        enforcement log forward (that log is never persisted, so a plain reload
+        would drop it).
+        """
         from tracemill.governance.state import SessionState
 
-        if session_id not in self._states:
-            self._states[session_id] = SessionState.load_from_db(session_id, self._store.connection)
-        return self._states[session_id]
+        resident = self._states.get(session_id)
+        if resident is not None and resident.is_db_backed():
+            return resident
+        durable = SessionState.load_from_db(session_id, self._store.connection)
+        if resident is not None:
+            durable.adopt_enforcement_log(resident)
+        self._states[session_id] = durable
+        return durable
 
     def ensure(self, session_id: str) -> "SessionState":
         """Return the resident state, creating fresh ephemeral state on a miss.

--- a/src/tracemill/governance/state.py
+++ b/src/tracemill/governance/state.py
@@ -115,6 +115,14 @@ class SessionState:
     def attach_db(self, db: sqlite3.Connection | None) -> None:
         self._db = db
 
+    def is_db_backed(self) -> bool:
+        """True when this state can persist (has a live DB connection).
+
+        The gate channel's ephemeral states (created via ``SessionRegistry.ensure``)
+        are DB-less; the observation writer must never persist through one.
+        """
+        return self._db is not None
+
     def increment_budget(
         self,
         *,
@@ -209,6 +217,23 @@ class SessionState:
         observation (increment_budget), never here."""
         if tool_call_id:
             self._prior_tool_call_ids.append(tool_call_id)  # deque(maxlen=100)
+
+    def adopt_enforcement_log(self, other: "SessionState") -> None:
+        """Carry another state's in-memory Shield decision log into this one.
+
+        The enforcement log (denial count, prior verdicts, allowed tool-call ids)
+        lives only in memory — it is never persisted, so a session reloaded from
+        SQLite starts it empty. When the observation writer promotes the gate
+        channel's ephemeral state to a durable, DB-backed one, this transfers the
+        gate's accumulated decisions onto the durable state so they are not lost.
+        Observation fields are intentionally untouched: those are single-writer
+        and authoritative on the DB-backed instance.
+        """
+        self._denied_count = other._denied_count
+        self._prior_verdicts = deque(other._prior_verdicts, maxlen=other._prior_verdicts.maxlen)
+        self._prior_tool_call_ids = deque(
+            other._prior_tool_call_ids, maxlen=other._prior_tool_call_ids.maxlen
+        )
 
     def check_pressure(self, thresholds: dict | None) -> bool:
         """Check if any threshold is exceeded. Updates pressure flag."""

--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -13,8 +13,10 @@ from tracemill.governance.budget import BudgetTracker
 from tracemill.governance.labeler import GovernanceLabeler
 from tracemill.governance.persistence import SystemStore
 from tracemill.governance.pipeline import GovernancePipeline, SessionMeta
+from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.results import RecommendedAction
 from tracemill.governance.rules import parse_rules
+from tracemill.governance.state import SessionState
 from tracemill.types import EventKind, EventMetadata, SessionEvent
 
 
@@ -369,3 +371,54 @@ class TestScoreDoesNotSuppressObservation:
             f"score:{event.id}",
             event.id,
         }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Gate-before-observe: the writer must never inherit a DB-less state (durability)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGateBeforeObserveDurability:
+    """Regression (F2): a gate-first ``ensure`` must not leave the observation
+    writer holding an ephemeral, DB-less state.
+
+    ``SessionRegistry.ensure`` (the gate channel) deliberately creates a
+    thread-safe, ``_db=None`` state so it never touches SQLite cross-thread. In
+    the gate-before-observe model the gate touches a session first, so its
+    ephemeral state lands in the shared residency map. If the observation writer
+    then received that same DB-less instance, every ``persist`` /
+    ``persist_no_commit`` would silently no-op and session state would never reach
+    disk. ``get_or_create`` now promotes such a resident to a durable, DB-backed
+    state, carrying the gate's in-memory enforcement log forward.
+    """
+
+    def test_writer_state_is_db_backed_after_gate_ensure(self, store):
+        registry = SessionRegistry(store)
+        sid = "gate-first-session"
+        gate_state = registry.ensure(sid)
+        assert gate_state.is_db_backed() is False
+        writer_state = registry.get_or_create(sid)
+        assert writer_state.is_db_backed() is True
+
+    def test_writer_persistence_survives_gate_first_creation(self, store):
+        # The teeth of F2: with the pre-fix registry the writer inherits the gate's
+        # DB-less state, persist() no-ops, and the reload sees nothing.
+        registry = SessionRegistry(store)
+        sid = "gate-first-durable"
+        registry.ensure(sid)  # gate channel creates the ephemeral state first
+        writer_state = registry.get_or_create(sid)
+        writer_state.increment_budget(effect="write")
+        writer_state.persist()
+        reloaded = SessionState.load_from_db(sid, store.connection)
+        assert reloaded.tool_call_count == 1
+
+    def test_promotion_preserves_enforcement_log(self, store):
+        registry = SessionRegistry(store)
+        sid = "gate-first-log"
+        gate_state = registry.ensure(sid)
+        gate_state.record_denial("deny:policy")
+        gate_state.record_allow("tool-call-42")
+        writer_state = registry.get_or_create(sid)
+        assert writer_state.denied_count == 1
+        assert "tool-call-42" in writer_state.prior_tool_call_ids()
+        assert writer_state.prior_verdicts() == ("deny:policy",)


### PR DESCRIPTION
## What & why

Closes the **F2 durability gap** in the governance runtime: session state could be silently lost whenever a Shield gate touched a session before the observation writer did.

### Root cause
`SessionRegistry._states` is the single residency map shared by two creation paths:
- **`get_or_create`** — the observation *writer* path (`monitor.get_or_create_state`). Loads a **DB-backed** state via `SessionState.load_from_db`.
- **`ensure`** — the Shield *gate* path (`shield._ensure_gate_state`). Deliberately builds an **ephemeral `_db=None`** state so it never touches SQLite cross-thread.

In the **gate-before-observe** ordering (a gated tool call reaches the gate before trace ever observes it — by definition), the gate's `ensure` populates `_states` first. The writer's `get_or_create` then found the session already resident and returned that **ephemeral, DB-less** instance. Its `persist()` / `persist_no_commit()` early-return on `_db is None` (state.py) → **budgets, phase window, and taints were never written to disk.**

### Fix
`get_or_create` now guarantees a DB-backed state:
- Hit + already DB-backed → return it (unchanged behavior).
- Otherwise → load the durable state from the store, and if a gate-created ephemeral was resident, carry its **in-memory enforcement log** (denial count, prior verdicts, allowed tool-call ids) forward via the new `SessionState.adopt_enforcement_log`. That log is never persisted by design, so a plain reload would drop it.

New encapsulated helpers on `SessionState`: `is_db_backed()` (so the registry doesn't poke `_db`) and `adopt_enforcement_log(other)`.

### Invariants preserved
1. The gate/`ensure` path still creates only `_db=None` state and **never** touches cross-thread `sqlite3`.
2. The observation writer **always** receives a DB-backed state.

Observation fields are single-writer and authoritative from the DB, so **no counter reconciliation / dedup** is introduced — only the ephemeral's in-memory gate log is carried across the one-time promotion.

### Known residual (out of scope, pre-existing)
A gate `record_denial` landing on the old ephemeral in the microscopic window during the one-time promotion could be lost. This is advisory-only (a denial count), pre-existing, and no lock exists today; adding one would be a broader concurrency change beyond this fix.

## Tests
Adds `TestGateBeforeObserveDurability` (3 tests). The durability test uses only pre-existing API and **fails pre-fix** (`tool_call_count == 0`, verified by reverting only the registry hunk).

- Full suite: **1888 passed / 4 skipped** (1885 baseline + 3 new)
- `ruff check` + `ruff format --check`: clean

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>