### PR TITLE
fix(cli): supply project_root so integrity/drift key by the real repo, not "unknown"

### DIFF
--- a/src/tracemill/cli/factory.py
+++ b/src/tracemill/cli/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,14 @@ def create_default_pipeline(
     """Create a GovernancePipeline with all default components.
 
     This is the standard way to instantiate a pipeline for CLI and Score API use.
+
+    When ``project_root`` is not supplied it defaults to the resolved absolute current
+    working directory. The CLI entry points (``watch``/``score``/``replay``) run *inside*
+    the target repository and share a persistent ``~/.tracemill/system.db``; without a
+    real key both :class:`IntegrityVerifier` and :class:`DriftDetector` would namespace
+    their per-file baselines under the literal ``"unknown"``, colliding every repository
+    the user runs against on relative tool-call paths (e.g. two repos both writing
+    ``src/main.py``). Defaulting to the cwd gives each repository its own namespace.
     """
     from tracemill.classify.config import get_default_engine
     from tracemill.governance.budget import BudgetTracker
@@ -34,6 +43,13 @@ def create_default_pipeline(
     rules = parse_rules(rules_path)
 
     engine = get_default_engine()
+
+    # watch/score/replay pass no project_root but share the persistent
+    # ~/.tracemill/system.db; default the repo key to the resolved cwd so integrity and
+    # drift namespace per-repo, never the colliding "unknown" bucket (see docstring).
+    if project_root is None:
+        project_root = os.path.abspath(os.getcwd())
+
     # Content integrity is live by default on this primary CLI/Score path. The repo
     # key mirrors drift.py's ``project_root or "unknown"`` idiom so runtime contexts
     # and the constructed verifier agree on the namespace.

--- a/tests/unit/test_governance_integrity.py
+++ b/tests/unit/test_governance_integrity.py
@@ -13,6 +13,7 @@ writer attribution, and — critically — a preflight simulation that never rec
 
 import hashlib
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -256,8 +257,11 @@ class TestDefaultInjection:
     way — with NO hand-injected verifier — record the baseline on a first write and flag
     a mismatched re-write with the +10 integrity bonus. Integrity is on by default at
     both composition roots (`create_default_pipeline` and `GovernancePipeline.create`/
-    `from_config`) and opt-out via `integrity_verification: false`. The repo key falls
-    back to ``"unknown"`` (matching drift.py) when no project_root is configured."""
+    `from_config`) and opt-out via `integrity_verification: false`. `GovernancePipeline.
+    create`/`from_config` fall back to a repo key of ``"unknown"`` (matching drift.py)
+    when no project_root is configured, whereas the CLI factory `create_default_pipeline`
+    defaults the key to the resolved cwd so per-repo baselines in the shared persistent
+    store never collide."""
 
     def test_default_factory_wires_integrity_live(self, store):
         # cli/factory.py path (CLI + Score API). No manual IntegrityVerifier.
@@ -282,6 +286,44 @@ class TestDefaultInjection:
         assert meta_drift.risk_assessment.score - meta0.risk_assessment.score == 10
         # Drift re-baselines (deferred) to what was actually written.
         assert store.get_content_hash(REPO, "src/a.py") == _sha(b"v2")
+
+    def test_cli_factory_keys_baseline_by_cwd_not_unknown(self, store, monkeypatch, tmp_path):
+        """The CLI builds its pipeline with NO explicit project_root — exactly
+        ``create_default_pipeline(store)`` as in watch/score/replay — against the shared,
+        persistent ``~/.tracemill/system.db``. That store used to namespace every repo's
+        per-file baseline under the literal ``"unknown"``, so two different repositories
+        both writing the relative path ``src/main.py`` collided and produced false
+        integrity signals. The factory now defaults the repo key to the resolved cwd, so
+        each repository gets its own, non-colliding namespace."""
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        # ── Repo A: run the CLI-style factory from inside repo_a, no project_root ──
+        monkeypatch.chdir(repo_a)
+        key_a = os.path.abspath(os.getcwd())
+        pipeline_a = create_default_pipeline(store)
+        pipeline_a.process_event(
+            _ctx(_write_event("src/main.py", "content-A", session_id="A", event_id="a1", key="ka"))
+        )
+
+        # ── Repo B: SAME relative path, DIFFERENT content, from inside repo_b ──
+        monkeypatch.chdir(repo_b)
+        key_b = os.path.abspath(os.getcwd())
+        pipeline_b = create_default_pipeline(store)
+        pipeline_b.process_event(
+            _ctx(_write_event("src/main.py", "content-B", session_id="B", event_id="b1", key="kb"))
+        )
+
+        assert key_a != key_b  # distinct repos → distinct keys, no "unknown" collision
+        assert "unknown" not in (key_a, key_b)
+
+        # Each repo's baseline is namespaced by its own cwd (its real identity) …
+        assert store.get_content_hash(key_a, "src/main.py") == _sha(b"content-A")
+        assert store.get_content_hash(key_b, "src/main.py") == _sha(b"content-B")
+        # … and nothing landed in the colliding "unknown" bucket that caused the bug.
+        assert store.get_content_hash("unknown", "src/main.py") is None
 
     def test_zero_config_pipeline_wires_integrity_live(self):
         # GovernancePipeline.create() with default config (the from_config root, which


### PR DESCRIPTION
## Problem

The governance subsystem namespaces per-file baselines by a `repo` key. Two features derive that key as `project_root or "unknown"`:

- **IntegrityVerifier** (`governance/integrity.py`, wired live in #59) — repo comes from the pipeline's `project_root`.
- **DriftDetector** (`governance/drift.py:165`) — `repo = ctx.project_root or "unknown"`.

But the three CLI entry points build their pipeline **without** a `project_root`:

- `cli/watch.py` → `create_default_pipeline(store, policy=policy)`
- `cli/score.py` → `create_default_pipeline(store)`
- `cli/replay.py` → `create_default_pipeline(store)`

and `cli/factory.py:create_default_pipeline` defaulted `project_root` to `None`. So in `tracemill watch`/`score`/`replay`, **both** integrity and drift keyed the repo namespace as the literal string `"unknown"`. Because these commands use a **persistent** store (`~/.tracemill/system.db`), every repository a user ever ran against shared the single `"unknown"` bucket — under relative tool-call paths (e.g. two different repos both writing `src/main.py`) this caused cross-repo baseline **collisions** and false integrity/drift signals.

## Fix (CLI layer only)

In `cli/factory.py:create_default_pipeline`, when `project_root` is `None`, default it to the resolved absolute cwd (`os.path.abspath(os.getcwd())`) and let the existing `project_root or "unknown"` sites resolve to the real repository. This fixes all three callers at once — `watch`/`score`/`replay` all run **inside** the target repo, so cwd is the correct repo identity.

- `GovernancePipeline.create()` (the SDK / `from_config` root) is **untouched** and stays behavior-neutral (`None` → in-memory `:memory:`), as relied on by the SDK and the existing test suite.
- No changes to `governance/integrity.py`, `governance/drift.py`, or `governance/pipeline.py` — once a real `project_root` flows in, they key correctly.

## Verification

New test `test_cli_factory_keys_baseline_by_cwd_not_unknown` reproduces the bug scenario: a pipeline built the CLI way (`create_default_pipeline(store)`, no explicit `project_root`) against one shared persistent store, run from two different cwds both writing `src/main.py`. It asserts each repo's `content_hashes` baseline is namespaced by its own cwd, the two keys differ, and nothing lands in the `"unknown"` bucket.

- Full suite green: **1926 passed, 4 skipped**.
- `ruff check` + `ruff format --check` (pinned `0.15.20`): clean.

Rebased on latest `main` (includes #60).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>