### PR TITLE
Make IntegrityVerifier per-event so CLI paths key by real repo (#61)

### DIFF
--- a/src/tracemill/cli/factory.py
+++ b/src/tracemill/cli/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -27,6 +28,13 @@ def create_default_pipeline(
     from tracemill.governance.labeler import GovernanceLabeler
     from tracemill.governance.rules import parse_rules
 
+    # watch/score/replay run inside the target repo, so cwd is its identity. Defaulting
+    # here (rather than leaving project_root unset) gives per-event integrity a real repo
+    # key instead of "unknown", so a persistent system.db doesn't bucket every repo the
+    # user watches under one namespace and raise cross-repo false drift.
+    if project_root is None:
+        project_root = os.getcwd()
+
     # Load default recommendation rules from bundled data
     rules_path = (
         Path(__file__).resolve().parent.parent / "classify" / "data" / "recommendation_rules.yaml"
@@ -34,10 +42,10 @@ def create_default_pipeline(
     rules = parse_rules(rules_path)
 
     engine = get_default_engine()
-    # Content integrity is live by default on this primary CLI/Score path. The repo
-    # key mirrors drift.py's ``project_root or "unknown"`` idiom so runtime contexts
-    # and the constructed verifier agree on the namespace.
-    integrity_verifier = IntegrityVerifier(store, project_root or "unknown")
+    # Content integrity is live by default on this primary CLI/Score path. The verifier
+    # is per-event: it derives the repo key from each event's ctx.project_root, so no
+    # construction-time repo is needed.
+    integrity_verifier = IntegrityVerifier(store)
     labeler = GovernanceLabeler(integrity_verifier=integrity_verifier)
     tracker = BudgetTracker()
 

--- a/src/tracemill/governance/integrity.py
+++ b/src/tracemill/governance/integrity.py
@@ -39,11 +39,21 @@ class IntegrityWrite:
 
 
 class IntegrityVerifier:
-    """Verifies content integrity by comparing SHA-256 hashes against stored baselines."""
+    """Verifies content integrity by comparing SHA-256 hashes against stored baselines.
 
-    def __init__(self, store: "SystemStore", repo: str) -> None:
+    The repo key is derived **per event** from ``ctx.project_root`` (mirroring
+    ``drift.py``'s ``ctx.project_root or "unknown"``), not fixed at construction. A
+    single verifier therefore serves every session/repo a pipeline observes, so the
+    default composition can wire it unconditionally without a construction-time repo.
+    """
+
+    def __init__(self, store: "SystemStore") -> None:
         self._store = store
-        self._repo = repo
+
+    @staticmethod
+    def _repo_for(ctx: "EnrichmentContext") -> str:
+        """Repo key for this event — matches drift.py's ``project_root or "unknown"``."""
+        return ctx.project_root or "unknown"
 
     def should_check(self, classification: "object") -> bool:
         """Whether to verify integrity for this classification."""
@@ -60,14 +70,15 @@ class IntegrityVerifier:
         """High-level: check integrity for all file writes in event."""
         if not self.should_check(ctx.base_classification):
             return
+        repo = self._repo_for(ctx)
         for path, content in self._extract_file_writes(ctx):
-            result = self.check(path, content)
+            result = self.check(repo, path, content)
             if result and not result.matched:
                 cap.add("integrity_unverified")
 
-    def check(self, path: str, content: bytes) -> IntegrityCheck | None:
-        """Low-level: compare content hash against stored value."""
-        expected = self._store.get_content_hash(self._repo, path)
+    def check(self, repo: str, path: str, content: bytes) -> IntegrityCheck | None:
+        """Low-level: compare content hash against the stored value for ``repo``."""
+        expected = self._store.get_content_hash(repo, path)
         if expected is None:
             return None  # Path not tracked
 
@@ -75,7 +86,7 @@ class IntegrityVerifier:
         # Get writer from content_hashes table
         row = self._store.connection.execute(
             "SELECT updated_by_session FROM content_hashes WHERE repo = ? AND file_path = ?",
-            (self._repo, path),
+            (repo, path),
         ).fetchone()
         writer = row[0] if row else None
 
@@ -87,10 +98,12 @@ class IntegrityVerifier:
             last_known_writer=writer,
         )
 
-    def record_write(self, path: str, content: bytes, session_id: str, timestamp: str) -> None:
+    def record_write(
+        self, repo: str, path: str, content: bytes, session_id: str, timestamp: str
+    ) -> None:
         """Record a new content hash after a successful write."""
         sha = hashlib.sha256(content).hexdigest()
-        self._store.store_content_hash(self._repo, path, sha, session_id, timestamp)
+        self._store.store_content_hash(repo, path, sha, session_id, timestamp)
 
     def pending_writes(self, ctx: "EnrichmentContext") -> list[IntegrityWrite]:
         """Prescriptions to (re)baseline this event's writes. Pure — no store mutation.
@@ -103,12 +116,13 @@ class IntegrityVerifier:
         """
         if not self.should_check(ctx.base_classification):
             return []
+        repo = self._repo_for(ctx)
         ts = ctx.event.timestamp
         timestamp = ts.isoformat() if hasattr(ts, "isoformat") else str(ts)
         session_id = ctx.event.session_id
         return [
             IntegrityWrite(
-                repo=self._repo,
+                repo=repo,
                 path=path,
                 sha256=hashlib.sha256(content).hexdigest(),
                 session_id=session_id,

--- a/src/tracemill/governance/pipeline.py
+++ b/src/tracemill/governance/pipeline.py
@@ -169,11 +169,11 @@ class GovernancePipeline:
             pii_scanner = PIIScanner()
 
         # Content integrity is live by default (opt out via integrity_verification).
-        # The repo key mirrors drift.py's ``project_root or "unknown"`` idiom so runtime
-        # contexts and the constructed verifier agree on the namespace.
+        # The verifier is per-event: it derives the repo key from each event's
+        # ctx.project_root, so no construction-time repo is needed.
         integrity_verifier = None
         if config.integrity_verification:
-            integrity_verifier = IntegrityVerifier(store, config.project_root or "unknown")
+            integrity_verifier = IntegrityVerifier(store)
 
         instance = cls(
             store=store,

--- a/tests/unit/test_governance_integrity.py
+++ b/tests/unit/test_governance_integrity.py
@@ -13,6 +13,7 @@ writer attribution, and — critically — a preflight simulation that never rec
 
 import hashlib
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -73,7 +74,7 @@ def _write_event(path, content, session_id="sess1", event_id="evt-1", key="key-1
     )
 
 
-def _ctx(event, effect="mutating"):
+def _ctx(event, effect="mutating", project_root=REPO):
     classification = Classification(mechanism="filesystem.write", effect=effect)
     return EnrichmentContext(
         event=event,
@@ -81,7 +82,7 @@ def _ctx(event, effect="mutating"):
         command_analysis=None,
         session_state=None,
         mcp_profiles=None,
-        project_root=None,
+        project_root=project_root,
         engine="coding",
         drift_baseline=None,
         mcp_profile_key=None,
@@ -95,7 +96,7 @@ def _ctx(event, effect="mutating"):
 
 class TestVerifier:
     def test_first_seen_write_not_flagged_and_yields_prescription(self, store):
-        verifier = IntegrityVerifier(store, REPO)
+        verifier = IntegrityVerifier(store)
         ctx = _ctx(_write_event("src/a.py", "hello"))
 
         cap: set[str] = set()
@@ -114,26 +115,26 @@ class TestVerifier:
         ]
 
     def test_matching_rewrite_is_not_flagged(self, store):
-        verifier = IntegrityVerifier(store, REPO)
-        verifier.record_write("src/a.py", b"hello", "sess1", _TS)
+        verifier = IntegrityVerifier(store)
+        verifier.record_write(REPO, "src/a.py", b"hello", "sess1", _TS)
 
         cap: set[str] = set()
         verifier.check_event(_ctx(_write_event("src/a.py", "hello")), cap)
         assert "integrity_unverified" not in cap
 
-        check = verifier.check("src/a.py", b"hello")
+        check = verifier.check(REPO, "src/a.py", b"hello")
         assert check is not None and check.matched is True
 
     def test_mismatched_content_is_flagged(self, store):
-        verifier = IntegrityVerifier(store, REPO)
-        verifier.record_write("src/a.py", b"hello", "sess1", _TS)
+        verifier = IntegrityVerifier(store)
+        verifier.record_write(REPO, "src/a.py", b"hello", "sess1", _TS)
 
         cap: set[str] = set()
         verifier.check_event(_ctx(_write_event("src/a.py", "tampered")), cap)
         assert "integrity_unverified" in cap
 
     def test_should_check_gates_pending_writes(self, store):
-        verifier = IntegrityVerifier(store, REPO)
+        verifier = IntegrityVerifier(store)
         # read_only effect and no filesystem_write capability → not integrity-relevant
         assert (
             verifier.pending_writes(_ctx(_write_event("src/a.py", "x"), effect="read_only")) == []
@@ -142,17 +143,17 @@ class TestVerifier:
     def test_cross_session_attribution(self, store):
         """A write by session B on a path baselined by session A is detectable, and
         `last_known_writer` reflects the *prior* writer until B's record commits."""
-        writer_a = IntegrityVerifier(store, REPO)
-        writer_a.record_write("src/a.py", b"content-A", "session-A", _TS)
+        writer_a = IntegrityVerifier(store)
+        writer_a.record_write(REPO, "src/a.py", b"content-A", "session-A", _TS)
 
-        writer_b = IntegrityVerifier(store, REPO)
-        drift = writer_b.check("src/a.py", b"content-B")
+        writer_b = IntegrityVerifier(store)
+        drift = writer_b.check(REPO, "src/a.py", b"content-B")
         assert drift is not None
         assert drift.matched is False
         assert drift.last_known_writer == "session-A"  # attribution to prior writer
 
         # After session B's write commits, the baseline is re-attributed to B.
-        writer_b.record_write("src/a.py", b"content-B", "session-B", _TS)
+        writer_b.record_write(REPO, "src/a.py", b"content-B", "session-B", _TS)
         row = store.connection.execute(
             "SELECT updated_by_session FROM content_hashes WHERE repo = ? AND file_path = ?",
             (REPO, "src/a.py"),
@@ -167,8 +168,8 @@ class TestVerifier:
 
 class TestLabelerBonus:
     def test_mismatch_surfaces_integrity_bonus(self, store):
-        verifier = IntegrityVerifier(store, REPO)
-        verifier.record_write("src/a.py", b"original", "sess1", _TS)
+        verifier = IntegrityVerifier(store)
+        verifier.record_write(REPO, "src/a.py", b"original", "sess1", _TS)
         labeler = GovernanceLabeler(integrity_verifier=verifier)
 
         result = labeler.label(_ctx(_write_event("src/a.py", "tampered")))
@@ -180,8 +181,8 @@ class TestLabelerBonus:
         assert result.integrity_deferred_writes[0].sha256 == _sha(b"tampered")
 
     def test_matching_write_has_no_bonus(self, store):
-        verifier = IntegrityVerifier(store, REPO)
-        verifier.record_write("src/a.py", b"same", "sess1", _TS)
+        verifier = IntegrityVerifier(store)
+        verifier.record_write(REPO, "src/a.py", b"same", "sess1", _TS)
         labeler = GovernanceLabeler(integrity_verifier=verifier)
 
         result = labeler.label(_ctx(_write_event("src/a.py", "same")))
@@ -190,7 +191,7 @@ class TestLabelerBonus:
         assert result.risk_modifiers.integrity_bonus == 0
 
     def test_first_seen_has_no_bonus_but_defers_record(self, store):
-        verifier = IntegrityVerifier(store, REPO)
+        verifier = IntegrityVerifier(store)
         labeler = GovernanceLabeler(integrity_verifier=verifier)
 
         result = labeler.label(_ctx(_write_event("src/new.py", "brand-new")))
@@ -206,7 +207,7 @@ class TestLabelerBonus:
 
 
 def _pipeline(store, rules):
-    verifier = IntegrityVerifier(store, REPO)
+    verifier = IntegrityVerifier(store)
     labeler = GovernanceLabeler(integrity_verifier=verifier)
     return GovernancePipeline(
         store=store,
@@ -285,16 +286,23 @@ class TestDefaultInjection:
 
     def test_zero_config_pipeline_wires_integrity_live(self):
         # GovernancePipeline.create() with default config (the from_config root, which
-        # delegates here). No project_root → repo key "unknown"; still live by default.
+        # delegates here). Events with no project_root exercise the per-event "unknown"
+        # repo fallback (mirrors drift.py); integrity is still live by default.
         pipeline = GovernancePipeline.create()
 
         meta0 = pipeline.process_event(
-            _ctx(_write_event("src/a.py", "v1", session_id="A", event_id="e0", key="k0"))
+            _ctx(
+                _write_event("src/a.py", "v1", session_id="A", event_id="e0", key="k0"),
+                project_root=None,
+            )
         )
         assert "integrity_unverified" not in meta0.classification.capability
 
         meta_drift = pipeline.process_event(
-            _ctx(_write_event("src/a.py", "v2", session_id="B", event_id="e1", key="k1"))
+            _ctx(
+                _write_event("src/a.py", "v2", session_id="B", event_id="e1", key="k1"),
+                project_root=None,
+            )
         )
         assert "integrity_unverified" in meta_drift.classification.capability
         assert "integrity_unverified" in meta_drift.risk_assessment.factors
@@ -312,3 +320,39 @@ class TestDefaultInjection:
         )
         assert "integrity_unverified" not in meta_drift.classification.capability
         assert "integrity_unverified" not in meta_drift.risk_assessment.factors
+
+    def test_watch_style_pipeline_is_live_without_project_root(self, store):
+        # The way `tracemill watch`/`score`/`replay` build the pipeline: the factory is
+        # called with NO project_root. This is exactly the path that was dead before this
+        # fix — every real CLI entry omits project_root, so a construction-time-gated
+        # verifier was None there. A per-event verifier makes it live regardless.
+        pipeline = create_default_pipeline(store)
+
+        # Item 4: production derives a real repo identity from cwd, never a bare
+        # "unknown", so a persistent system.db keys baselines per repo instead of
+        # colliding every watched repo under one namespace (false cross-repo drift).
+        repo = os.getcwd()
+        assert pipeline._project_root == repo
+
+        # First-seen write records the baseline under the cwd repo key (no flag) …
+        meta0 = pipeline.process_event(
+            _ctx(
+                _write_event("src/a.py", "v1", session_id="A", event_id="e0", key="k0"),
+                project_root=repo,
+            )
+        )
+        assert "integrity_unverified" not in meta0.classification.capability
+        assert store.get_content_hash(repo, "src/a.py") == _sha(b"v1")
+
+        # … and a drifted re-write on the tracked path flags integrity_unverified and
+        # raises risk by exactly the +10 integrity bonus — integrity is LIVE by default.
+        meta_drift = pipeline.process_event(
+            _ctx(
+                _write_event("src/a.py", "v2", session_id="B", event_id="e1", key="k1"),
+                project_root=repo,
+            )
+        )
+        assert "integrity_unverified" in meta_drift.classification.capability
+        assert "integrity_unverified" in meta_drift.risk_assessment.factors
+        assert meta_drift.risk_assessment.score - meta0.risk_assessment.score == 10
+        assert store.get_content_hash(repo, "src/a.py") == _sha(b"v2")

--- a/tests/unit/test_governance_integrity.py
+++ b/tests/unit/test_governance_integrity.py
@@ -356,3 +356,49 @@ class TestDefaultInjection:
         assert "integrity_unverified" in meta_drift.risk_assessment.factors
         assert meta_drift.risk_assessment.score - meta0.risk_assessment.score == 10
         assert store.get_content_hash(repo, "src/a.py") == _sha(b"v2")
+
+    def test_cli_factory_keys_baseline_by_cwd_not_unknown(self, store, monkeypatch, tmp_path):
+        # Two distinct repos watched through the SAME persistent store must NOT collide:
+        # create_default_pipeline keys each baseline by cwd (os.getcwd()), so one shared
+        # system.db keeps per-repo namespaces instead of bucketing every watched repo under
+        # "unknown" and raising cross-repo false drift (the watch/score/replay hazard).
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        # Repo A: built inside repo_a, so the factory's cwd default is its repo identity.
+        monkeypatch.chdir(repo_a)
+        key_a = os.getcwd()  # the factory's exact expression — asserted equal below
+        pipeline_a = create_default_pipeline(store)
+        assert pipeline_a._project_root == key_a  # factory & test share os.getcwd(): no drift
+        # The verifier is per-event (keys off ctx.project_root); in production ContextBuilder
+        # stamps the pipeline's project_root onto each event. Thread that SAME value here so
+        # the assertions truly exercise the factory default: drop it and pipeline._project_root
+        # is None, the write lands under "unknown", and the key_a lookup below returns None.
+        pipeline_a.process_event(
+            _ctx(
+                _write_event("src/main.py", "content-A", session_id="A", event_id="a1", key="ka"),
+                project_root=pipeline_a._project_root,
+            )
+        )
+
+        # Repo B: a different cwd → a distinct integrity key through the same store.
+        monkeypatch.chdir(repo_b)
+        key_b = os.getcwd()
+        pipeline_b = create_default_pipeline(store)
+        assert pipeline_b._project_root == key_b
+        pipeline_b.process_event(
+            _ctx(
+                _write_event("src/main.py", "content-B", session_id="B", event_id="b1", key="kb"),
+                project_root=pipeline_b._project_root,
+            )
+        )
+
+        # Distinct real repo keys, neither the "unknown" sentinel …
+        assert key_a != key_b
+        assert "unknown" not in (key_a, key_b)
+        # … each namespace holds ONLY its own content, and the "unknown" bucket stays empty.
+        assert store.get_content_hash(key_a, "src/main.py") == _sha(b"content-A")
+        assert store.get_content_hash(key_b, "src/main.py") == _sha(b"content-B")
+        assert store.get_content_hash("unknown", "src/main.py") is None


### PR DESCRIPTION
Closes #61

The CLI commands `watch`/`score`/`replay` build their pipeline via `create_default_pipeline(store)` with no `project_root`, so both `IntegrityVerifier` and `drift.py` keyed their per-repo namespace by the literal string `"unknown"`. Every watched repo collided in the persistent `~/.tracemill/system.db`, causing cross-repo false drift.

This lands the two-part fix (cherry-picked from commit `1c3dc0a`):

- **cwd default**: `create_default_pipeline` now defaults `project_root` to `os.getcwd()` when unset. `watch`/`score`/`replay` run inside the target repo, so cwd is its real identity.
- **per-event verifier**: `IntegrityVerifier` drops its construction-time `repo` arg and instead derives `repo = ctx.project_root or "unknown"` inside `check_event`/`pending_writes` — mirroring how `drift.py` already derives repo per event. A single verifier now correctly serves every session/repo a pipeline observes.

`GovernancePipeline.create()` stays behavior-neutral (`:memory:`, `project_root` None → `"unknown"`). Adds a watch-style integration test plus coverage for the `"unknown"` fallback and the `integrity_verification: false` opt-out.

Full suite green (1926 passed, 4 skipped); `ruff check` and `ruff format --check` clean.