### PR TITLE
Fix governance F2 durability with two-map residency (supersede #57)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1377,7 +1377,7 @@ API; the SDK `Pipeline` composes it with the observation backbone.
 |---|---|---|
 | `SessionState` | Encapsulate one session's accumulators — **one** tool-call counter, budget dimensions, taint ledger, phase window, gate history. Mutated only through its own methods; exposes an immutable `snapshot()` and a detached `clone` for previews. | — |
 | `SystemStore` | Durability: idempotency reservations, atomic commit, crash recovery, audit persistence. | sqlite |
-| `SessionRegistry` | Residency: the one place sessions are created, found, and LRU-evicted; reservation bookkeeping. | `SystemStore` |
+| `SessionRegistry` | Residency: the one place sessions are created and found, keeping two separate scopes — **durable** observation state (DB-backed, the single writer's) and **ephemeral** gate state (`_db=None`, never cross-thread sqlite) — so the writer always persists and the gate never touches the DB; plus eviction and reservation bookkeeping. | `SystemStore` |
 | `ContextBuilder` | Bridge a raw hook payload / adapted `SessionEvent` into an `EnrichmentContext` (classification + shell-command analysis). | engine |
 | `Phase1` | The Phase-1 state-advance step — budget, taint (IFC), phase window, pressure — applied to whichever `SessionState` it is handed (the real one, or a clone). | budget, labeler |
 | `Assessor` | Turn `(snapshot, event)` into a `SessionMeta` — label + risk + recommendation + drift + MCP. Side-effect-free. | labeler, rules, engine |
@@ -1397,7 +1397,7 @@ flowchart TB
     SCO["Scorer<br/>(read-only preview)"]
     SH["Shield<br/>(enforcement)"]
   end
-  REG["SessionRegistry<br/>(residency + eviction)"]
+  REG["SessionRegistry<br/>(durable + gate residency)"]
   ST["SessionState<br/>(one counter, methods only)"]
   ASS["Assessor<br/>(label · risk · drift · recommend)"]
   POL["GatePolicy<br/>(Verdict strategy)"]

--- a/src/tracemill/governance/monitor.py
+++ b/src/tracemill/governance/monitor.py
@@ -123,8 +123,10 @@ class SessionMonitor:
             # Finalize: write session summary
             snapshot = state.snapshot()
             self._write_session_summary(session_id, snapshot)
-            # Evict session state to prevent unbounded memory growth
+            # Evict session state to prevent unbounded memory growth. Both
+            # residencies (durable + gate) are dropped on session end.
             self._registry.evict(session_id)
+            self._registry.evict_gate(session_id)
             self._write_failures.pop(session_id, None)
             # Clean up any lingering phase23 attempts for this session's events
             for key in self._phase23_session_keys.pop(session_id, set()):

--- a/src/tracemill/governance/registry.py
+++ b/src/tracemill/governance/registry.py
@@ -14,12 +14,11 @@ class SessionRegistry:
 
     Centralizing the residency map here means no two code paths can create
     divergent state for the same session (the pipeline previously carried two
-    uncoordinated creation paths). Two creation strategies share this single map:
+    uncoordinated creation paths). Two creation strategies share this single
+    map, and both return an already-resident state when one exists:
 
-      * ``get_or_create`` returns a DB-backed state — rehydrating from the durable
-        store on a miss, and promoting a gate-created ephemeral resident to a
-        durable one — so the observation writer's persistence always reaches disk
-        and its crash recovery sees persisted budgets.
+      * ``get_or_create`` rehydrates from the durable store, so the observation
+        channel's crash recovery sees persisted budgets.
       * ``ensure`` creates thread-safe ephemeral state (never touching SQLite
         cross-thread), which the gate channel uses for enforcement context.
     """
@@ -36,28 +35,12 @@ class SessionRegistry:
         return self._states.get(session_id)
 
     def get_or_create(self, session_id: str) -> "SessionState":
-        """Return a DB-backed resident state, rehydrating from the store on a miss.
-
-        This is the observation writer's path, so the returned state MUST be
-        DB-backed — its ``persist`` / ``persist_no_commit`` calls have to reach
-        SQLite. The gate channel's :meth:`ensure` may have already installed an
-        ephemeral, DB-less state for this session (the gate-before-observe
-        ordering); returning that instance would make every write silently no-op
-        and lose durability. In that case, promote it: load the durable
-        observation state from the store and carry the gate's in-memory
-        enforcement log forward (that log is never persisted, so a plain reload
-        would drop it).
-        """
+        """Return the resident state, rehydrating from the store on a miss."""
         from tracemill.governance.state import SessionState
 
-        resident = self._states.get(session_id)
-        if resident is not None and resident.is_db_backed():
-            return resident
-        durable = SessionState.load_from_db(session_id, self._store.connection)
-        if resident is not None:
-            durable.adopt_enforcement_log(resident)
-        self._states[session_id] = durable
-        return durable
+        if session_id not in self._states:
+            self._states[session_id] = SessionState.load_from_db(session_id, self._store.connection)
+        return self._states[session_id]
 
     def ensure(self, session_id: str) -> "SessionState":
         """Return the resident state, creating fresh ephemeral state on a miss.

--- a/src/tracemill/governance/registry.py
+++ b/src/tracemill/governance/registry.py
@@ -1,4 +1,21 @@
-"""Per-session residency for governance: the single owner of live SessionState."""
+"""Per-session residency for governance: the single owner of live SessionState.
+
+A session has two distinct residency scopes that must never be conflated, because
+the two governance channels have opposite durability and threading constraints:
+
+  * **Durable / observation residency** — owned by the ``SessionMonitor`` single
+    writer. States are rehydrated from the durable store, carry a live DB
+    connection, and their ``persist`` actually writes. Phase-1 mutations here
+    (budget, taint) must survive a restart.
+  * **Ephemeral / gate residency** — owned by the ``Shield`` enforcement gate,
+    which runs at the framework's input edge on arbitrary threads. Gate state is
+    created with ``_db=None`` and never touches SQLite, so it is safe to build
+    cross-thread; it only carries in-process gate context.
+
+Keeping these separate is the fix for the F2 durability gap: when the gate creates
+a session's state first, the writer must not be handed that non-durable
+``_db=None`` state (its persists would silently no-op). See :class:`SessionRegistry`.
+"""
 
 from __future__ import annotations
 
@@ -10,54 +27,84 @@ if TYPE_CHECKING:
 
 
 class SessionRegistry:
-    """Owns per-session residency — the one home for live SessionState.
+    """Owns per-session residency across two scopes: durable and gate-ephemeral.
 
-    Centralizing the residency map here means no two code paths can create
-    divergent state for the same session (the pipeline previously carried two
-    uncoordinated creation paths). Two creation strategies share this single
-    map, and both return an already-resident state when one exists:
+    Centralizing residency here means no two code paths create divergent state for
+    the same session. But the observation (writer) and gate channels have
+    incompatible needs, so each session keeps a state in whichever of two maps
+    matches the caller's channel — the writer never borrows the gate's state and
+    vice versa:
 
-      * ``get_or_create`` rehydrates from the durable store, so the observation
-        channel's crash recovery sees persisted budgets.
-      * ``ensure`` creates thread-safe ephemeral state (never touching SQLite
-        cross-thread), which the gate channel uses for enforcement context.
+      * ``_durable_states`` — the observation channel (single writer:
+        ``SessionMonitor``). ``get_or_create`` rehydrates from the durable store,
+        so entries are always DB-backed and their persists durably write.
+      * ``_gate_states`` — the gate channel (``Shield``). ``ensure`` creates
+        thread-safe ephemeral state (``_db=None``, never touching SQLite
+        cross-thread) for enforcement context.
+
+    Because the two channels hold *separate* ``SessionState`` objects per session,
+    their counters can never be mutated concurrently from different threads, and
+    the writer's ``persist_no_commit`` is guaranteed a live connection (the F2
+    durability invariant).
     """
 
     def __init__(self, store: "SystemStore") -> None:
         self._store = store
-        self._states: dict[str, "SessionState"] = {}
+        # Observation channel: DB-backed states (single writer: SessionMonitor).
+        self._durable_states: dict[str, "SessionState"] = {}
+        # Gate channel: ephemeral _db=None states (Shield enforcement).
+        self._gate_states: dict[str, "SessionState"] = {}
 
-    def __contains__(self, session_id: str) -> bool:
-        return session_id in self._states
-
-    def get(self, session_id: str) -> "SessionState | None":
-        """Return the resident state for a session, or None if not resident."""
-        return self._states.get(session_id)
+    # ── Durable / observation residency (the single writer) ──
 
     def get_or_create(self, session_id: str) -> "SessionState":
-        """Return the resident state, rehydrating from the store on a miss."""
+        """Return the durable, DB-backed state, rehydrating from the store on a miss.
+
+        Always yields a state with a live connection, so the writer's
+        ``persist_no_commit`` / ``persist`` durably write. Observation channel only.
+        """
         from tracemill.governance.state import SessionState
 
-        if session_id not in self._states:
-            self._states[session_id] = SessionState.load_from_db(session_id, self._store.connection)
-        return self._states[session_id]
+        if session_id not in self._durable_states:
+            self._durable_states[session_id] = SessionState.load_from_db(
+                session_id, self._store.connection
+            )
+        return self._durable_states[session_id]
+
+    def evict(self, session_id: str) -> "SessionState | None":
+        """Remove and return the durable (observation) state for a session, if any."""
+        return self._durable_states.pop(session_id, None)
+
+    # ── Ephemeral / gate residency (enforcement, thread-safe) ──
 
     def ensure(self, session_id: str) -> "SessionState":
-        """Return the resident state, creating fresh ephemeral state on a miss.
+        """Return the gate's ephemeral state, creating it (``_db=None``) on a miss.
 
         Never rehydrates from SQLite, so it is safe to call from any thread.
         Uses ``setdefault`` so concurrent callers converge on one instance.
         """
         from tracemill.governance.state import SessionState
 
-        if session_id not in self._states:
-            self._states.setdefault(session_id, SessionState(session_id=session_id))
-        return self._states[session_id]
+        if session_id not in self._gate_states:
+            self._gate_states.setdefault(session_id, SessionState(session_id=session_id))
+        return self._gate_states[session_id]
 
-    def replace(self, session_id: str, state: "SessionState") -> None:
-        """Install a state instance for a session (used after a forced reload)."""
-        self._states[session_id] = state
+    def get_gate(self, session_id: str) -> "SessionState | None":
+        """Return the gate's resident ephemeral state, or None if not resident."""
+        return self._gate_states.get(session_id)
 
-    def evict(self, session_id: str) -> "SessionState | None":
-        """Remove and return the resident state for a session, if any."""
-        return self._states.pop(session_id, None)
+    def evict_gate(self, session_id: str) -> "SessionState | None":
+        """Remove and return the gate's ephemeral state for a session, if any."""
+        return self._gate_states.pop(session_id, None)
+
+    # ── Read-only preview (Scorer) ──
+
+    def preview_state(self, session_id: str) -> "SessionState | None":
+        """Return a base state for a non-persisted preview, or None if unknown.
+
+        Prefers the durable observation state (so a preview reflects accumulated,
+        persisted budgets), falling back to the gate's ephemeral state. The caller
+        clones this via ``clone_detached`` and never mutates or persists it, so
+        returning either residency is side-effect-free.
+        """
+        return self._durable_states.get(session_id) or self._gate_states.get(session_id)

--- a/src/tracemill/governance/scorer.py
+++ b/src/tracemill/governance/scorer.py
@@ -179,8 +179,9 @@ class Scorer:
         session_id = ctx.event.session_id
 
         # Use cached state if available; otherwise start fresh (thread-safe,
-        # avoids cross-thread sqlite3 access for unknown sessions)
-        state = self._registry.get(session_id)
+        # avoids cross-thread sqlite3 access for unknown sessions). Prefers the
+        # durable observation state so the preview reflects accumulated budgets.
+        state = self._registry.preview_state(session_id)
         if state is None:
             state = SessionState(session_id=session_id)
 

--- a/src/tracemill/governance/shield.py
+++ b/src/tracemill/governance/shield.py
@@ -251,7 +251,7 @@ class Shield:
         """
         from tracemill.sdk.gate_types import GateContext
 
-        state = self._registry.get(session_id)
+        state = self._registry.get_gate(session_id)
         if state is None:
             return GateContext(session_id=session_id, tool_call_count=0, denied_count=0)
 

--- a/src/tracemill/governance/state.py
+++ b/src/tracemill/governance/state.py
@@ -115,14 +115,6 @@ class SessionState:
     def attach_db(self, db: sqlite3.Connection | None) -> None:
         self._db = db
 
-    def is_db_backed(self) -> bool:
-        """True when this state can persist (has a live DB connection).
-
-        The gate channel's ephemeral states (created via ``SessionRegistry.ensure``)
-        are DB-less; the observation writer must never persist through one.
-        """
-        return self._db is not None
-
     def increment_budget(
         self,
         *,
@@ -217,23 +209,6 @@ class SessionState:
         observation (increment_budget), never here."""
         if tool_call_id:
             self._prior_tool_call_ids.append(tool_call_id)  # deque(maxlen=100)
-
-    def adopt_enforcement_log(self, other: "SessionState") -> None:
-        """Carry another state's in-memory Shield decision log into this one.
-
-        The enforcement log (denial count, prior verdicts, allowed tool-call ids)
-        lives only in memory — it is never persisted, so a session reloaded from
-        SQLite starts it empty. When the observation writer promotes the gate
-        channel's ephemeral state to a durable, DB-backed one, this transfers the
-        gate's accumulated decisions onto the durable state so they are not lost.
-        Observation fields are intentionally untouched: those are single-writer
-        and authoritative on the DB-backed instance.
-        """
-        self._denied_count = other._denied_count
-        self._prior_verdicts = deque(other._prior_verdicts, maxlen=other._prior_verdicts.maxlen)
-        self._prior_tool_call_ids = deque(
-            other._prior_tool_call_ids, maxlen=other._prior_tool_call_ids.maxlen
-        )
 
     def check_pressure(self, thresholds: dict | None) -> bool:
         """Check if any threshold is exceeded. Updates pressure flag."""

--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -427,3 +427,57 @@ class TestGateThenObserveDurability:
         # ── And the writer's in-memory durable residency advanced exactly once —
         # not twice from inheriting the gate's already-incremented counter.
         assert pipeline.get_or_create_state(session_id).tool_call_count == 1
+
+    def test_two_gated_and_observed_calls_count_once_per_channel(self, pipeline, store):
+        """Two calls each flow through BOTH channels (gate then observe); the
+        durable observation counter must land on exactly 2 — one per observed
+        call — never 3+ from a shared residency letting the gate's increments
+        bleed into the writer's state.
+
+        This is the empirical double-count the two-map split fixes. With a single
+        shared residency that *promotes* the gate's ephemeral state to DB-backed
+        (the reverted design), the writer inherits the gate's already-incremented
+        counter and then increments again, so two real calls persisted a count of
+        3. A single-call test can't distinguish that regression on its own, so
+        this drives two full gate+observe cycles and asserts each channel counted
+        its own calls exactly once, on its own SessionState object.
+        """
+        session_id = "gate-then-observe-x2"
+
+        def gate_and_observe(command: str) -> None:
+            payload = {
+                "tool_name": "bash",
+                "tool_input": {"command": command},
+                "session_id": session_id,
+            }
+            trace, verdict = pipeline._score_and_gate_preflight(payload)
+            assert verdict.allowed
+            pipeline._enforce_postflight(
+                trace, session_id=trace.session_id, output={"result": "ok"}
+            )
+            event = _make_event(
+                tool_name="bash",
+                arguments={"command": command},
+                kind=EventKind.TOOL_CALL_COMPLETED,
+                session_id=session_id,
+            )
+            pipeline.observe_event(event)
+
+        gate_and_observe("ls")
+        gate_and_observe("pwd")
+
+        # Observation channel: the durably persisted count is exactly 2 (one per
+        # observed call). Under the reverted single-map/promotion design this
+        # over-counted to 3 because the writer inherited the gate's increments.
+        reloaded = SessionState.load_from_db(session_id, store.connection)
+        assert reloaded.tool_call_count == 2
+        durable = pipeline.get_or_create_state(session_id)
+        assert durable.tool_call_count == 2
+
+        # Gate channel counts independently on its OWN ephemeral state — a
+        # distinct object from the writer's durable one (the two-map invariant) —
+        # also landing on 2 without cross-channel bleed.
+        gate_state = pipeline._registry.get_gate(session_id)
+        assert gate_state is not None
+        assert gate_state.tool_call_count == 2
+        assert gate_state is not durable

--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -13,10 +13,8 @@ from tracemill.governance.budget import BudgetTracker
 from tracemill.governance.labeler import GovernanceLabeler
 from tracemill.governance.persistence import SystemStore
 from tracemill.governance.pipeline import GovernancePipeline, SessionMeta
-from tracemill.governance.registry import SessionRegistry
 from tracemill.governance.results import RecommendedAction
 from tracemill.governance.rules import parse_rules
-from tracemill.governance.state import SessionState
 from tracemill.types import EventKind, EventMetadata, SessionEvent
 
 
@@ -371,54 +369,3 @@ class TestScoreDoesNotSuppressObservation:
             f"score:{event.id}",
             event.id,
         }
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Gate-before-observe: the writer must never inherit a DB-less state (durability)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-class TestGateBeforeObserveDurability:
-    """Regression (F2): a gate-first ``ensure`` must not leave the observation
-    writer holding an ephemeral, DB-less state.
-
-    ``SessionRegistry.ensure`` (the gate channel) deliberately creates a
-    thread-safe, ``_db=None`` state so it never touches SQLite cross-thread. In
-    the gate-before-observe model the gate touches a session first, so its
-    ephemeral state lands in the shared residency map. If the observation writer
-    then received that same DB-less instance, every ``persist`` /
-    ``persist_no_commit`` would silently no-op and session state would never reach
-    disk. ``get_or_create`` now promotes such a resident to a durable, DB-backed
-    state, carrying the gate's in-memory enforcement log forward.
-    """
-
-    def test_writer_state_is_db_backed_after_gate_ensure(self, store):
-        registry = SessionRegistry(store)
-        sid = "gate-first-session"
-        gate_state = registry.ensure(sid)
-        assert gate_state.is_db_backed() is False
-        writer_state = registry.get_or_create(sid)
-        assert writer_state.is_db_backed() is True
-
-    def test_writer_persistence_survives_gate_first_creation(self, store):
-        # The teeth of F2: with the pre-fix registry the writer inherits the gate's
-        # DB-less state, persist() no-ops, and the reload sees nothing.
-        registry = SessionRegistry(store)
-        sid = "gate-first-durable"
-        registry.ensure(sid)  # gate channel creates the ephemeral state first
-        writer_state = registry.get_or_create(sid)
-        writer_state.increment_budget(effect="write")
-        writer_state.persist()
-        reloaded = SessionState.load_from_db(sid, store.connection)
-        assert reloaded.tool_call_count == 1
-
-    def test_promotion_preserves_enforcement_log(self, store):
-        registry = SessionRegistry(store)
-        sid = "gate-first-log"
-        gate_state = registry.ensure(sid)
-        gate_state.record_denial("deny:policy")
-        gate_state.record_allow("tool-call-42")
-        writer_state = registry.get_or_create(sid)
-        assert writer_state.denied_count == 1
-        assert "tool-call-42" in writer_state.prior_tool_call_ids()
-        assert writer_state.prior_verdicts() == ("deny:policy",)

--- a/tests/unit/test_bridge.py
+++ b/tests/unit/test_bridge.py
@@ -15,6 +15,7 @@ from tracemill.governance.persistence import SystemStore
 from tracemill.governance.pipeline import GovernancePipeline, SessionMeta
 from tracemill.governance.results import RecommendedAction
 from tracemill.governance.rules import parse_rules
+from tracemill.governance.state import SessionState
 from tracemill.types import EventKind, EventMetadata, SessionEvent
 
 
@@ -369,3 +370,60 @@ class TestScoreDoesNotSuppressObservation:
             f"score:{event.id}",
             event.id,
         }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Gate-before-observe durability (F2): the writer must persist even when the
+# Shield created the session's ephemeral (_db=None) gate state first.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGateThenObserveDurability:
+    """Regression for F2: the observation writer must durably persist even when
+    the Shield gated the same session first.
+
+    The Shield's gate channel creates ephemeral ``SessionState(_db=None)`` for a
+    session — deliberately, so enforcement never does cross-thread sqlite. Before
+    the fix the ``SessionRegistry`` shared one residency map, so the
+    ``SessionMonitor``'s ``get_or_create`` was handed that same ``_db=None``
+    state; its ``persist_no_commit`` then silently no-op'd (it early-returns when
+    ``_db is None``) and the observed Phase-1 mutation never reached the DB. The
+    registry now keeps the gate (ephemeral) and observation (DB-backed)
+    residencies separate, so the writer always operates on a persistable state.
+    """
+
+    def test_gate_then_observe_persists_durably(self, pipeline, store):
+        session_id = "gate-then-observe"
+
+        # ── Gate first (Shield path): creates the ephemeral _db=None gate state,
+        # then advances the gate-channel counter at postflight.
+        payload = {
+            "tool_name": "bash",
+            "tool_input": {"command": "ls"},
+            "session_id": session_id,
+        }
+        trace, verdict = pipeline._score_and_gate_preflight(payload)
+        assert verdict.allowed
+        # Guard the assumption that both channels key on the same session id.
+        assert trace.session_id == session_id
+        pipeline._enforce_postflight(trace, session_id=trace.session_id, output={"result": "ok"})
+
+        # ── Observe the same session (SessionMonitor path — the single writer).
+        event = _make_event(
+            tool_name="bash",
+            arguments={"command": "ls"},
+            kind=EventKind.TOOL_CALL_COMPLETED,
+            session_id=session_id,
+        )
+        pipeline.observe_event(event)
+
+        # ── The observation must be DURABLE: a fresh read straight from the DB
+        # must reflect the advanced counter. Without the fix the writer mutated
+        # the gate's _db=None state, persist_no_commit no-op'd, no session_state
+        # row was written, and this reload returns 0.
+        reloaded = SessionState.load_from_db(session_id, store.connection)
+        assert reloaded.tool_call_count == 1
+
+        # ── And the writer's in-memory durable residency advanced exactly once —
+        # not twice from inheriting the gate's already-incremented counter.
+        assert pipeline.get_or_create_state(session_id).tool_call_count == 1


### PR DESCRIPTION
## What & why

Replaces the PR #57 durability fix, which was proven to **double-count tool calls**, with the more fundamentally correct **two-map residency** design (adopts PR #56's commit).

### The bug in #57
#57 fixed the gate-before-observe durability gap by sharing **one** `SessionRegistry` residency map and *promoting* a gate-created ephemeral (`_db=None`) state to DB-backed on the writer path. But promotion makes the **gate channel** and the **observation channel** share a single `SessionState`, and `tool_call_count` is advanced by *both* channels:

- gate: `shield._observe_completed_call` → `registry.ensure`
- observe: `monitor` Phase-1 → `budget.increment` → `registry.get_or_create`

So a call that is both gated *and* observed increments the same counter twice. Empirically (2 gated+observed calls on one session): **#57 persisted `tool_call_count = 3`** for 2 real calls.

### The fix (two maps)
`SessionRegistry` now keeps **two separate residency maps**:

- `_durable_states` — observation writer, always DB-backed (`get_or_create` / `evict`)
- `_gate_states` — Shield gate, ephemeral `_db=None`, thread-safe (`ensure` / `get_gate` / `evict_gate`)
- `preview_state` — Scorer read-only (durable-or-gate)

Writer and gate hold **separate** `SessionState` objects per session, so each channel is its own single-writer counting its own calls once. No promotion, no enforcement-log transfer, no dedup — this is the correct reading of the Shield's own docstring: *"the single place the counter advances **in the gate channel**"* — two channels, each single-writer in its channel.

Same 2-call scenario now persists the correct **`tool_call_count = 2`**.

Also rewired by this change: `shield._build_gate_context` → `get_gate`; `scorer.preflight_event` → `preview_state`; `monitor.process_lifecycle` evicts both residencies; SPEC.md updated. The `is_db_backed()` / `adopt_enforcement_log()` helpers #57 added to `state.py` are removed (no longer needed — no dead code).

### How it landed
`git revert` of #57 (clean single-parent squash) then `git cherry-pick` of #56's commit (SPEC.md auto-merged with #53's docs).

## Tests
- `TestGateThenObserveDurability::test_gate_then_observe_persists_durably` (from #56) — 1-call durability: durable reload == 1, resident == 1 (fails under #57, which gives 2).
- **Added** `test_two_gated_and_observed_calls_count_once_per_channel` — the true double-count guard: 2 calls ⇒ durable persisted == 2 (not 3), gate residency == 2 on a **distinct** object from the durable one (the two-map invariant).

Full suite **1887 passed / 4 skipped**; ruff check + format clean.

Closes the F2 durability gap. Supersedes #57 and #56.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>