### PR TITLE
Wire IntegrityVerifier.record_write into the governance flow (#14)

### DIFF
--- a/src/tracemill/cli/factory.py
+++ b/src/tracemill/cli/factory.py
@@ -34,9 +34,10 @@ def create_default_pipeline(
     rules = parse_rules(rules_path)
 
     engine = get_default_engine()
-    # Content-integrity verification is live when a project_root (the repo key) is
-    # configured; otherwise degrade gracefully to no verifier (no-op).
-    integrity_verifier = IntegrityVerifier(store, project_root) if project_root else None
+    # Content integrity is live by default on this primary CLI/Score path. The repo
+    # key mirrors drift.py's ``project_root or "unknown"`` idiom so runtime contexts
+    # and the constructed verifier agree on the namespace.
+    integrity_verifier = IntegrityVerifier(store, project_root or "unknown")
     labeler = GovernanceLabeler(integrity_verifier=integrity_verifier)
     tracker = BudgetTracker()
 

--- a/src/tracemill/cli/factory.py
+++ b/src/tracemill/cli/factory.py
@@ -23,6 +23,7 @@ def create_default_pipeline(
     """
     from tracemill.classify.config import get_default_engine
     from tracemill.governance.budget import BudgetTracker
+    from tracemill.governance.integrity import IntegrityVerifier
     from tracemill.governance.labeler import GovernanceLabeler
     from tracemill.governance.rules import parse_rules
 
@@ -33,7 +34,10 @@ def create_default_pipeline(
     rules = parse_rules(rules_path)
 
     engine = get_default_engine()
-    labeler = GovernanceLabeler()
+    # Content-integrity verification is live when a project_root (the repo key) is
+    # configured; otherwise degrade gracefully to no verifier (no-op).
+    integrity_verifier = IntegrityVerifier(store, project_root) if project_root else None
+    labeler = GovernanceLabeler(integrity_verifier=integrity_verifier)
     tracker = BudgetTracker()
 
     return GovernancePipeline(

--- a/src/tracemill/config/defaults.py
+++ b/src/tracemill/config/defaults.py
@@ -46,6 +46,7 @@ score:
 # ─── Governance ─────────────────────────────────────────────────────────────
 governance:
   pii_scanning: true
+  integrity_verification: true
   # budget:
   #   max_tool_calls: 200
   #   max_by_effect:

--- a/src/tracemill/config/models.py
+++ b/src/tracemill/config/models.py
@@ -244,6 +244,7 @@ class GovernanceConfig(StrictModel):
           db_path: ./tracemill.db
           project_root: .
           pii_scanning: true
+          integrity_verification: true
           budget:
             max_tool_calls: 200
             max_by_effect:
@@ -254,6 +255,7 @@ class GovernanceConfig(StrictModel):
             db_path="./tracemill.db",
             project_root=".",
             pii_scanning=True,
+            integrity_verification=True,
             budget=BudgetConfig(max_tool_calls=200, max_by_effect={"destructive": 10}),
         )
     """
@@ -262,6 +264,7 @@ class GovernanceConfig(StrictModel):
     project_root: str | None = None
     rules_path: str | None = None  # custom rules YAML override
     pii_scanning: bool = True
+    integrity_verification: bool = True  # content-hash tamper detection (baseline + drift)
     budget: BudgetConfig = Field(default_factory=BudgetConfig)
     tool_preflight_gate: str | None = None  # dotted import path (e.g. "myapp.policies.my_policy")
 

--- a/src/tracemill/governance/assessor.py
+++ b/src/tracemill/governance/assessor.py
@@ -39,12 +39,14 @@ class Assessment:
 
     ``meta`` is the caller-facing verdict surface (classification + risk +
     recommendation + evidence). ``mcp_deferred_writes`` carries the MCP fingerprint
-    write prescriptions emitted during labeling, which the writer persists *after*
-    finalization commits — the assessor itself never writes them.
+    write prescriptions emitted during labeling, and ``integrity_deferred_writes`` the
+    content-hash baseline prescriptions, which the writer persists *after* finalization
+    commits — the assessor itself never writes them.
     """
 
     meta: SessionMeta
     mcp_deferred_writes: tuple = field(default_factory=tuple)
+    integrity_deferred_writes: tuple = field(default_factory=tuple)
 
 
 class Assessor(Protocol):
@@ -93,7 +95,11 @@ class DefaultAssessor:
             mcp_alerts=gov_result.mcp_alerts,
             evidence=evidence,
         )
-        return Assessment(meta=meta, mcp_deferred_writes=gov_result.mcp_deferred_writes)
+        return Assessment(
+            meta=meta,
+            mcp_deferred_writes=gov_result.mcp_deferred_writes,
+            integrity_deferred_writes=gov_result.integrity_deferred_writes,
+        )
 
     def _with_snapshot(
         self, ctx: "EnrichmentContext", snapshot: "SessionStateSnapshot"

--- a/src/tracemill/governance/integrity.py
+++ b/src/tracemill/governance/integrity.py
@@ -22,6 +22,22 @@ class IntegrityCheck:
     last_known_writer: str | None
 
 
+@dataclass(frozen=True)
+class IntegrityWrite:
+    """A self-contained prescription to (re)baseline one file's content hash.
+
+    Emitted during side-effect-free labeling and committed later by the monitor's
+    finalization transaction (mirroring ``mcp_deferred_writes``). Carries everything
+    needed to persist the row so the writer never needs the verifier's ``repo``.
+    """
+
+    repo: str
+    path: str
+    sha256: str
+    session_id: str
+    timestamp: str
+
+
 class IntegrityVerifier:
     """Verifies content integrity by comparing SHA-256 hashes against stored baselines."""
 
@@ -75,6 +91,31 @@ class IntegrityVerifier:
         """Record a new content hash after a successful write."""
         sha = hashlib.sha256(content).hexdigest()
         self._store.store_content_hash(self._repo, path, sha, session_id, timestamp)
+
+    def pending_writes(self, ctx: "EnrichmentContext") -> list[IntegrityWrite]:
+        """Prescriptions to (re)baseline this event's writes. Pure — no store mutation.
+
+        Gated by the same :meth:`should_check` as :meth:`check_event`, so only
+        mutating/destructive or ``filesystem_write`` events produce baselines. The
+        actual persistence is deferred to the monitor's finalization commit, which runs
+        *after* :meth:`check_event` has already compared against the prior baseline — so
+        drift (including cross-session drift) is detected before the baseline is updated.
+        """
+        if not self.should_check(ctx.base_classification):
+            return []
+        ts = ctx.event.timestamp
+        timestamp = ts.isoformat() if hasattr(ts, "isoformat") else str(ts)
+        session_id = ctx.event.session_id
+        return [
+            IntegrityWrite(
+                repo=self._repo,
+                path=path,
+                sha256=hashlib.sha256(content).hexdigest(),
+                session_id=session_id,
+                timestamp=timestamp,
+            )
+            for path, content in self._extract_file_writes(ctx)
+        ]
 
     def _extract_file_writes(self, ctx: "EnrichmentContext") -> list[tuple[str, bytes]]:
         """Extract file paths and content from a write event."""

--- a/src/tracemill/governance/labeler.py
+++ b/src/tracemill/governance/labeler.py
@@ -31,6 +31,7 @@ class GovernanceResult:
     drift_result: "DriftResult | None" = None
     mcp_alerts: tuple = ()  # tuple[MCPIntegrityAlert, ...]
     mcp_deferred_writes: tuple = ()  # tuple[MCPDeferredWrite, ...] — committed by pipeline after finalization
+    integrity_deferred_writes: tuple = ()  # tuple[IntegrityWrite, ...] — committed by pipeline after finalization
 
 
 class GovernanceLabeler:
@@ -64,9 +65,13 @@ class GovernanceLabeler:
         if self._pii:
             self._pii.scan(ctx, cap, struct)
 
-        # Content integrity
+        # Content integrity — CHECK against the existing baseline (read-only), then
+        # collect deferred (re)baseline prescriptions. The check runs first so drift
+        # from a prior baseline is flagged before the monitor commits the new baseline.
+        integrity_deferred_writes: tuple = ()
         if self._integrity:
             self._integrity.check_event(ctx, cap)
+            integrity_deferred_writes = tuple(self._integrity.pending_writes(ctx))
 
         # MCP fingerprint drift — scan returns typed MCPScanResult
         mcp_alerts: tuple = ()
@@ -140,6 +145,7 @@ class GovernanceLabeler:
             drift_result=drift_result,
             mcp_alerts=mcp_alerts,
             mcp_deferred_writes=mcp_deferred_writes,
+            integrity_deferred_writes=integrity_deferred_writes,
         )
 
     def _ifc_label_only(self, ctx: "EnrichmentContext", src_labels: set[str]) -> None:

--- a/src/tracemill/governance/monitor.py
+++ b/src/tracemill/governance/monitor.py
@@ -349,6 +349,8 @@ class SessionMonitor:
             )
             if assessment.mcp_deferred_writes:
                 self._commit_mcp_writes_no_commit(assessment.mcp_deferred_writes)
+            if assessment.integrity_deferred_writes:
+                self._commit_integrity_writes_no_commit(assessment.integrity_deferred_writes)
             self._store.commit()
             self._store.cache_processed(event.source_event_key, meta_json)
         except (
@@ -419,6 +421,22 @@ class SessionMonitor:
                     "UPDATE mcp_fingerprints SET last_seen = ? WHERE server = ? AND tool_name = ?",
                     (write.payload, write.server, write.tool_name),
                 )
+
+    def _commit_integrity_writes_no_commit(self, writes: tuple) -> None:
+        """Persist deferred content-hash baselines without committing — caller owns transaction.
+
+        Runs after :meth:`Assessor.assess` has already checked each write against the
+        prior baseline, so this only (re)baselines to what the agent wrote, stamped with
+        the writing session + timestamp. Committed atomically with the idempotency record.
+        """
+        for write in writes:
+            self._store.store_content_hash_no_commit(
+                write.repo,
+                write.path,
+                write.sha256,
+                write.session_id,
+                write.timestamp,
+            )
 
     def _write_session_summary(self, session_id: str, snapshot: "SessionStateSnapshot") -> None:
         """Write session summary to session_summaries table (idempotent — won't overwrite existing)."""

--- a/src/tracemill/governance/persistence.py
+++ b/src/tracemill/governance/persistence.py
@@ -250,15 +250,26 @@ class SystemStore:
             ).fetchone()
         return row[0] if row else None
 
+    def store_content_hash_no_commit(
+        self, repo: str, file_path: str, sha256: str, session_id: str, updated_at: str
+    ) -> None:
+        """Upsert a content-hash baseline within the caller's transaction (no commit).
+
+        Participates in the caller's open transaction, matching
+        :meth:`execute_in_transaction`. Used by the monitor's finalization commit so a
+        content-integrity baseline update lands atomically with the idempotency record.
+        """
+        self._conn.execute(
+            """INSERT OR REPLACE INTO content_hashes (repo, file_path, sha256, updated_at, updated_by_session)
+               VALUES (?, ?, ?, ?, ?)""",
+            (repo, file_path, sha256, updated_at, session_id),
+        )
+
     def store_content_hash(
         self, repo: str, file_path: str, sha256: str, session_id: str, updated_at: str
     ) -> None:
         with self._lock:
-            self._conn.execute(
-                """INSERT OR REPLACE INTO content_hashes (repo, file_path, sha256, updated_at, updated_by_session)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (repo, file_path, sha256, updated_at, session_id),
-            )
+            self.store_content_hash_no_commit(repo, file_path, sha256, session_id, updated_at)
             self._conn.commit()
 
     def get_drift_baseline(self, agent_model: str, repo: str) -> dict | None:

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -133,6 +133,7 @@ class GovernancePipeline:
         from tracemill.classify.config import get_default_engine
         from tracemill.config.models import GovernanceConfig
         from tracemill.governance.budget import BudgetThresholds, BudgetTracker
+        from tracemill.governance.integrity import IntegrityVerifier
         from tracemill.governance.labeler import GovernanceLabeler
         from tracemill.governance.persistence import SystemStore
         from tracemill.governance.rules import parse_rules
@@ -167,9 +168,17 @@ class GovernancePipeline:
 
             pii_scanner = PIIScanner()
 
+        # Content-integrity verification is live when a project_root (the repo key) is
+        # configured; otherwise degrade gracefully to no verifier (no-op).
+        integrity_verifier = (
+            IntegrityVerifier(store, config.project_root) if config.project_root else None
+        )
+
         instance = cls(
             store=store,
-            labeler=GovernanceLabeler(pii_scanner=pii_scanner),
+            labeler=GovernanceLabeler(
+                pii_scanner=pii_scanner, integrity_verifier=integrity_verifier
+            ),
             budget_tracker=BudgetTracker(thresholds=thresholds),
             rules=rules,
             engine=engine,

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -168,11 +168,12 @@ class GovernancePipeline:
 
             pii_scanner = PIIScanner()
 
-        # Content-integrity verification is live when a project_root (the repo key) is
-        # configured; otherwise degrade gracefully to no verifier (no-op).
-        integrity_verifier = (
-            IntegrityVerifier(store, config.project_root) if config.project_root else None
-        )
+        # Content integrity is live by default (opt out via integrity_verification).
+        # The repo key mirrors drift.py's ``project_root or "unknown"`` idiom so runtime
+        # contexts and the constructed verifier agree on the namespace.
+        integrity_verifier = None
+        if config.integrity_verification:
+            integrity_verifier = IntegrityVerifier(store, config.project_root or "unknown")
 
         instance = cls(
             store=store,

--- a/tests/unit/test_governance_integrity.py
+++ b/tests/unit/test_governance_integrity.py
@@ -21,6 +21,7 @@ import pytest
 from tracemill.classify.config import get_default_engine
 from tracemill.classify.core import Classification
 from tracemill.cli.factory import create_default_pipeline
+from tracemill.config import GovernanceConfig
 from tracemill.governance.budget import BudgetTracker
 from tracemill.governance.integrity import IntegrityVerifier, IntegrityWrite
 from tracemill.governance.labeler import GovernanceLabeler
@@ -246,19 +247,20 @@ class TestEndToEnd:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Default composition root: integrity is live with NO manual verifier injection
+# Default composition roots: integrity is live by default with NO manual injection
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 class TestDefaultInjection:
-    """Proves the orphan is actually closed: a pipeline built by the default factory
-    (no manual verifier) records the baseline on a first write and flags a mismatched
-    re-write with the +10 integrity bonus. Gated on a configured project_root (the repo
-    key); with no project_root the verifier degrades to a no-op (covered implicitly by
-    the existing zero-config suite, which stays green)."""
+    """Proves the orphan is actually closed in production: pipelines built the standard
+    way — with NO hand-injected verifier — record the baseline on a first write and flag
+    a mismatched re-write with the +10 integrity bonus. Integrity is on by default at
+    both composition roots (`create_default_pipeline` and `GovernancePipeline.create`/
+    `from_config`) and opt-out via `integrity_verification: false`. The repo key falls
+    back to ``"unknown"`` (matching drift.py) when no project_root is configured."""
 
-    def test_default_pipeline_wires_integrity_live(self, store):
-        # No manual IntegrityVerifier — the factory wires it from project_root.
+    def test_default_factory_wires_integrity_live(self, store):
+        # cli/factory.py path (CLI + Score API). No manual IntegrityVerifier.
         pipeline = create_default_pipeline(store, project_root=REPO)
 
         # First-seen write: nothing to compare against → no flag, no bonus …
@@ -267,7 +269,7 @@ class TestDefaultInjection:
         )
         assert "integrity_unverified" not in meta0.classification.capability
         assert "integrity_unverified" not in meta0.risk_assessment.factors
-        # … but the baseline is recorded live (record_write is actually reached).
+        # … but the baseline is recorded live (record path is actually reached).
         assert store.get_content_hash(REPO, "src/a.py") == _sha(b"v1")
 
         # Mismatched re-write on the tracked path → integrity_unverified surfaces,
@@ -281,10 +283,32 @@ class TestDefaultInjection:
         # Drift re-baselines (deferred) to what was actually written.
         assert store.get_content_hash(REPO, "src/a.py") == _sha(b"v2")
 
-    def test_default_pipeline_without_project_root_is_noop(self, store):
-        """No project_root configured → verifier absent → no baseline, no flag, no crash."""
-        pipeline = create_default_pipeline(store)  # project_root defaults to None
+    def test_zero_config_pipeline_wires_integrity_live(self):
+        # GovernancePipeline.create() with default config (the from_config root, which
+        # delegates here). No project_root → repo key "unknown"; still live by default.
+        pipeline = GovernancePipeline.create()
 
-        meta = pipeline.process_event(_ctx(_write_event("src/a.py", "v1", event_id="e0", key="k0")))
-        assert "integrity_unverified" not in meta.classification.capability
-        assert store.get_content_hash(REPO, "src/a.py") is None
+        meta0 = pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v1", session_id="A", event_id="e0", key="k0"))
+        )
+        assert "integrity_unverified" not in meta0.classification.capability
+
+        meta_drift = pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v2", session_id="B", event_id="e1", key="k1"))
+        )
+        assert "integrity_unverified" in meta_drift.classification.capability
+        assert "integrity_unverified" in meta_drift.risk_assessment.factors
+        assert meta_drift.risk_assessment.score - meta0.risk_assessment.score == 10
+
+    def test_integrity_verification_disabled_is_noop(self):
+        # Opt-out: integrity_verification=False → no verifier → no labels even on drift.
+        pipeline = GovernancePipeline.create(GovernanceConfig(integrity_verification=False))
+
+        pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v1", session_id="A", event_id="e0", key="k0"))
+        )
+        meta_drift = pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v2", session_id="B", event_id="e1", key="k1"))
+        )
+        assert "integrity_unverified" not in meta_drift.classification.capability
+        assert "integrity_unverified" not in meta_drift.risk_assessment.factors

--- a/tests/unit/test_governance_integrity.py
+++ b/tests/unit/test_governance_integrity.py
@@ -20,6 +20,7 @@ import pytest
 
 from tracemill.classify.config import get_default_engine
 from tracemill.classify.core import Classification
+from tracemill.cli.factory import create_default_pipeline
 from tracemill.governance.budget import BudgetTracker
 from tracemill.governance.integrity import IntegrityVerifier, IntegrityWrite
 from tracemill.governance.labeler import GovernanceLabeler
@@ -241,4 +242,49 @@ class TestEndToEnd:
             _ctx(_write_event("src/a.py", "speculative", event_id="e1", key="k1"))
         )
 
+        assert store.get_content_hash(REPO, "src/a.py") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Default composition root: integrity is live with NO manual verifier injection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDefaultInjection:
+    """Proves the orphan is actually closed: a pipeline built by the default factory
+    (no manual verifier) records the baseline on a first write and flags a mismatched
+    re-write with the +10 integrity bonus. Gated on a configured project_root (the repo
+    key); with no project_root the verifier degrades to a no-op (covered implicitly by
+    the existing zero-config suite, which stays green)."""
+
+    def test_default_pipeline_wires_integrity_live(self, store):
+        # No manual IntegrityVerifier — the factory wires it from project_root.
+        pipeline = create_default_pipeline(store, project_root=REPO)
+
+        # First-seen write: nothing to compare against → no flag, no bonus …
+        meta0 = pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v1", session_id="A", event_id="e0", key="k0"))
+        )
+        assert "integrity_unverified" not in meta0.classification.capability
+        assert "integrity_unverified" not in meta0.risk_assessment.factors
+        # … but the baseline is recorded live (record_write is actually reached).
+        assert store.get_content_hash(REPO, "src/a.py") == _sha(b"v1")
+
+        # Mismatched re-write on the tracked path → integrity_unverified surfaces,
+        # raising the final risk by exactly the +10 integrity bonus.
+        meta_drift = pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v2", session_id="B", event_id="e1", key="k1"))
+        )
+        assert "integrity_unverified" in meta_drift.classification.capability
+        assert "integrity_unverified" in meta_drift.risk_assessment.factors
+        assert meta_drift.risk_assessment.score - meta0.risk_assessment.score == 10
+        # Drift re-baselines (deferred) to what was actually written.
+        assert store.get_content_hash(REPO, "src/a.py") == _sha(b"v2")
+
+    def test_default_pipeline_without_project_root_is_noop(self, store):
+        """No project_root configured → verifier absent → no baseline, no flag, no crash."""
+        pipeline = create_default_pipeline(store)  # project_root defaults to None
+
+        meta = pipeline.process_event(_ctx(_write_event("src/a.py", "v1", event_id="e0", key="k0")))
+        assert "integrity_unverified" not in meta.classification.capability
         assert store.get_content_hash(REPO, "src/a.py") is None

--- a/tests/unit/test_governance_integrity.py
+++ b/tests/unit/test_governance_integrity.py
@@ -1,0 +1,244 @@
+"""Tests for content-integrity verification wiring (issue #14).
+
+`IntegrityVerifier.record_write` was orphaned: nothing populated the `content_hashes`
+baseline, so `check()` always returned None and `integrity_unverified` (and its
+`integrity_bonus`) were unreachable. These tests pin the wired behaviour:
+
+* the CHECK runs during side-effect-free labeling (against the *prior* baseline), and
+* the RECORD is a deferred write committed by the monitor's finalization transaction,
+
+which yields check-before-record ordering (no baseline-laundering), cross-session
+writer attribution, and — critically — a preflight simulation that never records.
+"""
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tracemill.classify.config import get_default_engine
+from tracemill.classify.core import Classification
+from tracemill.governance.budget import BudgetTracker
+from tracemill.governance.integrity import IntegrityVerifier, IntegrityWrite
+from tracemill.governance.labeler import GovernanceLabeler
+from tracemill.governance.persistence import SystemStore
+from tracemill.governance.pipeline import GovernancePipeline
+from tracemill.governance.rules import parse_rules
+from tracemill.governance.types import EnrichmentContext, ToolCallEvent
+
+REPO = "acme/widgets"
+_TS = "2024-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = SystemStore(tmp_path / "integrity.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def rules():
+    rules_path = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "tracemill"
+        / "classify"
+        / "data"
+        / "recommendation_rules.yaml"
+    )
+    return parse_rules(rules_path)
+
+
+def _sha(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _write_event(path, content, session_id="sess1", event_id="evt-1", key="key-1"):
+    """A ToolCallEvent that writes ``content`` to ``path`` (path+content arg shape)."""
+    return ToolCallEvent(
+        event_id=event_id,
+        session_id=session_id,
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        source_event_key=key,
+        span_id="span-1",
+        tool_name="write_file",
+        server_namespace=None,
+        tool_args_json=json.dumps({"path": path, "content": content}),
+        source_event_id=None,
+    )
+
+
+def _ctx(event, effect="mutating"):
+    classification = Classification(mechanism="filesystem.write", effect=effect)
+    return EnrichmentContext(
+        event=event,
+        base_classification=classification,
+        command_analysis=None,
+        session_state=None,
+        mcp_profiles=None,
+        project_root=None,
+        engine="coding",
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# IntegrityVerifier: check-before-record, matching, mismatch, attribution
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVerifier:
+    def test_first_seen_write_not_flagged_and_yields_prescription(self, store):
+        verifier = IntegrityVerifier(store, REPO)
+        ctx = _ctx(_write_event("src/a.py", "hello"))
+
+        cap: set[str] = set()
+        verifier.check_event(ctx, cap)
+        assert "integrity_unverified" not in cap  # untracked path — nothing to compare
+
+        writes = verifier.pending_writes(ctx)
+        assert writes == [
+            IntegrityWrite(
+                repo=REPO,
+                path="src/a.py",
+                sha256=_sha(b"hello"),
+                session_id="sess1",
+                timestamp="2024-01-01T00:00:00+00:00",
+            )
+        ]
+
+    def test_matching_rewrite_is_not_flagged(self, store):
+        verifier = IntegrityVerifier(store, REPO)
+        verifier.record_write("src/a.py", b"hello", "sess1", _TS)
+
+        cap: set[str] = set()
+        verifier.check_event(_ctx(_write_event("src/a.py", "hello")), cap)
+        assert "integrity_unverified" not in cap
+
+        check = verifier.check("src/a.py", b"hello")
+        assert check is not None and check.matched is True
+
+    def test_mismatched_content_is_flagged(self, store):
+        verifier = IntegrityVerifier(store, REPO)
+        verifier.record_write("src/a.py", b"hello", "sess1", _TS)
+
+        cap: set[str] = set()
+        verifier.check_event(_ctx(_write_event("src/a.py", "tampered")), cap)
+        assert "integrity_unverified" in cap
+
+    def test_should_check_gates_pending_writes(self, store):
+        verifier = IntegrityVerifier(store, REPO)
+        # read_only effect and no filesystem_write capability → not integrity-relevant
+        assert (
+            verifier.pending_writes(_ctx(_write_event("src/a.py", "x"), effect="read_only")) == []
+        )
+
+    def test_cross_session_attribution(self, store):
+        """A write by session B on a path baselined by session A is detectable, and
+        `last_known_writer` reflects the *prior* writer until B's record commits."""
+        writer_a = IntegrityVerifier(store, REPO)
+        writer_a.record_write("src/a.py", b"content-A", "session-A", _TS)
+
+        writer_b = IntegrityVerifier(store, REPO)
+        drift = writer_b.check("src/a.py", b"content-B")
+        assert drift is not None
+        assert drift.matched is False
+        assert drift.last_known_writer == "session-A"  # attribution to prior writer
+
+        # After session B's write commits, the baseline is re-attributed to B.
+        writer_b.record_write("src/a.py", b"content-B", "session-B", _TS)
+        row = store.connection.execute(
+            "SELECT updated_by_session FROM content_hashes WHERE repo = ? AND file_path = ?",
+            (REPO, "src/a.py"),
+        ).fetchone()
+        assert row[0] == "session-B"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Labeler: integrity_bonus surfaces on drift
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLabelerBonus:
+    def test_mismatch_surfaces_integrity_bonus(self, store):
+        verifier = IntegrityVerifier(store, REPO)
+        verifier.record_write("src/a.py", b"original", "sess1", _TS)
+        labeler = GovernanceLabeler(integrity_verifier=verifier)
+
+        result = labeler.label(_ctx(_write_event("src/a.py", "tampered")))
+
+        assert "integrity_unverified" in result.classification.capability
+        assert result.risk_modifiers.integrity_bonus == 10
+        # ... and the drift event still re-baselines (deferred) to what was written.
+        assert len(result.integrity_deferred_writes) == 1
+        assert result.integrity_deferred_writes[0].sha256 == _sha(b"tampered")
+
+    def test_matching_write_has_no_bonus(self, store):
+        verifier = IntegrityVerifier(store, REPO)
+        verifier.record_write("src/a.py", b"same", "sess1", _TS)
+        labeler = GovernanceLabeler(integrity_verifier=verifier)
+
+        result = labeler.label(_ctx(_write_event("src/a.py", "same")))
+
+        assert "integrity_unverified" not in result.classification.capability
+        assert result.risk_modifiers.integrity_bonus == 0
+
+    def test_first_seen_has_no_bonus_but_defers_record(self, store):
+        verifier = IntegrityVerifier(store, REPO)
+        labeler = GovernanceLabeler(integrity_verifier=verifier)
+
+        result = labeler.label(_ctx(_write_event("src/new.py", "brand-new")))
+
+        assert "integrity_unverified" not in result.classification.capability
+        assert result.risk_modifiers.integrity_bonus == 0
+        assert len(result.integrity_deferred_writes) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# End-to-end through the mutating pipeline vs. read-only preflight
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _pipeline(store, rules):
+    verifier = IntegrityVerifier(store, REPO)
+    labeler = GovernanceLabeler(integrity_verifier=verifier)
+    return GovernancePipeline(
+        store=store,
+        labeler=labeler,
+        budget_tracker=BudgetTracker(),
+        rules=rules,
+        engine=get_default_engine(),
+    )
+
+
+class TestEndToEnd:
+    def test_process_event_records_baseline_then_detects_drift(self, store, rules):
+        pipeline = _pipeline(store, rules)
+
+        # First write establishes the baseline (proves record_write is wired live).
+        pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v1", session_id="A", event_id="e1", key="k1"))
+        )
+        assert store.get_content_hash(REPO, "src/a.py") == _sha(b"v1")
+
+        # A later, different-session write with different content drifts from the baseline.
+        meta2 = pipeline.process_event(
+            _ctx(_write_event("src/a.py", "v2", session_id="B", event_id="e2", key="k2"))
+        )
+        assert "integrity_unverified" in meta2.classification.capability
+        # ... and the baseline is re-recorded to what was actually written.
+        assert store.get_content_hash(REPO, "src/a.py") == _sha(b"v2")
+
+    def test_preflight_does_not_launder_baseline(self, store, rules):
+        """The read-only preflight/simulation path must never populate the baseline."""
+        pipeline = _pipeline(store, rules)
+
+        pipeline.preflight_event(
+            _ctx(_write_event("src/a.py", "speculative", event_id="e1", key="k1"))
+        )
+
+        assert store.get_content_hash(REPO, "src/a.py") is None


### PR DESCRIPTION
Closes #14

## Problem
`IntegrityVerifier.record_write` (`governance/integrity.py`) is the only method that populates the `content_hashes` baseline (via `store.store_content_hash`), and it had **zero callers**. As a result:
- `content_hashes` was never populated,
- `check()` → `get_content_hash()` always returned `None` ("path not tracked"),
- `check_event()` (wired at `labeler.py`) could therefore **never** add the `integrity_unverified` capability,
- so `integrity_bonus = 10 if 'integrity_unverified' in cap` was unreachable dead code.

Net: content-integrity verification was non-functional.

## Wiring decision
The CHECK stays where it was (side-effect-free labeling); the RECORD becomes a **deferred write**, mirroring the existing `mcp_deferred_writes` pattern:

- `IntegrityVerifier.check_event` runs during `GovernanceLabeler.label()` and compares incoming content against the **existing** baseline **first** (flagging drift before anything is recorded).
- `IntegrityVerifier.pending_writes(ctx)` (pure, gated by the same `should_check`) emits self-contained `IntegrityWrite` prescriptions. These are threaded through `GovernanceResult` → `Assessment` and committed by the monitor's finalization transaction (`_commit_integrity_writes_no_commit`), **atomically with the idempotency record**.

Why this site/ordering:
1. **Check-before-record / no baseline-laundering** — drift (including from a prior *different-session* baseline) is detected before the baseline is re-recorded to what the agent just wrote.
2. **Respects existing contracts** — `label()` and `assess()` are documented side-effect-free; the monitor is the single writer, exactly as for MCP fingerprint writes.
3. **Preflight-safe (decisive)** — `assess()`'s read-only caller (`Scorer`, used by the Shield preflight simulation) takes only `.meta` and discards deferred writes, so speculative/denied writes never launder the baseline.
4. **Attribution** — `updated_by_session` records the writing session; `check()` reads it back as `last_known_writer`, so a later session sees the prior writer.

`persistence.store_content_hash` is refactored to delegate to a new `store_content_hash_no_commit` primitive (single SQL source) so the monitor can persist within its open transaction.

## Default-ON in production (the point of #14)
Building the chain isn't enough — the verifier must actually be **constructed and live on the paths real users hit**, otherwise the orphan just relocates from `integrity.py` into the test suite.

**The repo key is per-event, not a construction constant.** `repo` is a per-event property (it already lives on `EnrichmentContext`), so gating a single verifier on a construction-time `project_root` was the wrong axis — and it left the verifier effectively dead in `watch`/`score`/`replay`, all of which call the factory with **no** `project_root`. Instead:

- `IntegrityVerifier` is constructed with `store` only. `check_event(ctx)` and `pending_writes(ctx)` derive `repo = ctx.project_root or "unknown"` per event (mirroring `drift.py`), thread it into `check()`/`record_write()`/`IntegrityWrite`, and the monitor commits each write under its own repo. One verifier serves every session/repo a pipeline observes.
- **`cli/factory.py:create_default_pipeline`** (the primary CLI/Score path): constructs `IntegrityVerifier(store)` **unconditionally**, and defaults `project_root` to `os.getcwd()` when unset. `watch`/`score`/`replay` run inside the target repo, so cwd is its real identity — without this a persistent `system.db` would bucket every watched repo under `"unknown"` and raise cross-repo false drift. `"unknown"` remains only as a last-resort fallback.
- **`governance/pipeline.py:GovernancePipeline.create`** (also covers `from_config`): constructs `IntegrityVerifier(store)` gated on the config flag; stays `:memory:`/unchanged otherwise.

Mirroring the `pii_scanning` precedent, integrity is **on by default with an opt-out flag**: new `integrity_verification: bool = True` on `GovernanceConfig` (`config/models.py`, beside `pii_scanning`) + `integrity_verification: true` in `config/defaults.py`. Opt out with `integrity_verification: false`. Blast radius on the existing suite is nil: `GovernancePipeline.create()` uses `:memory:` (fresh empty store per test), `should_check` only fires on mutating/destructive/`filesystem_write`, and first-seen writes never flag. Edits are confined to the labeler/verifier construction lines — they do **not** touch `__init__` or the sink-emission path.

## Scope
Integrity path only: `integrity.py`, `labeler.py`, `assessor.py`, `monitor.py`, `persistence.py`, the two composition roots (`cli/factory.py`, `governance/pipeline.py` — labeler construction only), `config/models.py` + `config/defaults.py` (the toggle), and tests. Does **not** touch the enrichment/emission subsystem (`src/tracemill/pipeline.py` EventPipeline, `observer.py`, `emitter.py`, `envelope.py`, `sinks/`).

## Tests
`tests/unit/test_governance_integrity.py`:
- first-seen write: baseline recorded, no `integrity_unverified`, no bonus;
- matching re-write: no flag;
- mismatched content on a tracked path: `integrity_unverified` added and `integrity_bonus == 10`;
- cross-session attribution: `last_known_writer` reflects the prior writer, `updated_by_session` re-attributes after the later write;
- end-to-end via `GovernancePipeline.process_event`: baseline is actually recorded, then drift on a later event is detected;
- no-laundering negative: `preflight_event` does not populate the baseline;
- **default-ON** (`TestDefaultInjection`): a pipeline built the standard way with **no manual verifier** flags a mismatched re-write with final-risk delta `== 10` — proven via `create_default_pipeline(store, project_root=...)`, via zero-config `GovernancePipeline.create()` (exercising the `"unknown"` fallback), and — the test that would have caught the dead-in-prod gap — via **`create_default_pipeline(store)` with no `project_root`** (the way `watch` builds it), which asserts `pipeline._project_root == os.getcwd()` and that drift is flagged live under the cwd repo key; plus a negative that `integrity_verification: false` suppresses labels even on drift.

Full suite: **1901 passed, 4 skipped**. `ruff check` and `ruff format --check` (pinned `ruff==0.15.20`) both clean.