### PR TITLE
Wire observe → enrich → emit subsystem (#22, #23, #26)

### DIFF
--- a/src/tracemill/governance/__init__.py
+++ b/src/tracemill/governance/__init__.py
@@ -46,7 +46,13 @@ from tracemill.governance.mcp_drift import MCPIntegrityScanner, MCPIntegrityAler
 from tracemill.governance.drift import DriftDetector, DriftAssessment
 from tracemill.governance.budget import BudgetThresholds, BudgetTracker
 from tracemill.governance.envelope import ContextGapEvent, EnrichedEvent
-from tracemill.governance.observer import TracemillObserver, AgentContext
+from tracemill.governance.emitter import EnrichedEmitter
+from tracemill.governance.observer import (
+    AgentContext,
+    GovernanceObserver,
+    TracemillObserver,
+    create_observer,
+)
 
 __all__ = [
     # Types
@@ -107,6 +113,9 @@ __all__ = [
     # Envelope & Observer
     "ContextGapEvent",
     "EnrichedEvent",
+    "EnrichedEmitter",
     "TracemillObserver",
+    "GovernanceObserver",
     "AgentContext",
+    "create_observer",
 ]

--- a/src/tracemill/governance/emitter.py
+++ b/src/tracemill/governance/emitter.py
@@ -1,0 +1,234 @@
+"""Async emission actor for governance-enriched events, with backpressure.
+
+The observer enriches **synchronously** (single-writer governance: ``observe_event``
+runs exactly once per event and advances the tool-call budget) and hands an
+already-scored ``(event, meta)`` pair to this actor via :meth:`EnrichedEmitter.submit`.
+The actor owns *only* audit emission and backpressure — it never enriches, so it
+can never re-run ``observe_event`` and double-count the budget.
+
+A bounded :class:`asyncio.Queue` decouples the latency-sensitive enforcement path
+(the observer hook returns ``SessionMeta`` to the host immediately) from
+potentially slow sinks. When the queue is full the **oldest audit record** is
+dropped — never an enforcement decision, which already took effect synchronously
+in the observer — the drop is counted durably via an injected ``record_drop``
+callback, and a **coalesced** :class:`ContextGapEvent` is emitted downstream so
+consumers see an explicit gap marker instead of silent loss.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Callable, Iterable
+
+from tracemill.governance.envelope import ContextGapEvent, EnrichedEvent
+from tracemill.governance.results import SessionMeta
+
+if TYPE_CHECKING:
+    import tracemill.types
+    from tracemill.sinks.base import StorageSink
+
+logger = logging.getLogger(__name__)
+
+# Synthetic gap markers bypass enrichment, so they carry an empty SessionMeta
+# (serializes to ``"_governance": {}``). Reused — SessionMeta is immutable data.
+_EMPTY_META = SessionMeta(classification=None, risk_assessment=None)
+
+DEFAULT_CAPACITY = 1024
+
+
+class _GapAccumulator:
+    """Coalesces consecutive dropped events for one session into one marker.
+
+    The durable drop *counter* is precise (``record_drop`` fires once per dropped
+    event); the emitted *marker* is coalesced so a burst of drops surfaces as a
+    single :class:`ContextGapEvent` spanning ``first``..``last`` sequence.
+    """
+
+    __slots__ = ("session_id", "count", "first_sequence", "last_sequence", "gap_ordinal")
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self.count = 0
+        self.first_sequence: int | None = None
+        self.last_sequence: int | None = None
+        self.gap_ordinal = 0
+
+    def add(self, sequence: int | None, gap_ordinal: int) -> None:
+        self.count += 1
+        self.gap_ordinal = gap_ordinal
+        if sequence is not None:
+            if self.first_sequence is None:
+                self.first_sequence = sequence
+            self.last_sequence = sequence
+
+    def to_event(self) -> ContextGapEvent:
+        key = ContextGapEvent.compute_source_event_key(
+            self.session_id,
+            self.first_sequence,
+            self.last_sequence,
+            self.gap_ordinal,
+        )
+        return ContextGapEvent(
+            id=f"gap-{uuid.uuid4().hex[:12]}",
+            session_id=self.session_id,
+            timestamp=datetime.now(timezone.utc),
+            source_event_key=key,
+            dropped_count=self.count,
+            first_dropped_sequence=self.first_sequence,
+            last_dropped_sequence=self.last_sequence,
+            gap_ordinal=self.gap_ordinal,
+        )
+
+
+class EnrichedEmitter:
+    """Bounded async actor: wraps ``(event, meta)`` in :class:`EnrichedEvent` and
+    fans it out to sinks via ``on_enriched_event``, dropping the oldest audit
+    record under backpressure.
+
+    Runs on a single event loop; :meth:`submit` is synchronous and non-blocking
+    (safe to call from inside the observer's async hooks). Because everything runs
+    single-threaded on the loop, ``submit`` executes atomically with respect to the
+    drain task — no locks are needed.
+    """
+
+    def __init__(
+        self,
+        sinks: "Iterable[StorageSink]",
+        *,
+        capacity: int = DEFAULT_CAPACITY,
+        record_drop: "Callable[[str, int], None] | None" = None,
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be >= 1")
+        self._sinks: list[StorageSink] = list(sinks)
+        self._capacity = capacity
+        self._record_drop = record_drop
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=capacity)
+        # Per-session coalescing of dropped events, flushed just before that
+        # session's next surviving event (and any trailing remainder at aclose).
+        self._pending_gaps: dict[str, _GapAccumulator] = {}
+        self._gap_ordinals: dict[str, int] = {}
+        self._drain_task: asyncio.Task | None = None
+        self._closed = False
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    async def start(self) -> None:
+        """Begin draining. Idempotent; must be called inside the event loop that
+        will own emission."""
+        if self._drain_task is None and not self._closed:
+            self._drain_task = asyncio.create_task(self._drain_loop())
+
+    def submit(self, event: "tracemill.types.SessionEvent", meta: SessionMeta) -> None:
+        """Enqueue an already-enriched ``(event, meta)`` for emission.
+
+        Synchronous and non-blocking. On a full queue, drop the **oldest**
+        surviving audit record (enforcement already happened in the observer, so
+        only audit emission is lost), record it durably, coalesce it into the
+        session's pending gap marker, then enqueue the new item.
+        """
+        item = (event, meta)
+        try:
+            self._queue.put_nowait(item)
+            return
+        except asyncio.QueueFull:
+            pass
+        try:
+            dropped_event, _ = self._queue.get_nowait()
+            # Balance the unfinished-task count for the put() that enqueued the
+            # dropped item, so aclose()'s queue.join() cannot hang.
+            self._queue.task_done()
+        except asyncio.QueueEmpty:
+            dropped_event = None
+        if dropped_event is not None:
+            self._record_dropped(dropped_event)
+        try:
+            self._queue.put_nowait(item)
+        except asyncio.QueueFull:
+            # We just freed a slot, so this should not happen; if it somehow does,
+            # count the *new* item as dropped rather than block the caller.
+            self._record_dropped(event)
+
+    def _record_dropped(self, event: "tracemill.types.SessionEvent") -> None:
+        sid = getattr(event, "session_id", "") or ""
+        sequence = None
+        metadata = getattr(event, "metadata", None)
+        if metadata is not None:
+            sequence = getattr(metadata, "sequence", None)
+        ordinal = self._gap_ordinals.get(sid, 0) + 1
+        self._gap_ordinals[sid] = ordinal
+        acc = self._pending_gaps.get(sid)
+        if acc is None:
+            acc = _GapAccumulator(sid)
+            self._pending_gaps[sid] = acc
+        acc.add(sequence, ordinal)
+        if self._record_drop is not None:
+            try:
+                self._record_drop(sid, 1)
+            except Exception as exc:  # never let a persistence hiccup break submit
+                logger.error("record_drop failed for session %s: %s", sid, exc)
+
+    async def _drain_loop(self) -> None:
+        while True:
+            event, meta = await self._queue.get()
+            try:
+                await self._emit(event, meta)
+            finally:
+                self._queue.task_done()
+
+    async def _emit(self, event: "tracemill.types.SessionEvent", meta: SessionMeta) -> None:
+        # Flush this session's coalesced gap (if any) *before* the surviving event,
+        # so downstream sees the gap marker in order ahead of the next real record.
+        sid = getattr(event, "session_id", "") or ""
+        acc = self._pending_gaps.pop(sid, None)
+        if acc is not None:
+            await self._fanout_enriched(EnrichedEvent(event=acc.to_event(), governance=_EMPTY_META))
+        await self._fanout_enriched(EnrichedEvent(event=event, governance=meta))
+
+    async def _fanout_enriched(self, enriched: EnrichedEvent) -> None:
+        results = await asyncio.gather(
+            *(sink.on_enriched_event(enriched) for sink in self._sinks),
+            return_exceptions=True,
+        )
+        self._log_sink_errors(results, "on_enriched_event")
+
+    def _log_sink_errors(self, results: list, op: str) -> None:
+        for sink, result in zip(self._sinks, results):
+            if isinstance(result, BaseException):
+                logger.error(
+                    "Sink %s failed during %s: %s",
+                    type(sink).__name__,
+                    op,
+                    result,
+                    exc_info=(type(result), result, result.__traceback__),
+                )
+
+    async def aclose(self) -> None:
+        """Drain everything already submitted, flush trailing gap markers, then
+        flush sinks. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._drain_task is not None:
+            # Wait for all queued items to be emitted, then stop the loop.
+            await self._queue.join()
+            self._drain_task.cancel()
+            try:
+                await self._drain_task
+            except asyncio.CancelledError:
+                pass
+            self._drain_task = None
+        # Any coalesced gaps whose surviving event never arrived still deserve a
+        # downstream marker.
+        for sid in list(self._pending_gaps.keys()):
+            acc = self._pending_gaps.pop(sid)
+            await self._fanout_enriched(EnrichedEvent(event=acc.to_event(), governance=_EMPTY_META))
+        results = await asyncio.gather(
+            *(sink.flush() for sink in self._sinks), return_exceptions=True
+        )
+        self._log_sink_errors(results, "flush")

--- a/src/tracemill/governance/envelope.py
+++ b/src/tracemill/governance/envelope.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    import tracemill.types
+
     from tracemill.governance.pipeline import SessionMeta
     from tracemill.governance.types import SessionEvent
 
@@ -50,7 +52,7 @@ class EnrichedEvent:
     Sinks serialize this as {"event": {...}, "_governance": {...}} or equivalent per sink type.
     """
 
-    event: "SessionEvent | ContextGapEvent"
+    event: "tracemill.types.SessionEvent | SessionEvent | ContextGapEvent"
     governance: "SessionMeta"
 
     def to_dict(self) -> dict:
@@ -67,6 +69,25 @@ class EnrichedEvent:
                 "last_dropped_sequence": self.event.last_dropped_sequence,
                 "gap_ordinal": self.event.gap_ordinal,
                 "reason": self.event.reason,
+            }
+        elif hasattr(self.event, "model_dump"):
+            # Live tracemill.types.SessionEvent (pydantic). Mirror JsonlSink's
+            # event body, but lift governance out of metadata into the top-level
+            # ``_governance`` slot so the event stays the raw structural record
+            # and governance is not duplicated inside it.
+            live = self.event
+            metadata_dict = (
+                live.metadata.model_dump(exclude_none=True) if live.metadata is not None else None
+            )
+            if isinstance(metadata_dict, dict):
+                metadata_dict.pop("governance", None)
+            event_dict = {
+                "id": live.id,
+                "kind": live.kind,
+                "session_id": live.session_id,
+                "timestamp": live.timestamp.isoformat(),
+                "payload": live.payload,
+                "metadata": metadata_dict,
             }
         else:
             event_dict = {

--- a/src/tracemill/governance/observer.py
+++ b/src/tracemill/governance/observer.py
@@ -1,11 +1,32 @@
-"""TracemillObserver protocol — integration point for framework adapters."""
+"""TracemillObserver protocol + concrete GovernanceObserver adapter.
+
+``TracemillObserver`` is the integration point host frameworks call around tool
+calls and session lifecycle. ``GovernanceObserver`` is the concrete
+implementation: it runs governance enrichment **synchronously** inside each hook
+(so it can return real ``SessionMeta`` to the host, and so ``observe_event`` — the
+single writer that advances the tool-call budget — runs exactly once per event),
+then hands the enriched record to an :class:`~tracemill.governance.emitter.EnrichedEmitter`
+for asynchronous, backpressure-bounded audit fan-out to sinks.
+"""
 
 from __future__ import annotations
 
+import logging
+from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from tracemill.governance.emitter import DEFAULT_CAPACITY, EnrichedEmitter
 from tracemill.governance.pipeline import SessionMeta
+
+if TYPE_CHECKING:
+    from tracemill.classify.core import Classification
+    from tracemill.governance.pipeline import GovernancePipeline
+    from tracemill.sinks.base import StorageSink
+    from tracemill.types import SessionEvent
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -41,3 +62,215 @@ class TracemillObserver(Protocol):
     async def on_session_end(self, context: AgentContext) -> SessionMeta:
         """Called when an agent session ends."""
         ...
+
+
+class GovernanceObserver:
+    """Concrete :class:`TracemillObserver`: sync single-writer enrichment in the
+    hooks, async audit emission via :class:`EnrichedEmitter`.
+
+    **Session-scoped.** Construct one per agent session (or let
+    :meth:`on_session_start` set the session id). A monotonic per-session sequence
+    is stamped on ``metadata.sequence`` so dropped events can be summarized in a
+    :class:`~tracemill.governance.envelope.ContextGapEvent`.
+
+    **Enrichment cardinality** (the load-bearing invariant):
+
+    * ``on_session_start`` / ``on_session_end`` → ``observe_event`` routes to
+      ``process_lifecycle`` (Phase 1 only; does **not** advance the tool-call
+      budget). Stamped + submitted for audit.
+    * ``on_pre_tool_call`` → ``score_tool_call_event`` — a **read-only** preflight
+      preview (transient state copy; does **not** advance the budget). Its
+      ``SessionMeta`` is **returned to the host** for immediate
+      classification/enforcement but is **not** emitted to sinks (avoids doubling
+      audit output per tool call).
+    * ``on_post_tool_call`` → ``observe_event`` routes to ``process_event`` — the
+      **single writer** that advances the tool-call budget **exactly once**.
+      Stamped + submitted for audit.
+
+    So across a full ``start → pre → post → end`` cycle the budget advances
+    exactly once (at ``post``).
+    """
+
+    def __init__(
+        self,
+        governance: "GovernancePipeline",
+        emitter: EnrichedEmitter,
+        *,
+        session_id: str | None = None,
+        project_root: str | None = None,
+    ) -> None:
+        self._governance = governance
+        self._emitter = emitter
+        self._session_id = session_id
+        self._project_root = project_root
+        self._sequence = 0
+        # Positional pre→post argument correlation: the post hook receives only a
+        # result, but building the completed event's payload (and shell command
+        # analysis) needs the original args. Agents call tools sequentially per
+        # session, so a per-tool FIFO of pending args pairs them up.
+        self._pending_args: dict[str, deque] = defaultdict(deque)
+
+    # ── internals ──────────────────────────────────────────────────────────────
+
+    def _next_sequence(self) -> int:
+        self._sequence += 1
+        return self._sequence
+
+    def _require_session(self) -> str:
+        if not self._session_id:
+            raise RuntimeError(
+                "GovernanceObserver has no session_id; call on_session_start first "
+                "or pass session_id to the constructor."
+            )
+        return self._session_id
+
+    def _classify(
+        self, tool_name: str, arguments: dict, server_namespace: str | None
+    ) -> "Classification | None":
+        """Reuse the blessed self-classifying governance path so the observed
+        event carries a real ``Classification`` rather than the UNKNOWN fallback
+        ``from_session_event`` would otherwise apply."""
+        from tracemill.governance.types import ToolCallEvent
+
+        gov_event = ToolCallEvent.from_dict(
+            {
+                "tool_name": tool_name,
+                "session_id": self._session_id,
+                "tool_input": arguments if isinstance(arguments, dict) else {},
+                "server_namespace": server_namespace,
+            }
+        )
+        try:
+            return self._governance.enrich_event(gov_event).base_classification
+        except Exception as exc:  # classification is best-effort; never break the hook
+            logger.error("governance classification failed for tool %s: %s", tool_name, exc)
+            return None
+
+    def _build_event(
+        self, kind: str, payload: dict, *, classification: "Classification | None" = None
+    ) -> "SessionEvent":
+        from tracemill.types import EventMetadata, SessionEvent
+
+        metadata = EventMetadata(sequence=self._next_sequence(), classification=classification)
+        return SessionEvent(
+            kind=kind,
+            session_id=self._require_session(),
+            timestamp=datetime.now(timezone.utc),
+            payload=payload,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _stamp(event: "SessionEvent", meta: SessionMeta) -> "SessionEvent":
+        """Return a copy of ``event`` carrying ``meta`` under ``metadata.governance``.
+
+        Stamping keeps the backward-compat sink path correct: a sink that only
+        implements ``on_event`` still receives governance (the base
+        ``on_enriched_event`` forwards the stamped event to ``on_event``)."""
+        stamped_meta = event.metadata.model_copy(update={"governance": meta})
+        return event.model_copy(update={"metadata": stamped_meta})
+
+    def _empty_meta(self) -> SessionMeta:
+        return SessionMeta(classification=None, risk_assessment=None)
+
+    # ── TracemillObserver hooks ─────────────────────────────────────────────────
+
+    async def on_session_start(self, context: AgentContext) -> SessionMeta:
+        self._session_id = context.session_id
+        if context.project_root:
+            self._project_root = context.project_root
+        from tracemill.types import EventKind
+
+        event = self._build_event(
+            EventKind.SESSION_STARTED,
+            {"agent_model": context.agent_model, "repo": context.repo},
+        )
+        meta = self._governance.observe_event(event) or self._empty_meta()
+        self._emitter.submit(self._stamp(event, meta), meta)
+        return meta
+
+    async def on_session_end(self, context: AgentContext) -> SessionMeta:
+        if context.session_id:
+            self._session_id = context.session_id
+        if context.project_root:
+            self._project_root = context.project_root
+        from tracemill.types import EventKind
+
+        event = self._build_event(
+            EventKind.SESSION_ENDED,
+            {"agent_model": context.agent_model, "repo": context.repo},
+        )
+        meta = self._governance.observe_event(event) or self._empty_meta()
+        self._emitter.submit(self._stamp(event, meta), meta)
+        return meta
+
+    async def on_pre_tool_call(self, tool_name: str, args: dict) -> SessionMeta:
+        self._require_session()
+        from tracemill.types import EventKind
+
+        server_namespace = args.get("server_namespace") if isinstance(args, dict) else None
+        classification = self._classify(tool_name, args, server_namespace)
+        event = self._build_event(
+            EventKind.TOOL_CALL_STARTED,
+            {"tool_name": tool_name, "arguments": args, "server_namespace": server_namespace},
+            classification=classification,
+        )
+        # Remember args so the paired post hook can rebuild the completed event.
+        self._pending_args[tool_name].append(args)
+        # Read-only preflight preview — advances no budget, returned to host only.
+        return self._governance.score_tool_call_event(event)
+
+    async def on_post_tool_call(self, tool_name: str, result: dict) -> SessionMeta:
+        self._require_session()
+        from tracemill.types import EventKind
+
+        pending = self._pending_args.get(tool_name)
+        args = pending.popleft() if pending else {}
+        server_namespace = args.get("server_namespace") if isinstance(args, dict) else None
+        classification = self._classify(tool_name, args, server_namespace)
+        event = self._build_event(
+            EventKind.TOOL_CALL_COMPLETED,
+            {
+                "tool_name": tool_name,
+                "arguments": args,
+                "server_namespace": server_namespace,
+                "result": result,
+            },
+            classification=classification,
+        )
+        # Single writer: advances the tool-call budget exactly once.
+        meta = self._governance.observe_event(event) or self._empty_meta()
+        self._emitter.submit(self._stamp(event, meta), meta)
+        return meta
+
+
+def create_observer(
+    governance: "GovernancePipeline",
+    sinks: "list[StorageSink]",
+    *,
+    capacity: int = DEFAULT_CAPACITY,
+    session_id: str | None = None,
+    project_root: str | None = None,
+) -> "tuple[GovernanceObserver, EnrichedEmitter]":
+    """Wire a :class:`GovernanceObserver` + :class:`EnrichedEmitter` against a
+    governance pipeline and sinks.
+
+    The emitter's ``record_drop`` is bound to durable session state so a
+    backpressure drop is persisted (``SessionState._dropped_events``) via the
+    existing raw-SQLite write-through — no new migration needed.
+
+    The returned emitter is **not** started; the caller owns its lifecycle and
+    must ``await emitter.start()`` inside the event loop that will drive the
+    observer, and ``await emitter.aclose()`` at shutdown.
+    """
+
+    def _record_drop(sid: str, n: int) -> None:
+        state = governance.get_or_create_state(sid)
+        state.record_drop(n)
+        state.persist()
+
+    emitter = EnrichedEmitter(sinks, capacity=capacity, record_drop=_record_drop)
+    observer = GovernanceObserver(
+        governance, emitter, session_id=session_id, project_root=project_root
+    )
+    return observer, emitter

--- a/src/tracemill/pipeline.py
+++ b/src/tracemill/pipeline.py
@@ -6,10 +6,14 @@ import asyncio
 import logging
 from collections import OrderedDict
 from collections.abc import Awaitable, Iterable
+from typing import TYPE_CHECKING
 
 from tracemill.enricher import Enricher
 from tracemill.sinks.base import StorageSink
 from tracemill.types import EventMetadata, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+
+if TYPE_CHECKING:
+    from tracemill.governance.results import SessionMeta
 
 logger = logging.getLogger(__name__)
 
@@ -613,18 +617,47 @@ class EventPipeline:
         attached to the fully-structured event, then the event fans out to every
         sink. Every event passes through here (the single sink choke point), so
         this is where governance belongs as one stage of the pipeline.
-        """
-        if self._governance is not None:
-            event = self._annotate_governance(event)
-        await self._fanout((sink.on_event(event) for sink in self._sinks), f"event {event.id}")
 
-    def _annotate_governance(self, event: SessionEvent) -> SessionEvent:
+        When governance produces a ``SessionMeta``, the event and its meta are
+        wrapped in an :class:`~tracemill.governance.envelope.EnrichedEvent` and
+        dispatched via ``sink.on_enriched_event`` — the ``{event, _governance}``
+        envelope. This is backward compatible: the event is *also* stamped with
+        ``metadata.governance`` (as before), and the base ``on_enriched_event``
+        default forwards a live event to ``on_event``, so a sink that only
+        implements ``on_event`` sees byte-identical output. When governance is not
+        wired, or produces no meta for this event kind, the bare event goes to
+        ``on_event`` exactly as before.
+        """
+        if self._governance is None:
+            await self._fanout((sink.on_event(event) for sink in self._sinks), f"event {event.id}")
+            return
+
+        stamped, meta = self._annotate_governance(event)
+        if meta is None:
+            await self._fanout(
+                (sink.on_event(stamped) for sink in self._sinks), f"event {stamped.id}"
+            )
+            return
+
+        from tracemill.governance.envelope import EnrichedEvent
+
+        enriched = EnrichedEvent(event=stamped, governance=meta)
+        await self._fanout(
+            (sink.on_enriched_event(enriched) for sink in self._sinks),
+            f"enriched event {stamped.id}",
+        )
+
+    def _annotate_governance(
+        self, event: SessionEvent
+    ) -> tuple[SessionEvent, "SessionMeta | None"]:
         """Score one event through the governance stage and stamp its SessionMeta.
 
-        Returns a copy of the event with ``metadata.governance`` populated. The
-        stage is error-isolated: on any governance failure the original event is
-        emitted unchanged (logged), so the observation stream is never blocked by
-        the governance stage.
+        Returns ``(event, meta)``: a copy of the event with
+        ``metadata.governance`` populated, alongside the ``SessionMeta`` itself
+        (or ``(event, None)`` when the stage produces no governance for this event
+        kind). The stage is error-isolated: on any governance failure the original
+        event is returned unchanged with ``None`` meta (logged), so the
+        observation stream is never blocked by the governance stage.
         """
         try:
             meta = self._governance.observe_event(event)
@@ -635,15 +668,15 @@ class EventPipeline:
                 exc,
                 exc_info=True,
             )
-            return event
+            return event, None
         if meta is None:
-            return event
+            return event, None
         metadata = event.metadata
         if metadata is None:
             metadata = EventMetadata.model_construct(governance=meta)
         else:
             metadata = metadata.model_copy(update={"governance": meta})
-        return event.model_copy(update={"metadata": metadata})
+        return event.model_copy(update={"metadata": metadata}), meta
 
     async def close(self) -> None:
         """Flush then close all sinks. Error-isolated."""

--- a/src/tracemill/sinks/base.py
+++ b/src/tracemill/sinks/base.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from tracemill.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+
+if TYPE_CHECKING:
+    from tracemill.governance.envelope import EnrichedEvent
 
 logger = logging.getLogger(__name__)
 
@@ -15,11 +18,46 @@ class StorageSink(ABC):
     # Sink classes that have already been warned about dropping title updates,
     # so the warning fires once per class per process rather than per title.
     _title_drop_warned: ClassVar[set[str]] = set()
+    # Sink classes already warned about dropping non-event envelope payloads
+    # (gap markers / governance-only records) they do not know how to persist.
+    _enriched_drop_warned: ClassVar[set[str]] = set()
 
     @abstractmethod
     async def on_event(self, event: SessionEvent) -> None:
         """Handle a session event. Required for all sinks."""
         ...
+
+    async def on_enriched_event(self, enriched: "EnrichedEvent") -> None:
+        """Handle a governance-enriched event envelope.
+
+        This is the emission entry point used when governance is wired into the
+        pipeline: the envelope pairs an event with its ``SessionMeta``. The base
+        default keeps every existing sink working unchanged — a live
+        ``SessionEvent`` (which already carries its ``metadata.governance`` stamp)
+        is forwarded to :meth:`on_event`, so a sink that only implements
+        ``on_event`` sees byte-identical output whether or not governance is on.
+
+        Synthetic envelope payloads that are *not* live session events — a
+        :class:`~tracemill.governance.envelope.ContextGapEvent` emitted under
+        backpressure, or a governance-only record — cannot be expressed through
+        ``on_event``. Rather than silently drop them (they signal audit gaps),
+        the base logs a one-time warning naming the sink class. Sinks that want
+        to persist gaps override this method (``JsonlSink``/``SqliteOutputSink``
+        do).
+        """
+        event = enriched.event
+        if isinstance(event, SessionEvent):
+            await self.on_event(event)
+            return
+        cls = type(self).__name__
+        if cls not in StorageSink._enriched_drop_warned:
+            StorageSink._enriched_drop_warned.add(cls)
+            logger.warning(
+                "%s does not handle non-event envelope payloads (e.g. context-gap "
+                "markers); they will be dropped. Override on_enriched_event(enriched) "
+                "to persist or forward them.",
+                cls,
+            )
 
     async def on_span(self, span: TelemetrySpan) -> None:
         """Handle a telemetry span. Default no-op."""

--- a/src/tracemill/sinks/jsonl.py
+++ b/src/tracemill/sinks/jsonl.py
@@ -66,6 +66,41 @@ class JsonlSink(StorageSink):
     async def on_usage(self, usage: UsageRecord) -> None:
         pass
 
+    async def on_enriched_event(self, enriched) -> None:
+        """Persist a governance envelope. Live events keep byte-identical output;
+        context-gap markers are written as a tagged ``context_gap`` record."""
+        from tracemill.governance.envelope import ContextGapEvent
+
+        gap = enriched.event
+        if not isinstance(gap, ContextGapEvent):
+            await super().on_enriched_event(enriched)
+            return
+
+        path = self._resolve_path(gap.session_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        line = json.dumps(
+            {
+                "record": "context_gap",
+                "id": gap.id,
+                "session_id": gap.session_id,
+                "timestamp": gap.timestamp.isoformat(),
+                "dropped_count": gap.dropped_count,
+                "first_dropped_sequence": gap.first_dropped_sequence,
+                "last_dropped_sequence": gap.last_dropped_sequence,
+                "gap_ordinal": gap.gap_ordinal,
+                "reason": gap.reason,
+                "source_event_key": gap.source_event_key,
+            },
+            default=str,
+        )
+
+        try:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+        except OSError as exc:
+            logger.error("JsonlSink: failed to write to %s: %s", path, exc)
+
     async def on_title_update(self, update: TitleUpdate) -> None:
         path = self._resolve_path(update.session_id)
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/tracemill/sinks/sqlite_output.py
+++ b/src/tracemill/sinks/sqlite_output.py
@@ -45,6 +45,21 @@ CREATE TABLE IF NOT EXISTS segment_titles (
 );
 
 CREATE INDEX IF NOT EXISTS idx_segment_titles_session ON segment_titles(session_id);
+
+CREATE TABLE IF NOT EXISTS context_gaps (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    dropped_count INTEGER NOT NULL,
+    first_dropped_sequence INTEGER,
+    last_dropped_sequence INTEGER,
+    gap_ordinal INTEGER NOT NULL,
+    reason TEXT NOT NULL,
+    source_event_key TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_context_gaps_session ON context_gaps(session_id);
 """
 
 
@@ -126,6 +141,45 @@ class SqliteOutputSink(StorageSink):
 
     async def on_usage(self, usage: UsageRecord) -> None:
         pass
+
+    async def on_enriched_event(self, enriched) -> None:
+        """Persist a governance envelope. Live events keep byte-identical output
+        (delegated to :meth:`on_event`); context-gap markers land in the
+        ``context_gaps`` table."""
+        from tracemill.governance.envelope import ContextGapEvent
+
+        gap = enriched.event
+        if not isinstance(gap, ContextGapEvent):
+            await super().on_enriched_event(enriched)
+            return
+
+        params = (
+            gap.id,
+            gap.session_id,
+            gap.timestamp.isoformat() if gap.timestamp else None,
+            gap.dropped_count,
+            gap.first_dropped_sequence,
+            gap.last_dropped_sequence,
+            gap.gap_ordinal,
+            gap.reason,
+            gap.source_event_key,
+        )
+        await asyncio.to_thread(self._write_gap, params)
+
+    def _write_gap(self, params: tuple) -> None:
+        """Synchronous gap write — called via asyncio.to_thread."""
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """INSERT OR IGNORE INTO context_gaps
+                   (id, session_id, timestamp, dropped_count, first_dropped_sequence,
+                    last_dropped_sequence, gap_ordinal, reason, source_event_key)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                params,
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.error("SqliteOutputSink: gap write failed: %s", exc)
 
     async def on_title_update(self, update: TitleUpdate) -> None:
         params = (

--- a/tests/integration/test_enrich_emit_integration.py
+++ b/tests/integration/test_enrich_emit_integration.py
@@ -1,0 +1,194 @@
+"""Integration: raw agent activity → governance enrichment → sink envelopes.
+
+Proves the observe → enrich → emit path is wired end-to-end so the three
+previously-orphaned governance types are actually consumed:
+
+* ``GovernanceObserver`` (adapter) + ``EnrichedEmitter`` (async actor) deliver a
+  full ``{event, _governance}`` :class:`EnrichedEvent` envelope carrying real
+  governance to sinks, and the tool-call budget advances **exactly once** across
+  a ``start → pre → post → end`` cycle (the double-count guard).
+* Under forced backpressure a coalesced ``ContextGapEvent`` reaches sinks and the
+  dropped-event count is persisted durably (survives a fresh DB connection).
+* The live ``EventPipeline`` emits the same envelope through the additive
+  ``on_enriched_event`` sink interface, and a legacy on_event-only sink keeps
+  working unchanged.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+from tracemill.cli.factory import create_default_pipeline
+from tracemill.governance.envelope import ContextGapEvent, EnrichedEvent
+from tracemill.governance.observer import AgentContext, create_observer
+from tracemill.governance.persistence import SystemStore
+from tracemill.governance.results import SessionMeta
+from tracemill.pipeline import EventPipeline
+from tracemill.sinks.base import StorageSink
+from tracemill.types import EventKind, EventMetadata, SessionEvent
+
+
+class CapturingSink(StorageSink):
+    def __init__(self) -> None:
+        self.events: list = []
+        self.enriched: list = []
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+
+    async def on_enriched_event(self, enriched) -> None:
+        self.enriched.append(enriched)
+
+
+class LegacySink(StorageSink):
+    """Only implements on_event — must keep working via the base default."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+
+
+def _meta() -> SessionMeta:
+    return SessionMeta(classification=None, risk_assessment=None)
+
+
+def _live_event(session_id: str, sequence: int) -> SessionEvent:
+    return SessionEvent(
+        kind=EventKind.TOOL_CALL_COMPLETED,
+        session_id=session_id,
+        timestamp=datetime.now(timezone.utc),
+        payload={"tool_name": "shell", "arguments": {"command": "ls"}},
+        metadata=EventMetadata(sequence=sequence),
+    )
+
+
+class TestObserverEmitterEndToEnd:
+    def test_envelope_reaches_sinks_and_budget_advances_once(self):
+        gov = create_default_pipeline(SystemStore(":memory:"))
+        sink = CapturingSink()
+        observer, emitter = create_observer(gov, [sink], capacity=128)
+
+        def budget() -> int:
+            return gov.get_or_create_state("sess-e2e").snapshot().budget.total_tool_calls
+
+        async def run():
+            await emitter.start()
+            await observer.on_session_start(AgentContext(session_id="sess-e2e"))
+            b_start = budget()
+            await observer.on_pre_tool_call("shell", {"command": "rm -rf /tmp/x"})
+            b_pre = budget()
+            await observer.on_post_tool_call("shell", {"exit_code": 0})
+            b_post = budget()
+            await observer.on_session_end(AgentContext(session_id="sess-e2e"))
+            await emitter.aclose()
+            return b_start, b_pre, b_post
+
+        b_start, b_pre, b_post = asyncio.run(run())
+
+        # ── the double-count guard: budget advances EXACTLY once (at post) ──
+        assert b_start == 0
+        assert b_pre == 0  # read-only preview does not advance the durable budget
+        assert b_post == 1
+
+        # ── the full {event, _governance} envelope reaches sinks ──
+        completed = [e for e in sink.enriched if e.event.kind == EventKind.TOOL_CALL_COMPLETED]
+        assert len(completed) == 1
+        env = completed[0]
+        assert isinstance(env, EnrichedEvent)
+        as_dict = env.to_dict()
+        assert set(as_dict.keys()) == {"event", "_governance"}
+        assert as_dict["event"]["kind"] == EventKind.TOOL_CALL_COMPLETED
+        # Real governance (a classification) rode along in the envelope.
+        assert env.governance.classification is not None
+        assert as_dict["_governance"].get("classification") is not None
+
+        # The pre-call preview was NOT emitted as its own sink record.
+        kinds = [e.event.kind for e in sink.enriched]
+        assert EventKind.TOOL_CALL_STARTED not in kinds
+
+    def test_forced_backpressure_emits_gap_and_persists(self, tmp_path):
+        db = str(tmp_path / "gov.db")
+        gov = create_default_pipeline(SystemStore(db))
+        sink = CapturingSink()
+        # capacity=1 so a burst of submissions forces drops.
+        observer, emitter = create_observer(gov, [sink], capacity=1)
+
+        async def run():
+            # Submit a burst for one session before the drain starts → 4 drops.
+            for i in range(5):
+                emitter.submit(_live_event("sess-bp", i + 1), _meta())
+            await emitter.start()
+            await emitter.aclose()
+
+        asyncio.run(run())
+
+        # A coalesced ContextGapEvent envelope reached the sink downstream.
+        gaps = [e for e in sink.enriched if isinstance(e.event, ContextGapEvent)]
+        assert len(gaps) == 1
+        gap = gaps[0].event
+        assert gap.dropped_count == 4
+        assert gap.first_dropped_sequence == 1
+        assert gap.last_dropped_sequence == 4
+        # It serializes as a governance envelope downstream.
+        assert gaps[0].to_dict()["event"]["kind"] == "context_gap"
+
+        # The dropped-event count is persisted durably (fresh connection).
+        gov2 = create_default_pipeline(SystemStore(db))
+        snap = gov2.get_or_create_state("sess-bp").snapshot()
+        assert snap.dropped_events == 4
+
+
+class TestEventPipelineEnvelopeEmission:
+    def test_wired_governance_emits_envelope_and_keeps_legacy_sink(self):
+        gov = create_default_pipeline(SystemStore(":memory:"))
+        capturing = CapturingSink()
+        legacy = LegacySink()
+        pipeline = EventPipeline(
+            sinks=[capturing, legacy],
+            governance=gov,
+            enable_phase=False,
+            enable_boundary=False,
+        )
+
+        event = _live_event("sess-pipe", 1)
+
+        async def run():
+            await pipeline.push(event)
+            await pipeline.flush()
+
+        asyncio.run(run())
+
+        # The envelope-aware sink receives the {event, _governance} envelope.
+        assert len(capturing.enriched) == 1
+        env = capturing.enriched[0]
+        assert isinstance(env, EnrichedEvent)
+        assert env.governance is not None
+        assert env.event.kind == EventKind.TOOL_CALL_COMPLETED
+
+        # The legacy on_event-only sink still works: it receives the stamped
+        # event (governance folded into metadata) via the base default.
+        assert len(legacy.events) == 1
+        assert legacy.events[0].metadata.governance is not None
+
+    def test_no_governance_wired_is_unchanged(self):
+        capturing = CapturingSink()
+        legacy = LegacySink()
+        pipeline = EventPipeline(
+            sinks=[capturing, legacy],
+            enable_phase=False,
+            enable_boundary=False,
+        )
+        event = _live_event("sess-plain", 1)
+
+        async def run():
+            await pipeline.push(event)
+            await pipeline.flush()
+
+        asyncio.run(run())
+
+        # No governance wired → bare on_event, no envelope, no governance stamp.
+        assert capturing.enriched == []
+        assert len(capturing.events) == 1
+        assert capturing.events[0].metadata.governance is None
+        assert legacy.events[0].metadata.governance is None

--- a/tests/unit/test_enrich_emit_subsystem.py
+++ b/tests/unit/test_enrich_emit_subsystem.py
@@ -1,0 +1,457 @@
+"""Unit tests for the observe → enrich → emit subsystem (issues #22, #23, #26).
+
+Covers:
+* ``EnrichedEmitter`` enqueue/dequeue delivery, capacity validation, and
+  backpressure (drop-oldest + durable ``record_drop`` + ONE coalesced
+  ``ContextGapEvent`` spanning the dropped sequences).
+* ``EnrichedEvent.to_dict`` for the live ``SessionEvent`` branch (governance
+  lifted out of ``metadata`` into ``_governance``).
+* Additive sink evolution: the backward-compat ``on_enriched_event`` default
+  (live event → ``on_event``; gap marker → warn + skip, no crash) and the
+  ``JsonlSink`` / ``SqliteOutputSink`` gap-persistence overrides.
+* ``GovernanceObserver`` protocol conformance, pre-call = read-only preview
+  (returned to host, NOT emitted), post-call = single writer that advances the
+  tool-call budget exactly once, and durable drop persistence via ``create_observer``.
+"""
+
+import asyncio
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from tracemill.governance.emitter import EnrichedEmitter, _GapAccumulator
+from tracemill.governance.envelope import ContextGapEvent, EnrichedEvent
+from tracemill.governance.observer import (
+    AgentContext,
+    GovernanceObserver,
+    TracemillObserver,
+    create_observer,
+)
+from tracemill.governance.persistence import SystemStore
+from tracemill.governance.results import SessionMeta
+from tracemill.sinks.base import StorageSink
+from tracemill.sinks.jsonl import JsonlSink
+from tracemill.sinks.sqlite_output import SqliteOutputSink
+from tracemill.types import EventKind, EventMetadata, SessionEvent
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _meta() -> SessionMeta:
+    return SessionMeta(classification=None, risk_assessment=None)
+
+
+def _live_event(
+    session_id: str = "s1",
+    sequence: int = 1,
+    kind: str = EventKind.TOOL_CALL_COMPLETED,
+) -> SessionEvent:
+    return SessionEvent(
+        kind=kind,
+        session_id=session_id,
+        timestamp=datetime.now(timezone.utc),
+        payload={"tool_name": "shell"},
+        metadata=EventMetadata(sequence=sequence),
+    )
+
+
+def _gap(session_id: str = "s1") -> ContextGapEvent:
+    return ContextGapEvent(
+        id="g1",
+        session_id=session_id,
+        timestamp=datetime.now(timezone.utc),
+        source_event_key="gap:s1:1:2",
+        dropped_count=2,
+        first_dropped_sequence=1,
+        last_dropped_sequence=2,
+        gap_ordinal=1,
+    )
+
+
+class EnvelopeCapturingSink(StorageSink):
+    """Captures the full governance envelope (overrides on_enriched_event)."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+        self.enriched: list = []
+        self.flushed = 0
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+
+    async def on_enriched_event(self, enriched) -> None:
+        self.enriched.append(enriched)
+
+    async def flush(self) -> None:
+        self.flushed += 1
+
+
+class LegacyOnEventSink(StorageSink):
+    """A sink from before the envelope existed — only implements on_event, so it
+    exercises the base on_enriched_event backward-compat default."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+
+
+# ─── EnrichedEmitter: delivery + capacity ────────────────────────────────────
+
+
+class TestEnrichedEmitterDelivery:
+    def test_delivers_envelope_to_sink(self):
+        sink = EnvelopeCapturingSink()
+        emitter = EnrichedEmitter([sink], capacity=8)
+
+        async def run():
+            emitter.submit(_live_event(), _meta())
+            await emitter.start()
+            await emitter.aclose()
+
+        asyncio.run(run())
+
+        assert len(sink.enriched) == 1
+        env = sink.enriched[0]
+        assert isinstance(env, EnrichedEvent)
+        assert env.event.session_id == "s1"
+        assert env.event.kind == EventKind.TOOL_CALL_COMPLETED
+        assert sink.flushed == 1  # aclose flushes sinks
+
+    def test_preserves_submit_order(self):
+        sink = EnvelopeCapturingSink()
+        emitter = EnrichedEmitter([sink], capacity=16)
+
+        async def run():
+            await emitter.start()
+            for i in range(5):
+                emitter.submit(_live_event(sequence=i + 1), _meta())
+            await emitter.aclose()
+
+        asyncio.run(run())
+
+        seqs = [e.event.metadata.sequence for e in sink.enriched]
+        assert seqs == [1, 2, 3, 4, 5]
+
+    def test_rejects_bad_capacity(self):
+        with pytest.raises(ValueError):
+            EnrichedEmitter([], capacity=0)
+
+    def test_error_isolated_fanout(self):
+        class BoomSink(StorageSink):
+            async def on_event(self, event):
+                pass
+
+            async def on_enriched_event(self, enriched):
+                raise RuntimeError("boom")
+
+        good = EnvelopeCapturingSink()
+        emitter = EnrichedEmitter([BoomSink(), good], capacity=8)
+
+        async def run():
+            emitter.submit(_live_event(), _meta())
+            await emitter.start()
+            await emitter.aclose()
+
+        asyncio.run(run())  # must not raise
+        assert len(good.enriched) == 1  # the healthy sink still received it
+
+
+# ─── EnrichedEmitter: backpressure (#26) ─────────────────────────────────────
+
+
+class TestEnrichedEmitterBackpressure:
+    def test_drop_oldest_coalesces_one_gap(self):
+        sink = EnvelopeCapturingSink()
+        drops: list = []
+        emitter = EnrichedEmitter(
+            [sink], capacity=1, record_drop=lambda sid, n: drops.append((sid, n))
+        )
+
+        async def run():
+            # Submit 3 before starting the drain → deterministic 2 drops.
+            for i in range(3):
+                emitter.submit(_live_event(sequence=i + 1), _meta())
+            await emitter.start()
+            await emitter.aclose()
+
+        asyncio.run(run())
+
+        # record_drop fired once per dropped event (precise counter).
+        assert drops == [("s1", 1), ("s1", 1)]
+
+        gaps = [e for e in sink.enriched if isinstance(e.event, ContextGapEvent)]
+        lives = [e for e in sink.enriched if isinstance(e.event, SessionEvent)]
+
+        # Exactly ONE coalesced gap marker spanning the two dropped sequences.
+        assert len(gaps) == 1
+        gap = gaps[0].event
+        assert gap.dropped_count == 2
+        assert gap.first_dropped_sequence == 1
+        assert gap.last_dropped_sequence == 2
+        assert gap.source_event_key == "gap:s1:1:2"
+        # Gap envelopes carry an empty SessionMeta (bypass enrichment).
+        assert gaps[0].governance.classification is None
+
+        # The surviving event (seq 3) is still delivered, AFTER the gap marker.
+        assert [e.event.metadata.sequence for e in lives] == [3]
+        assert sink.enriched.index(gaps[0]) < sink.enriched.index(lives[0])
+
+    def test_trailing_gap_flushed_on_close(self):
+        # A drop whose session never gets a surviving event still surfaces a
+        # marker at aclose().
+        sink = EnvelopeCapturingSink()
+        emitter = EnrichedEmitter([sink], capacity=1)
+
+        async def run():
+            emitter.submit(_live_event(session_id="s1", sequence=1), _meta())
+            emitter.submit(_live_event(session_id="s1", sequence=2), _meta())
+            # queue now holds seq2; seq1 dropped + coalesced.
+            await emitter.start()
+            await emitter.aclose()
+
+        asyncio.run(run())
+
+        gaps = [e for e in sink.enriched if isinstance(e.event, ContextGapEvent)]
+        assert len(gaps) == 1
+        assert gaps[0].event.dropped_count == 1
+        assert gaps[0].event.first_dropped_sequence == 1
+
+
+class TestGapAccumulator:
+    def test_coalesces_sequences(self):
+        acc = _GapAccumulator("s1")
+        acc.add(5, 1)
+        acc.add(6, 2)
+        acc.add(9, 3)
+        assert acc.count == 3
+        assert acc.first_sequence == 5
+        assert acc.last_sequence == 9
+        ev = acc.to_event()
+        assert ev.dropped_count == 3
+        assert ev.source_event_key == "gap:s1:5:9"
+
+    def test_missing_sequences_fall_back_to_ordinal(self):
+        acc = _GapAccumulator("s1")
+        acc.add(None, 7)
+        ev = acc.to_event()
+        assert ev.first_dropped_sequence is None
+        assert ev.source_event_key == "gap:s1:ord:7"
+
+
+# ─── EnrichedEvent.to_dict: live branch (#22) ────────────────────────────────
+
+
+class TestEnrichedEventToDictLive:
+    def test_live_event_lifts_governance_out_of_metadata(self):
+        meta = _meta()
+        stamped_meta = EventMetadata(sequence=3, governance=meta)
+        event = SessionEvent(
+            kind=EventKind.TOOL_CALL_COMPLETED,
+            session_id="s1",
+            timestamp=datetime.now(timezone.utc),
+            payload={"tool_name": "shell", "arguments": {"command": "ls"}},
+            metadata=stamped_meta,
+        )
+        out = EnrichedEvent(event=event, governance=meta).to_dict()
+
+        assert set(out.keys()) == {"event", "_governance"}
+        ev = out["event"]
+        assert ev["id"] == event.id
+        assert ev["kind"] == EventKind.TOOL_CALL_COMPLETED
+        assert ev["session_id"] == "s1"
+        assert ev["payload"]["tool_name"] == "shell"
+        # governance must NOT be duplicated inside the event metadata.
+        assert "governance" not in (ev["metadata"] or {})
+        assert ev["metadata"]["sequence"] == 3
+
+    def test_gap_event_to_dict(self):
+        out = EnrichedEvent(event=_gap(), governance=_meta()).to_dict()
+        assert out["event"]["kind"] == "context_gap"
+        assert out["event"]["dropped_count"] == 2
+        assert out["event"]["first_dropped_sequence"] == 1
+        assert out["_governance"] == {}
+
+
+# ─── Additive sink evolution: backward compat + gap persistence ──────────────
+
+
+class TestSinkBackwardCompat:
+    def test_legacy_sink_receives_live_event_via_default(self):
+        sink = LegacyOnEventSink()
+        live = _live_event()
+        asyncio.run(sink.on_enriched_event(EnrichedEvent(event=live, governance=_meta())))
+        assert sink.events == [live]
+
+    def test_legacy_sink_skips_gap_without_crashing(self):
+        sink = LegacyOnEventSink()
+        asyncio.run(sink.on_enriched_event(EnrichedEvent(event=_gap(), governance=_meta())))
+        assert sink.events == []  # gap silently skipped (with a one-time warning)
+
+
+class TestSinkGapPersistence:
+    def test_jsonl_writes_gap_record(self, tmp_path):
+        sink = JsonlSink(str(tmp_path / "{session_id}.jsonl"))
+        asyncio.run(sink.on_enriched_event(EnrichedEvent(event=_gap(), governance=_meta())))
+
+        content = (tmp_path / "s1.jsonl").read_text().strip()
+        data = json.loads(content)
+        assert data["record"] == "context_gap"
+        assert data["dropped_count"] == 2
+        assert data["first_dropped_sequence"] == 1
+        assert data["last_dropped_sequence"] == 2
+
+    def test_jsonl_live_event_byte_identical(self, tmp_path):
+        # The envelope path for a live event must match the plain on_event output.
+        live = _live_event()
+        env_sink = JsonlSink(str(tmp_path / "env_{session_id}.jsonl"))
+        plain_sink = JsonlSink(str(tmp_path / "plain_{session_id}.jsonl"))
+        asyncio.run(env_sink.on_enriched_event(EnrichedEvent(event=live, governance=_meta())))
+        asyncio.run(plain_sink.on_event(live))
+
+        env_line = (tmp_path / "env_s1.jsonl").read_text()
+        plain_line = (tmp_path / "plain_s1.jsonl").read_text()
+        assert env_line == plain_line
+
+    def test_sqlite_writes_gap_row(self, tmp_path):
+        db = str(tmp_path / "out.db")
+        sink = SqliteOutputSink(db)
+        asyncio.run(sink.on_enriched_event(EnrichedEvent(event=_gap(), governance=_meta())))
+        asyncio.run(sink.close())
+
+        conn = sqlite3.connect(db)
+        try:
+            rows = conn.execute(
+                "SELECT dropped_count, first_dropped_sequence, last_dropped_sequence, "
+                "gap_ordinal, source_event_key FROM context_gaps WHERE id = 'g1'"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert rows == [(2, 1, 2, 1, "gap:s1:1:2")]
+
+
+# ─── GovernanceObserver (#23) ────────────────────────────────────────────────
+
+
+class TestGovernanceObserver:
+    def _pipeline(self):
+        from tracemill.cli.factory import create_default_pipeline
+
+        return create_default_pipeline(SystemStore(":memory:"))
+
+    def test_concrete_impl_satisfies_runtime_protocol(self):
+        gov = self._pipeline()
+        observer, _emitter = create_observer(gov, [])
+        assert isinstance(observer, TracemillObserver)
+        assert isinstance(observer, GovernanceObserver)
+
+    def test_requires_session_before_tool_hooks(self):
+        gov = self._pipeline()
+        observer, _emitter = create_observer(gov, [])
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(observer.on_pre_tool_call("shell", {"command": "ls"}))
+
+    def test_pre_is_return_only_post_is_emitted(self):
+        gov = self._pipeline()
+        sink = EnvelopeCapturingSink()
+        observer, emitter = create_observer(gov, [sink], capacity=64)
+
+        async def run():
+            await emitter.start()
+            await observer.on_session_start(AgentContext(session_id="s1"))
+            pre = await observer.on_pre_tool_call("shell", {"command": "ls"})
+            post = await observer.on_post_tool_call("shell", {"exit_code": 0})
+            await observer.on_session_end(AgentContext(session_id="s1"))
+            await emitter.aclose()
+            return pre, post
+
+        pre, post = asyncio.run(run())
+
+        assert isinstance(pre, SessionMeta)
+        assert isinstance(post, SessionMeta)
+
+        kinds = [e.event.kind for e in sink.enriched]
+        # start + post-completed + end are emitted; the pre-call PREVIEW is NOT.
+        assert EventKind.TOOL_CALL_STARTED not in kinds
+        assert EventKind.TOOL_CALL_COMPLETED in kinds
+        assert EventKind.SESSION_STARTED in kinds
+        assert EventKind.SESSION_ENDED in kinds
+
+    def test_budget_advances_exactly_once(self):
+        gov = self._pipeline()
+        sink = EnvelopeCapturingSink()
+        observer, emitter = create_observer(gov, [sink], capacity=64)
+
+        def budget():
+            return gov.get_or_create_state("s1").snapshot().budget.total_tool_calls
+
+        async def run():
+            await emitter.start()
+            await observer.on_session_start(AgentContext(session_id="s1"))
+            b_start = budget()
+            await observer.on_pre_tool_call("shell", {"command": "ls"})
+            b_pre = budget()
+            await observer.on_post_tool_call("shell", {"exit_code": 0})
+            b_post = budget()
+            await emitter.aclose()
+            return b_start, b_pre, b_post
+
+        b_start, b_pre, b_post = asyncio.run(run())
+
+        assert b_start == 0
+        # The read-only preview must NOT advance the durable budget.
+        assert b_pre == 0
+        # The single writer advances it exactly once.
+        assert b_post == 1
+
+    def test_completed_envelope_carries_real_classification(self):
+        gov = self._pipeline()
+        sink = EnvelopeCapturingSink()
+        observer, emitter = create_observer(gov, [sink], capacity=64)
+
+        async def run():
+            await emitter.start()
+            await observer.on_session_start(AgentContext(session_id="s1"))
+            await observer.on_pre_tool_call("shell", {"command": "ls"})
+            await observer.on_post_tool_call("shell", {"exit_code": 0})
+            await emitter.aclose()
+
+        asyncio.run(run())
+
+        completed = [e for e in sink.enriched if e.event.kind == EventKind.TOOL_CALL_COMPLETED]
+        assert len(completed) == 1
+        gov_meta = completed[0].governance
+        # A real classification (not the UNKNOWN fallback) reached the envelope.
+        assert gov_meta.classification is not None
+
+
+class TestRecordDropPersistence:
+    def test_dropped_events_persist_across_reconnect(self, tmp_path):
+        db = str(tmp_path / "gov.db")
+        gov = None
+
+        from tracemill.cli.factory import create_default_pipeline
+
+        store = SystemStore(db)
+        gov = create_default_pipeline(store)
+        sink = EnvelopeCapturingSink()
+        observer, emitter = create_observer(gov, [sink], capacity=1)
+
+        async def run():
+            for i in range(3):  # 2 forced drops for session s1
+                emitter.submit(_live_event(session_id="s1", sequence=i + 1), _meta())
+            await emitter.start()
+            await emitter.aclose()
+
+        asyncio.run(run())
+
+        # Reopen from a fresh connection/pipeline and rehydrate.
+        store2 = SystemStore(db)
+        gov2 = create_default_pipeline(store2)
+        snap = gov2.get_or_create_state("s1").snapshot()
+        assert snap.dropped_events == 2


### PR DESCRIPTION
## Summary

Three governance types were exported but consumed **nowhere** in the pipeline — orphaned scaffolding that this repo exists to remove. They land **together** as one coherent path (combined, not stacked) because each alone would merge unconsumed:

- **#23 `TracemillObserver`** — was a bare `Protocol` with no concrete adapter, no async actor, no queue.
- **#22 `EnrichedEvent`** — the `{event, _governance}` envelope, never constructed or emitted to sinks.
- **#26 `ContextGapEvent` + `SessionState.record_drop`** — a gap marker and drop counter with no bounded queue, no drop-oldest, no coalescing, no gap emission under backpressure.

Only with all three does the **observe → enrich → emit** path get consumed end-to-end.

## Design — the sync/async boundary

Governance enrichment runs **synchronously inside the observer hooks** (so they return real `SessionMeta` to the host, and `observe_event` runs **exactly once** — preserving the single-writer tool-call-budget invariant). A new **async actor owns ONLY emission + backpressure**.

```
host framework
   │  on_pre/post_tool_call, on_session_start/end   (returns SessionMeta, sync)
   ▼
GovernanceObserver ── enrich once (observe_event / score_tool_call_event / process_lifecycle)
   │  submit(event, meta)  [non-blocking put_nowait]                              → returns meta
   ▼
EnrichedEmitter ── bounded asyncio.Queue ── drain ── EnrichedEvent(event, meta) ── sink.on_enriched_event
        │ full → drop-oldest + record_drop + coalesce ContextGapEvent
```

## What changed

- **#23** — Concrete `GovernanceObserver` adapter + `create_observer` factory (`governance/observer.py`). Pre-call uses the read-only `score_tool_call_event` preview (returned to the host, **not** emitted as its own sink record); post-call uses the single-writer `observe_event`; lifecycle uses `process_lifecycle`. New async actor `EnrichedEmitter` (`governance/emitter.py`) backed by a bounded `asyncio.Queue`.
- **#26** — Backpressure inside `EnrichedEmitter`: on a full queue, drop-oldest → durable `record_drop` (reuses the existing dropped-events SQLite column — **no new migration**) → coalesce dropped events into **one** `ContextGapEvent` per session, emitted just before the next surviving event (trailing gaps flushed at `aclose`). Enforcement decisions are never dropped; only audit emission is lossy.
- **#22** — Additive sink evolution: new `async on_enriched_event` on `StorageSink` with a **backward-compat default** that forwards a live event to `on_event`, so all 8 existing sinks keep working byte-identically. `jsonl` + `sqlite_output` override it to also persist gap markers. `EventPipeline._push_to_sinks` dispatches the `EnrichedEvent` envelope when governance yields a `SessionMeta`, and the bare event via `on_event` otherwise.

## Tests

- **Unit** (`tests/unit/test_enrich_emit_subsystem.py`): observer protocol conformance; emitter enqueue/dequeue/ordering/capacity/error-isolation; backpressure drop-oldest + `record_drop` persistence + coalesced `ContextGapEvent`; `EnrichedEvent.to_dict` for live **and** gap variants; sink backward-compat + gap persistence (jsonl + sqlite).
- **Integration** (`tests/integration/test_enrich_emit_integration.py`): raw activity → enrich → sinks proving the full `{event, _governance}` envelope reaches sinks; **budget advances EXACTLY once** across `start→pre→post→end` (the double-count guard); forced-backpressure case emitting a `ContextGapEvent` downstream with the drop count persisted across a fresh connection.

Full suite: **1912 passed, 4 skipped** (1887 baseline + 25 new). `ruff check` and `ruff format --check` clean (pinned 0.15.20). No changes to `integrity.py` (owned by the parallel #14 session); framework-agnostic and torch-free throughout.

Closes #22
Closes #23
Closes #26