### PR TITLE
PII scanner: phone numbers, key-value secrets, and documentation false-positive suppression (#12)

### DIFF
--- a/src/tracemill/governance/pii.py
+++ b/src/tracemill/governance/pii.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -13,43 +15,228 @@ if TYPE_CHECKING:
 class PIICategory(StrEnum):
     SSN = "ssn"
     EMAIL = "email"
+    PHONE = "phone"
     CREDIT_CARD = "credit_card"
     API_KEY = "api_key"
+    PASSWORD = "password"
     PRIVATE_KEY = "private_key"
     AWS_KEY = "aws_key"
     JWT = "jwt"
     CONNECTION_STRING = "connection_string"
 
 
-_CREDENTIAL_CATEGORIES = frozenset(
+# ─── Reserved / documentation ranges ──────────────────────────────────────────
+# Standards bodies reserve these identifiers for documentation and testing, so a
+# match against one is a placeholder, never real PII, and must not be flagged.
+
+# RFC 2606 / RFC 6761 reserved TLDs and second-level example domains.
+_RESERVED_EMAIL_TLDS = frozenset({"test", "example", "invalid", "localhost"})
+_RESERVED_EMAIL_SLDS = frozenset({"example.com", "example.net", "example.org"})
+
+# Obvious non-secret values that appear in docs, configs, and type annotations.
+_PLACEHOLDER_SECRETS = frozenset(
     {
-        PIICategory.API_KEY,
-        PIICategory.PRIVATE_KEY,
-        PIICategory.AWS_KEY,
-        PIICategory.JWT,
-        PIICategory.CONNECTION_STRING,
+        "null",
+        "none",
+        "nil",
+        "true",
+        "false",
+        "redacted",
+        "changeme",
+        "example",
+        "placeholder",
+        "password",
+        "passphrase",
+        "secret",
+        "your_password",
+        "yourpassword",
+        "test",
     }
 )
 
-PII_PATTERNS: dict[PIICategory, re.Pattern[str]] = {
-    PIICategory.SSN: re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
-    PIICategory.EMAIL: re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
-    PIICategory.CREDIT_CARD: re.compile(
-        r"\b(?:"
-        r"(?:4\d{3}|5[1-5]\d{2}|6(?:011|5\d{2}))[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}"  # Visa/MC/Discover (16)
-        r"|3[47]\d{2}[- ]?\d{6}[- ]?\d{5}"  # Amex (15)
-        r")\b"
+
+def _digits(text: str) -> str:
+    return "".join(ch for ch in text if ch.isdigit())
+
+
+def _luhn_valid(number: str) -> bool:
+    """Return True when a digit string satisfies the Luhn checksum."""
+    if len(number) < 13:
+        return False
+    total = 0
+    parity = len(number) % 2
+    for index, char in enumerate(number):
+        digit = int(char)
+        if index % 2 == parity:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+def _valid_credit_card(match: re.Match[str]) -> bool:
+    """Card-shaped numbers only count when they pass Luhn (placeholders do not)."""
+    return _luhn_valid(_digits(match.group(0)))
+
+
+def _valid_ssn(match: re.Match[str]) -> bool:
+    """Reject SSNs the SSA never issues (documentation placeholders)."""
+    digits = _digits(match.group(0))
+    if len(digits) != 9:
+        return False
+    area, group, serial = digits[:3], digits[3:5], digits[5:]
+    if area in {"000", "666"} or area[0] == "9":
+        return False
+    return group != "00" and serial != "0000"
+
+
+def _valid_email(match: re.Match[str]) -> bool:
+    """Suppress RFC 2606 / RFC 6761 example and test domains."""
+    domain = match.group(0).rsplit("@", 1)[-1].lower().rstrip(".")
+    tld = domain.rsplit(".", 1)[-1]
+    if tld in _RESERVED_EMAIL_TLDS:
+        return False
+    return not any(domain == sld or domain.endswith("." + sld) for sld in _RESERVED_EMAIL_SLDS)
+
+
+def _valid_phone(match: re.Match[str]) -> bool:
+    """Suppress the NANP 555-0100..555-0199 range reserved for fictional use."""
+    subscriber = _digits(match.group(0))[-10:][-7:]
+    return not (subscriber[:3] == "555" and subscriber[3:5] == "01")
+
+
+def _valid_secret_kv(match: re.Match[str]) -> bool:
+    """A key/value pair is a cleartext secret only when the value is a literal.
+
+    Quoted values are treated as literal secrets. Bare values must carry a
+    non-alpha entropy signal, so type annotations (``password: str``) and plain
+    identifiers are not mistaken for credentials.
+    """
+    raw = match.group("value")
+    quoted = len(raw) >= 2 and raw[0] in "'\"" and raw[-1] == raw[0]
+    value = (raw[1:-1] if quoted else raw).strip()
+    if len(value) < 4 or value.lower() in _PLACEHOLDER_SECRETS:
+        return False
+    if quoted:
+        return True
+    return any(not char.isalpha() for char in value)
+
+
+def _always_valid(match: re.Match[str]) -> bool:
+    return True
+
+
+# Keys, longest/most-specific first, whose value may hold a cleartext secret.
+_SECRET_KEYWORDS = (
+    r"passphrase|passwd|password|pwd|"
+    r"secret[_-]?key|client[_-]?secret|secret|"
+    r"api[_-]?key|apikey|"
+    r"access[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|"
+    r"private[_-]?key|credentials?|token"
+)
+
+
+@dataclass(frozen=True)
+class _Detector:
+    """One PII/credential detector: a regex plus optional per-match validation."""
+
+    category: PIICategory
+    pattern: re.Pattern[str]
+    is_credential: bool
+    validator: Callable[[re.Match[str]], bool] = _always_valid
+
+    def found_in(self, content: str) -> bool:
+        """True when content holds at least one *valid* (non-placeholder) match."""
+        return any(self.validator(match) for match in self.pattern.finditer(content))
+
+
+_DETECTORS: tuple[_Detector, ...] = (
+    _Detector(
+        PIICategory.SSN,
+        re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+        is_credential=False,
+        validator=_valid_ssn,
     ),
-    PIICategory.API_KEY: re.compile(
-        r"\b(?:sk|pk|api|key|token|secret)[-_][A-Za-z0-9-_]{20,}\b", re.IGNORECASE
+    _Detector(
+        PIICategory.EMAIL,
+        re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
+        is_credential=False,
+        validator=_valid_email,
     ),
-    PIICategory.PRIVATE_KEY: re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
-    PIICategory.AWS_KEY: re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
-    PIICategory.JWT: re.compile(r"\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
-    PIICategory.CONNECTION_STRING: re.compile(
-        r"(?:mongodb|postgres|mysql|redis|amqp)://[^\s]+", re.IGNORECASE
+    _Detector(
+        PIICategory.PHONE,
+        # Two shapes: E.164 (`+` then 6-15 digits) or a grouped NANP-style number
+        # with mandatory separators, so plain digit runs, SSNs (3-2-4) and credit
+        # cards (4-4-4-4) are never misread as phone numbers.
+        re.compile(
+            r"(?<![\w.])"
+            r"(?:"
+            r"\+\d{6,15}"
+            r"|"
+            r"(?:\+\d{1,3}[ .\-]?)?"
+            r"(?:\(\d{3}\)[ .\-]?|\d{3}[ .\-])"
+            r"\d{3}[ .\-]\d{4}"
+            r")"
+            r"(?!\d)"
+        ),
+        is_credential=False,
+        validator=_valid_phone,
     ),
-}
+    _Detector(
+        PIICategory.CREDIT_CARD,
+        re.compile(
+            r"\b(?:"
+            r"(?:4\d{3}|5[1-5]\d{2}|6(?:011|5\d{2}))[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}"
+            r"|3[47]\d{2}[- ]?\d{6}[- ]?\d{5}"
+            r")\b"
+        ),
+        is_credential=False,
+        validator=_valid_credit_card,
+    ),
+    _Detector(
+        PIICategory.API_KEY,
+        re.compile(r"\b(?:sk|pk|api|key|token|secret)[-_][A-Za-z0-9-_]{20,}\b", re.IGNORECASE),
+        is_credential=True,
+    ),
+    _Detector(
+        PIICategory.PASSWORD,
+        # `key = value` / `key: value` secrets, tolerating a JSON key's closing
+        # quote (`"password": ...`). A separator is mandatory, so bare paths such
+        # as ``/etc/passwd`` never match.
+        re.compile(
+            r"\b(?:" + _SECRET_KEYWORDS + r")\b['\"]?\s*[:=]\s*"
+            r"(?P<value>'[^'\r\n]{4,}'|\"[^\"\r\n]{4,}\"|[^\s'\";,}]{6,})",
+            re.IGNORECASE,
+        ),
+        is_credential=True,
+        validator=_valid_secret_kv,
+    ),
+    _Detector(
+        PIICategory.PRIVATE_KEY,
+        re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
+        is_credential=True,
+    ),
+    _Detector(
+        PIICategory.AWS_KEY,
+        re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
+        is_credential=True,
+    ),
+    _Detector(
+        PIICategory.JWT,
+        re.compile(r"\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
+        is_credential=True,
+    ),
+    _Detector(
+        PIICategory.CONNECTION_STRING,
+        re.compile(r"(?:mongodb|postgres|mysql|redis|amqp)://[^\s]+", re.IGNORECASE),
+        is_credential=True,
+    ),
+)
+
+# Backward-compatible views derived from the detector table.
+_CREDENTIAL_CATEGORIES = frozenset(d.category for d in _DETECTORS if d.is_credential)
+PII_PATTERNS: dict[PIICategory, re.Pattern[str]] = {d.category: d.pattern for d in _DETECTORS}
 
 
 class PIIScanner:
@@ -71,12 +258,15 @@ class PIIScanner:
         found_pii = False
         found_credential = False
 
-        for category, pattern in PII_PATTERNS.items():
-            if pattern.search(content):
-                if category in _CREDENTIAL_CATEGORIES:
-                    found_credential = True
-                else:
-                    found_pii = True
+        for detector in _DETECTORS:
+            if not detector.found_in(content):
+                continue
+            if detector.is_credential:
+                found_credential = True
+            else:
+                found_pii = True
+            if found_pii and found_credential:
+                break
 
         if found_credential:
             cap.add("credential_exposure")

--- a/tests/unit/test_governance_pii.py
+++ b/tests/unit/test_governance_pii.py
@@ -1,0 +1,381 @@
+"""Tests for tracemill.governance.pii — the governance PIIScanner.
+
+These exercise the real regex detectors and validators (no mocks): phone-number
+and cleartext key/value secret detection, example/test-domain and documentation
+false-positive suppression, and bounded/ReDoS-safe scanning of large payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from tracemill.classify.core import Classification
+from tracemill.governance.pii import (
+    PIICategory,
+    PIIScanner,
+    _luhn_valid,
+    _valid_email,
+    _valid_ssn,
+)
+from tracemill.governance.types import (
+    EnrichmentContext,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+
+# ─── Fixtures / helpers ───────────────────────────────────────────────────────
+
+
+def _tool_call_event(args_json: str) -> ToolCallEvent:
+    return ToolCallEvent(
+        event_id="evt-001",
+        session_id="sess1",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        source_event_key="key-001",
+        span_id="span-001",
+        tool_name="bash",
+        server_namespace=None,
+        tool_args_json=args_json,
+        source_event_id=None,
+    )
+
+
+def _tool_result_event(payload_json: str | None) -> ToolResultEvent:
+    return ToolResultEvent(
+        event_id="evt-002",
+        session_id="sess1",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        source_event_key="key-002",
+        span_id="span-001",
+        tool_name="bash",
+        server_namespace=None,
+        result_payload_json=payload_json,
+        result_status="success",
+        pre_call_event_id="evt-001",
+    )
+
+
+def _ctx(event, *, network: bool = False) -> EnrichmentContext:
+    capability = frozenset({"network_outbound"}) if network else frozenset()
+    classification = Classification(
+        mechanism="shell.execute", effect="read_only", capability=capability
+    )
+    return EnrichmentContext(
+        event=event,
+        base_classification=classification,
+        command_analysis=None,
+        session_state=None,
+        mcp_profiles=None,
+        project_root=None,
+        engine="shell",
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+def _scan_args(args: dict, *, network: bool = False) -> tuple[set[str], set[str]]:
+    """Scan a tool-call event whose args are ``json.dumps(args)``."""
+    cap: set[str] = set()
+    struct: set[str] = set()
+    PIIScanner().scan(_ctx(_tool_call_event(json.dumps(args)), network=network), cap, struct)
+    return cap, struct
+
+
+def _scan_raw(text: str) -> tuple[set[str], set[str]]:
+    """Scan a tool-call event whose raw args string is ``text`` (not re-encoded)."""
+    cap: set[str] = set()
+    struct: set[str] = set()
+    PIIScanner().scan(_ctx(_tool_call_event(text)), cap, struct)
+    return cap, struct
+
+
+# ─── Phone-number detection ───────────────────────────────────────────────────
+
+
+class TestPhoneDetection:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "call 212-867-5309 now",  # dashed
+            "reach (415) 867-5309 today",  # parenthesized area code
+            "fax 415.867.5309",  # dotted
+            "phone 415 867 5309",  # spaced
+            "ring +1 415 867 5309",  # international, spaced
+            "dial +1-212-867-5309",  # international, dashed
+            "sms +14158675309",  # E.164 continuous
+        ],
+    )
+    def test_common_formats_flag_pii(self, text):
+        cap, _ = _scan_args({"note": text})
+        assert "pii_exposure" in cap, text
+
+    def test_phone_is_not_a_credential(self):
+        cap, _ = _scan_args({"note": "call 212-867-5309"})
+        assert "credential_exposure" not in cap
+
+    def test_plain_digit_run_is_not_a_phone(self):
+        # A bare 10-digit run (id, counter, timestamp) must not over-match.
+        cap, _ = _scan_args({"id": "4158675309"})
+        assert cap == set()
+
+    def test_ssn_shape_is_not_a_phone(self):
+        # 3-2-4 grouping is an SSN, never a 3-3-4 phone number.
+        cap, _ = _scan_args({"ref": "reference 123-45-6789"})
+        assert "pii_exposure" in cap  # flagged as SSN...
+        # ...but the phone detector itself must not claim it (no double reason).
+        assert PIICategory.PHONE not in _detected_categories("reference 123-45-6789")
+
+    def test_credit_card_shape_is_not_a_phone(self):
+        # 4-4-4-4 grouping must not be chopped into a phone match.
+        assert PIICategory.PHONE not in _detected_categories("4111 1111 1111 1111")
+
+    def test_fictional_555_0100_range_suppressed(self):
+        # NANP reserves 555-0100..555-0199 for fiction/documentation.
+        cap, _ = _scan_args({"note": "call (212) 555-0143 for the demo"})
+        assert cap == set()
+
+    def test_real_555_number_still_flags(self):
+        # 555 exchange outside the 01xx reserved block is a normal number.
+        cap, _ = _scan_args({"note": "call 212-555-7777"})
+        assert "pii_exposure" in cap
+
+    def test_phone_to_network_tool_is_tainted_flow(self):
+        cap, struct = _scan_args({"note": "exfil 212-867-5309"}, network=True)
+        assert "pii_exposure" in cap
+        assert "tainted_flow" in struct
+
+
+# ─── Cleartext password / key-value secret detection ──────────────────────────
+
+
+class TestSecretKeyValue:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "export PASSWORD=hunter2",
+            "password=P@ssw0rd",
+            "secret: s3cr3tValue",
+            "api_key=sk_live_9a8b7c6d5e",
+            "apikey = 0123456789abcdef",
+            "access_token=abc123def456",
+            "refresh_token: rt_9a8b7c6d5e4f",
+            "client_secret=zxy987wvu654",
+        ],
+    )
+    def test_key_value_secret_flags_credential(self, text):
+        cap, _ = _scan_args({"cmd": text})
+        assert "credential_exposure" in cap, text
+
+    def test_json_quoted_password_flags(self):
+        cap, _ = _scan_args({"password": "P@ssw0rd!"})
+        assert "credential_exposure" in cap
+
+    def test_json_numeric_secret_flags(self):
+        cap, _ = _scan_args({"api_key": 12345678})
+        assert "credential_exposure" in cap
+
+    def test_etc_passwd_path_is_not_a_secret(self):
+        # `/etc/passwd` has no `=`/`:` value, so it must never match.
+        cap, _ = _scan_args({"command": "cat /etc/passwd | grep root"})
+        assert cap == set()
+
+    def test_type_annotation_is_not_a_secret(self):
+        # `password: str` is a type hint, not a cleartext credential.
+        cap, _ = _scan_args({"code": "def login(user: str, password: str) -> bool: ..."})
+        assert "credential_exposure" not in cap
+
+    def test_placeholder_null_value_is_not_a_secret(self):
+        cap, _ = _scan_args({"config": "password: null"})
+        assert cap == set()
+
+    def test_quoted_placeholder_value_is_not_a_secret(self):
+        cap, _ = _scan_raw('{"config": "password=\\"changeme\\""}')
+        assert cap == set()
+
+    def test_empty_value_is_not_a_secret(self):
+        cap, _ = _scan_args({"config": "password="})
+        assert cap == set()
+
+    def test_pagination_token_is_not_a_secret(self):
+        # `next_token`/`page_token` are pagination cursors, not auth tokens.
+        cap, _ = _scan_args({"config": "next_token: abcdef123456"})
+        assert cap == set()
+
+
+# ─── Example / test-domain and documentation false-positive suppression ───────
+
+
+class TestFalsePositiveSuppression:
+    def test_real_email_flags(self):
+        cap, _ = _scan_args({"to": "alice@company.com"})
+        assert "pii_exposure" in cap
+
+    @pytest.mark.parametrize(
+        "email",
+        [
+            "ops@example.com",
+            "user@example.org",
+            "admin@example.net",
+            "a@mail.example.com",  # subdomain of a reserved SLD
+            "svc@service.test",
+            "x@host.invalid",
+            "root@internal.localhost",
+            "demo@widgets.example",
+        ],
+    )
+    def test_reserved_domains_suppressed(self, email):
+        cap, _ = _scan_args({"to": email})
+        assert cap == set(), email
+
+    def test_valid_ssn_flags(self):
+        cap, _ = _scan_args({"x": "SSN 123-45-6789"})
+        assert "pii_exposure" in cap
+
+    @pytest.mark.parametrize(
+        "ssn",
+        [
+            "000-12-3456",  # area 000 never issued
+            "666-12-3456",  # area 666 never issued
+            "900-12-3456",  # area 900-999 never issued
+            "123-00-6789",  # group 00 never issued
+            "123-45-0000",  # serial 0000 never issued
+        ],
+    )
+    def test_invalid_ssn_suppressed(self, ssn):
+        cap, _ = _scan_args({"x": f"id {ssn}"})
+        assert cap == set(), ssn
+
+    def test_luhn_valid_cards_flag(self):
+        assert "pii_exposure" in _scan_args({"x": "card 4111 1111 1111 1111"})[0]  # Visa
+        assert "pii_exposure" in _scan_args({"x": "amex 3782 822463 10005"})[0]  # Amex
+
+    @pytest.mark.parametrize(
+        "card",
+        [
+            "4111 1111 1111 1112",  # fails Luhn
+            "1234 5678 9012 3456",  # documentation placeholder, fails Luhn
+        ],
+    )
+    def test_luhn_invalid_cards_suppressed(self, card):
+        cap, _ = _scan_args({"x": card})
+        assert cap == set(), card
+
+
+# ─── Validator units (pure functions) ─────────────────────────────────────────
+
+
+class TestValidators:
+    def test_luhn(self):
+        assert _luhn_valid("4111111111111111") is True
+        assert _luhn_valid("378282246310005") is True
+        assert _luhn_valid("4111111111111112") is False
+        assert _luhn_valid("123456") is False  # too short
+
+    def test_email_validator_direct(self):
+        import re
+
+        pat = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b")
+        assert _valid_email(pat.search("a@company.com")) is True
+        assert _valid_email(pat.search("a@example.com")) is False
+
+    def test_ssn_validator_direct(self):
+        import re
+
+        pat = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+        assert _valid_ssn(pat.search("123-45-6789")) is True
+        assert _valid_ssn(pat.search("000-45-6789")) is False
+
+
+# ─── Result-payload path and non-regression of existing categories ───────────
+
+
+class TestScanSurfaceAndRegression:
+    def test_tool_result_payload_is_scanned(self):
+        cap: set[str] = set()
+        struct: set[str] = set()
+        event = _tool_result_event(json.dumps({"body": "contact bob@company.com"}))
+        PIIScanner().scan(_ctx(event), cap, struct)
+        assert "pii_exposure" in cap
+
+    def test_missing_result_payload_is_safe(self):
+        cap: set[str] = set()
+        struct: set[str] = set()
+        PIIScanner().scan(_ctx(_tool_result_event(None)), cap, struct)
+        assert cap == set()
+        assert struct == set()
+
+    def test_clean_content_flags_nothing(self):
+        cap, struct = _scan_args({"command": "echo hello && ls -la"})
+        assert cap == set()
+        assert struct == set()
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",  # api key token
+            "-----BEGIN RSA PRIVATE KEY-----",  # private key
+            "AKIAIOSFODNN7EXAMPLE",  # aws access key id
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",  # jwt
+            "mongodb://user:pass@host:27017/db",  # connection string
+        ],
+    )
+    def test_existing_credential_categories_still_flag(self, text):
+        cap, _ = _scan_args({"data": text})
+        assert "credential_exposure" in cap, text
+
+
+# ─── Large-payload performance / ReDoS safety ─────────────────────────────────
+
+
+class TestPerformanceAndReDoS:
+    def test_large_payload_scans_in_bounded_time(self):
+        # ~800 KB of benign, token-dense content. Linear scanning finishes in
+        # well under a second; catastrophic backtracking would take many seconds.
+        payload = json.dumps({"log": ("commit a1b2c3d4 wrote path/to/file for user data " * 16000)})
+        _scan_raw(payload)  # warm up caches / imports
+        start = time.perf_counter()
+        _scan_raw(payload)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 5.0, f"scan took {elapsed:.3f}s (possible backtracking)"
+
+    @pytest.mark.parametrize(
+        "adversarial",
+        [
+            pytest.param("b" + "a" * 60000 + "@" + "a" * 60000, id="email-no-tld"),
+            pytest.param("a@" * 30000, id="many-at-signs"),
+            pytest.param("1" * 80000, id="long-digit-run"),
+            pytest.param("password=" + "a" * 40000, id="long-secret-value"),
+            pytest.param("mongodb://" + "x" * 40000, id="long-conn-string"),
+        ],
+    )
+    def test_adversarial_inputs_do_not_backtrack(self, adversarial):
+        payload = json.dumps({"x": adversarial})
+        start = time.perf_counter()
+        _scan_raw(payload)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 2.0, f"adversarial scan took {elapsed:.3f}s"
+
+    def test_scan_time_scales_roughly_linearly(self):
+        def timed(repeat: int) -> float:
+            payload = json.dumps({"text": "lorem ipsum dolor sit amet " * repeat})
+            _scan_raw(payload)  # warm up
+            start = time.perf_counter()
+            _scan_raw(payload)
+            return time.perf_counter() - start
+
+        small = timed(4000)
+        large = timed(16000)  # 4x the input
+        # Linear scaling predicts ~4x; allow generous slack for timer noise but
+        # catch super-linear (quadratic/exponential) blow-ups.
+        assert large < small * 12 + 0.10, f"small={small:.4f}s large={large:.4f}s"
+
+
+def _detected_categories(content: str) -> set[PIICategory]:
+    """Introspect which detectors (by category) fire on raw content."""
+    from tracemill.governance.pii import _DETECTORS
+
+    return {d.category for d in _DETECTORS if d.found_in(content)}


### PR DESCRIPTION
## Summary

Closes the remaining PII scanner gaps in `src/tracemill/governance/pii.py` (epic #7). All work is folded into this PR — no follow-ups.

Closes #12

## What changed

- **Phone-number detection** — E.164 (`+` then 6–15 digits) and grouped NANP formats with **mandatory internal separators**, so plain digit runs, SSNs (3-2-4) and credit cards (4-4-4-4) are never misread as phones. The NANP `555-0100..555-0199` fictional range is suppressed.
- **Cleartext key-value secret detection** — `password=`, `secret:`, `api_key=`, including JSON-quoted keys (`"password": "…"`). An explicit `:`/`=` assignment is required, so bare paths like `/etc/passwd` never match; unquoted values need a non-alpha entropy signal, so type hints (`password: str`) and pagination cursors (`next_token`) are not mistaken for credentials.
- **Documentation / test false-positive suppression** via per-match validators:
  - RFC 2606 / RFC 6761 reserved email domains (`example.com`, `*.test`, `localhost`, …).
  - Structurally-invalid SSNs the SSA never issues (area `000/666/9xx`, group `00`, serial `0000`).
  - Non-Luhn credit-card candidates (documentation placeholders).
- **ReDoS-safe** — every regex uses bounded, non-nested quantifiers. Added performance coverage asserting bounded/near-linear scan time on large and adversarial payloads.

## Design

Refactored the flat `PII_PATTERNS` table into a SOLID `_Detector` dataclass model (regex + optional per-match validator). `PII_PATTERNS` and `_CREDENTIAL_CATEGORIES` are retained as backward-compatible derived views; `PIIScanner.scan()` keeps its signature and label behavior.

## Tests

New `tests/unit/test_governance_pii.py` covers every phone/secret format, each false-positive class, validator units, the result-payload path, non-regression of existing credential categories, and large-payload / adversarial-input performance bounds.

- Full suite: **1993 passed, 4 skipped** (baseline was ~1927 passed; +66 new tests, zero regressions).
- `ruff check` and `ruff format --check`: clean repo-wide.

Scope was limited strictly to `pii.py` and its dedicated test file.