### PR TITLE
Enforce RiskModifiers caps on freeze and set source_labels fresh (#11)

### DIFF
--- a/src/tracemill/governance/labeler.py
+++ b/src/tracemill/governance/labeler.py
@@ -1,7 +1,13 @@
 """GovernanceLabeler — Phase 2 of the governance pipeline.
 
-Side-effect-free enrichment. Accumulates capability/structure/source_labels
-on top of existing Classification dimensions. Returns GovernanceResult.
+Side-effect-free enrichment. ``capability`` and ``structure`` are unioned on
+top of the existing Classification dimensions (labels are cumulative). By
+contrast ``source_labels`` are *dynamic* IFC clearance labels — they are
+computed FRESH for the current event and replace (never union with) whatever
+the base classification carried, matching their exclusion from the canonical
+action hash. Governance risk bonuses are accumulated through
+``_RiskModifiersBuilder`` and bounded to their documented caps on ``freeze()``.
+Returns GovernanceResult.
 """
 
 from __future__ import annotations
@@ -34,6 +40,78 @@ class GovernanceResult:
     integrity_deferred_writes: tuple = ()  # tuple[IntegrityWrite, ...] — committed by pipeline after finalization
 
 
+def _bounded(value: int, cap: int) -> int:
+    """Clamp ``value`` to the inclusive range ``[0, cap]``."""
+    if value < 0:
+        return 0
+    return cap if value > cap else value
+
+
+class _RiskModifiersBuilder:
+    """Accumulator that bounds governance risk bonuses to their documented caps.
+
+    Each governance signal contributes additively to a modifier; ``freeze()``
+    bounds every accumulated value to the cap documented on the corresponding
+    :class:`~tracemill.governance.risk_wrapper.RiskModifiers` field, then
+    returns an immutable ``RiskModifiers``. Centralizing the caps here means no
+    individual accumulation site can emit a value that violates the
+    ``RiskModifiers`` contract — e.g. the drift detector may return a phase
+    bonus up to 25, but ``phase_drift_bonus`` is documented "up to 20", so the
+    ceiling is enforced exactly once, on freeze.
+    """
+
+    # Documented caps — mirror the RiskModifiers field docstrings.
+    PHASE_DRIFT_CAP = 20  # phase_drift_bonus: +10 per anomaly, up to 20
+    MCP_DRIFT_CAP = 40  # mcp_drift_bonus: severity-weighted, up to 40
+    IFC_VIOLATIONS_CAP = 3  # ifc_violations: +10 per violation up to 30 => 3 counts
+    INTEGRITY_CAP = 10  # integrity_bonus: +10 when integrity_unverified
+    BUDGET_CAP = 5  # budget_bonus: +5 under budget pressure
+
+    __slots__ = ("_phase_drift", "_mcp_drift", "_ifc_violations", "_integrity", "_budget")
+
+    def __init__(self) -> None:
+        self._phase_drift = 0
+        self._mcp_drift = 0
+        self._ifc_violations = 0
+        self._integrity = 0
+        self._budget = 0
+
+    def add_phase_drift(self, bonus: int) -> None:
+        """Accumulate a phase-drift bonus (bounded to the cap on freeze)."""
+        self._phase_drift += bonus
+
+    def add_mcp_drift(self, bonus: int) -> None:
+        """Accumulate an MCP fingerprint-drift bonus (bounded on freeze)."""
+        self._mcp_drift += bonus
+
+    def add_ifc_violation(self, count: int = 1) -> None:
+        """Record IFC violation(s); the running count is bounded on freeze."""
+        self._ifc_violations += count
+
+    def set_integrity_unverified(self) -> None:
+        """Flag content integrity as unverified (fixed integrity bonus)."""
+        self._integrity = self.INTEGRITY_CAP
+
+    def set_budget_pressure(self) -> None:
+        """Flag budget pressure (fixed budget bonus)."""
+        self._budget = self.BUDGET_CAP
+
+    def freeze(self) -> "RiskModifiers":
+        """Bound every accumulated modifier to its cap and return ``RiskModifiers``.
+
+        Pure: does not mutate the builder, so it may be called more than once.
+        """
+        from tracemill.governance.risk_wrapper import RiskModifiers
+
+        return RiskModifiers(
+            phase_drift_bonus=_bounded(self._phase_drift, self.PHASE_DRIFT_CAP),
+            mcp_drift_bonus=_bounded(self._mcp_drift, self.MCP_DRIFT_CAP),
+            ifc_violations=_bounded(self._ifc_violations, self.IFC_VIOLATIONS_CAP),
+            integrity_bonus=_bounded(self._integrity, self.INTEGRITY_CAP),
+            budget_bonus=_bounded(self._budget, self.BUDGET_CAP),
+        )
+
+
 class GovernanceLabeler:
     """Phase 2 labeler. Stateless — all state comes via EnrichmentContext."""
 
@@ -55,11 +133,10 @@ class GovernanceLabeler:
 
     def label(self, ctx: "EnrichmentContext") -> GovernanceResult:
         """Enrich classification with governance labels. Side-effect-free."""
-        from tracemill.governance.risk_wrapper import RiskModifiers
-
         cap: set[str] = set()
         struct: set[str] = set()
         src_labels: set[str] = set()
+        modifiers = _RiskModifiersBuilder()
 
         # PII scanning
         if self._pii:
@@ -76,18 +153,16 @@ class GovernanceLabeler:
         # MCP fingerprint drift — scan returns typed MCPScanResult
         mcp_alerts: tuple = ()
         mcp_deferred_writes: tuple = ()
-        mcp_bonus = 0
         if self._mcp:
             scan_result = self._mcp.scan(ctx, cap)
             mcp_alerts = scan_result.alerts
             mcp_deferred_writes = scan_result.deferred_writes
             severity_map = {"critical": 20, "warning": 10, "info": 5}
-            mcp_bonus = min(40, sum(severity_map[a.severity] for a in mcp_alerts))
+            modifiers.add_mcp_drift(sum(severity_map[a.severity] for a in mcp_alerts))
             if mcp_alerts:
                 struct.add("semantic_drift")
 
         # IFC source labels
-        ifc_violations = 0
         if self._ifc and ctx.session_state:
             self._ifc_label_only(ctx, src_labels)
             all_caps = ctx.base_classification.capability | frozenset(cap)
@@ -99,49 +174,42 @@ class GovernanceLabeler:
             ]
             if prior_taints and ctx.base_classification.effect in ("mutating", "destructive"):
                 struct.add("ifc_violation")
-                ifc_violations = 1
+                modifiers.add_ifc_violation()
             elif any("ifc:" in l for l in src_labels) and "network_outbound" in all_caps:
                 struct.add("ifc_violation")
-                ifc_violations = 1
+                modifiers.add_ifc_violation()
 
         # Phase drift — returns typed DriftAssessment with risk_bonus field
         drift_result: "DriftAssessment | None" = None
-        phase_bonus = 0
         if self._drift and ctx.session_state:
             drift_result = self._drift.detect(ctx, ctx.session_state, cap)
             if drift_result:
-                phase_bonus = drift_result.risk_bonus
+                modifiers.add_phase_drift(drift_result.risk_bonus)
                 if drift_result.anomaly:
                     struct.add("phase_anomaly")
 
         # Budget pressure check (read-only from snapshot — no thresholds dependency)
-        budget_bonus = 0
         if ctx.session_state and ctx.session_state.budget.pressure:
             cap.add("budget_pressure")
-            budget_bonus = 5
+            modifiers.set_budget_pressure()
 
-        # Integrity bonus
-        integrity_bonus = 10 if "integrity_unverified" in cap else 0
+        # Integrity bonus — surfaced by the integrity check above via the cap label.
+        if "integrity_unverified" in cap:
+            modifiers.set_integrity_unverified()
 
-        # Merge labels into classification
+        # Merge labels into classification. capability/structure are cumulative
+        # (unioned with the base); source_labels are dynamic IFC clearance labels
+        # set FRESH for this event (never carried forward from the base).
         enriched = dataclasses.replace(
             ctx.base_classification,
             capability=ctx.base_classification.capability | frozenset(cap),
             structure=ctx.base_classification.structure | frozenset(struct),
-            source_labels=ctx.base_classification.source_labels | frozenset(src_labels),
-        )
-
-        modifiers = RiskModifiers(
-            phase_drift_bonus=phase_bonus,
-            mcp_drift_bonus=mcp_bonus,
-            ifc_violations=ifc_violations,
-            integrity_bonus=integrity_bonus,
-            budget_bonus=budget_bonus,
+            source_labels=frozenset(src_labels),
         )
 
         return GovernanceResult(
             classification=enriched,
-            risk_modifiers=modifiers,
+            risk_modifiers=modifiers.freeze(),
             drift_result=drift_result,
             mcp_alerts=mcp_alerts,
             mcp_deferred_writes=mcp_deferred_writes,

--- a/tests/unit/test_governance_labeler.py
+++ b/tests/unit/test_governance_labeler.py
@@ -1,0 +1,591 @@
+"""Tests for GovernanceLabeler (Phase 2) — issue #11 gap closure.
+
+Covers the three still-open items from the issue:
+
+* ``_RiskModifiersBuilder.freeze()`` bounding every risk modifier to its
+  documented cap (the drift detector may emit up to 25 phase points, but
+  ``phase_drift_bonus`` is capped at 20 — the ceiling is enforced on freeze).
+* ``source_labels`` set FRESH per event (never unioned with the base
+  classification), while ``capability``/``structure`` stay cumulative.
+* Mock-scanner call-order / input-passing invariants, plus the MCP capability
+  and structure union behaviour.
+
+Scanners are mocked here; the real ``pii``/``ifc``/``mcp_drift``/``drift``
+modules are exercised by their own suites and are owned by other sessions.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from tracemill.classify.core import Classification
+from tracemill.governance.drift import DriftAssessment
+from tracemill.governance.labeler import (
+    GovernanceLabeler,
+    GovernanceResult,
+    _bounded,
+    _RiskModifiersBuilder,
+)
+from tracemill.governance.mcp_drift import MCPIntegrityAlert, MCPScanResult
+from tracemill.governance.risk_wrapper import RiskModifiers
+from tracemill.governance.state import BudgetSnapshot, SessionStateSnapshot, TaintEntry
+from tracemill.governance.types import EnrichmentContext, ToolCallEvent
+
+_TS = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+# ─────────────────────────────── helpers ────────────────────────────────
+
+
+def _event(source_event_key="evt-key", tool_name="bash", args='{"command": "ls"}'):
+    return ToolCallEvent(
+        event_id="evt-001",
+        session_id="sess1",
+        timestamp=_TS,
+        source_event_key=source_event_key,
+        span_id="span-001",
+        tool_name=tool_name,
+        server_namespace=None,
+        tool_args_json=args,
+        source_event_id=None,
+    )
+
+
+def _snapshot(*, pressure=False, taints=()):
+    return SessionStateSnapshot(
+        budget=BudgetSnapshot(pressure=pressure),
+        taint_ledger=tuple(taints),
+    )
+
+
+def _taint(clearance="confidential", source_event_key="other-key"):
+    return TaintEntry(
+        event_id="prior-evt",
+        source_event_key=source_event_key,
+        clearance=clearance,
+        source="file_read",
+        payload_pointer="ptr",
+    )
+
+
+def _ctx(
+    *,
+    classification=None,
+    session_state=None,
+    event=None,
+    engine="shell",
+):
+    if classification is None:
+        classification = Classification(mechanism="shell.execute", effect="read_only")
+    return EnrichmentContext(
+        event=event or _event(),
+        base_classification=classification,
+        command_analysis=None,
+        session_state=session_state,
+        mcp_profiles=None,
+        project_root=None,
+        engine=engine,
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+def _drift(risk_bonus, anomaly=None):
+    return DriftAssessment(
+        phase_window=("build",),
+        baseline_distribution=(),
+        current_phase="build",
+        anomaly_score=0.5,
+        risk_bonus=risk_bonus,
+        transitions=1,
+        anomaly=(risk_bonus > 0) if anomaly is None else anomaly,
+    )
+
+
+def _alert(severity):
+    return MCPIntegrityAlert(
+        tool_name="read_file",
+        server="mcp-fs",
+        alert_type="schema_change",
+        previous="{}",
+        current='{"x": 1}',
+        severity=severity,
+        timestamp=_TS,
+    )
+
+
+# ─────────────────────── _bounded / builder units ───────────────────────
+
+
+class TestBounded:
+    def test_within_range_passthrough(self):
+        assert _bounded(7, 20) == 7
+
+    def test_clamps_to_cap(self):
+        assert _bounded(25, 20) == 20
+
+    def test_at_cap_exact(self):
+        assert _bounded(20, 20) == 20
+
+    def test_negative_floors_to_zero(self):
+        assert _bounded(-3, 20) == 0
+
+    def test_zero_cap(self):
+        assert _bounded(5, 0) == 0
+
+
+class TestRiskModifiersBuilder:
+    def test_default_freeze_all_zero(self):
+        mods = _RiskModifiersBuilder().freeze()
+        assert mods == RiskModifiers()
+        assert (
+            mods.phase_drift_bonus,
+            mods.mcp_drift_bonus,
+            mods.ifc_violations,
+            mods.integrity_bonus,
+            mods.budget_bonus,
+        ) == (0, 0, 0, 0, 0)
+
+    def test_freeze_returns_immutable_riskmodifiers(self):
+        mods = _RiskModifiersBuilder().freeze()
+        assert isinstance(mods, RiskModifiers)
+        with pytest.raises(Exception):
+            mods.phase_drift_bonus = 99  # frozen dataclass
+
+    def test_phase_drift_under_cap_passthrough(self):
+        b = _RiskModifiersBuilder()
+        b.add_phase_drift(15)
+        assert b.freeze().phase_drift_bonus == 15
+
+    def test_phase_drift_capped_at_20(self):
+        # The drift detector may legitimately return up to 25 points; the
+        # documented phase_drift_bonus cap is 20. Freeze enforces it.
+        b = _RiskModifiersBuilder()
+        b.add_phase_drift(25)
+        assert b.freeze().phase_drift_bonus == 20
+
+    def test_phase_drift_accumulates_then_caps(self):
+        b = _RiskModifiersBuilder()
+        b.add_phase_drift(12)
+        b.add_phase_drift(12)
+        assert b.freeze().phase_drift_bonus == 20
+
+    def test_mcp_drift_under_cap(self):
+        b = _RiskModifiersBuilder()
+        b.add_mcp_drift(30)
+        assert b.freeze().mcp_drift_bonus == 30
+
+    def test_mcp_drift_capped_at_40(self):
+        b = _RiskModifiersBuilder()
+        b.add_mcp_drift(100)
+        assert b.freeze().mcp_drift_bonus == 40
+
+    def test_ifc_violations_capped_at_3(self):
+        b = _RiskModifiersBuilder()
+        for _ in range(5):
+            b.add_ifc_violation()
+        assert b.freeze().ifc_violations == 3
+
+    def test_ifc_violations_single(self):
+        b = _RiskModifiersBuilder()
+        b.add_ifc_violation()
+        assert b.freeze().ifc_violations == 1
+
+    def test_integrity_bonus_fixed_ten(self):
+        b = _RiskModifiersBuilder()
+        b.set_integrity_unverified()
+        assert b.freeze().integrity_bonus == 10
+
+    def test_budget_bonus_fixed_five(self):
+        b = _RiskModifiersBuilder()
+        b.set_budget_pressure()
+        assert b.freeze().budget_bonus == 5
+
+    def test_negative_phase_drift_floored(self):
+        b = _RiskModifiersBuilder()
+        b.add_phase_drift(-5)
+        assert b.freeze().phase_drift_bonus == 0
+
+    def test_freeze_is_pure_and_repeatable(self):
+        b = _RiskModifiersBuilder()
+        b.add_phase_drift(25)
+        b.add_mcp_drift(50)
+        first = b.freeze()
+        second = b.freeze()
+        assert first == second  # freeze does not mutate the accumulator
+        # further accumulation still works after a freeze
+        b.add_phase_drift(0)
+        assert b.freeze() == first
+
+    def test_documented_caps_match_field_docs(self):
+        # Caps are the source of truth for the RiskModifiers contract.
+        assert _RiskModifiersBuilder.PHASE_DRIFT_CAP == 20
+        assert _RiskModifiersBuilder.MCP_DRIFT_CAP == 40
+        assert _RiskModifiersBuilder.IFC_VIOLATIONS_CAP == 3
+        assert _RiskModifiersBuilder.INTEGRITY_CAP == 10
+        assert _RiskModifiersBuilder.BUDGET_CAP == 5
+
+
+# ─────────────────── caps enforced end-to-end via label() ────────────────
+
+
+class TestLabelerCapEnforcement:
+    def test_phase_drift_over_cap_is_bounded_by_label(self):
+        drift = MagicMock()
+        drift.detect.return_value = _drift(risk_bonus=25)  # over the 20 cap
+        labeler = GovernanceLabeler(drift_detector=drift)
+
+        result = labeler.label(_ctx(session_state=_snapshot()))
+
+        assert result.risk_modifiers.phase_drift_bonus == 20
+        assert "phase_anomaly" in result.classification.structure
+
+    def test_phase_drift_under_cap_passthrough_via_label(self):
+        drift = MagicMock()
+        drift.detect.return_value = _drift(risk_bonus=10)
+        labeler = GovernanceLabeler(drift_detector=drift)
+
+        result = labeler.label(_ctx(session_state=_snapshot()))
+
+        assert result.risk_modifiers.phase_drift_bonus == 10
+
+    def test_mcp_bonus_capped_at_40_via_label(self):
+        mcp = MagicMock()
+        # 3 critical alerts => 60 raw points, capped to 40 on freeze.
+        mcp.scan.return_value = MCPScanResult(
+            alerts=(_alert("critical"), _alert("critical"), _alert("critical")),
+            is_new=False,
+            deferred_writes=(),
+        )
+        labeler = GovernanceLabeler(mcp_scanner=mcp)
+
+        result = labeler.label(_ctx())
+
+        assert result.risk_modifiers.mcp_drift_bonus == 40
+
+
+# ───────────────────── source_labels set fresh, not unioned ──────────────
+
+
+class TestSourceLabelsFresh:
+    def test_base_source_labels_dropped_when_no_ifc(self):
+        # No IFC checker => no fresh labels => source_labels must be EMPTY,
+        # not the base classification's carried-over labels.
+        base = Classification(
+            mechanism="shell.execute",
+            effect="read_only",
+            source_labels=frozenset({"preexisting", "ifc:stale"}),
+        )
+        labeler = GovernanceLabeler()
+
+        result = labeler.label(_ctx(classification=base))
+
+        assert result.classification.source_labels == frozenset()
+
+    def test_source_labels_reflect_current_taint_only(self):
+        # Fresh IFC label computed for THIS event replaces the base's stale one.
+        base = Classification(
+            mechanism="shell.execute",
+            effect="read_only",
+            source_labels=frozenset({"ifc:stale", "preexisting"}),
+        )
+        ifc = MagicMock()
+        state = _snapshot(taints=[_taint(clearance="confidential")])
+        labeler = GovernanceLabeler(ifc_checker=ifc)
+
+        result = labeler.label(_ctx(classification=base, session_state=state))
+
+        assert result.classification.source_labels == frozenset({"ifc:confidential"})
+        # label() is side-effect-free: it must NOT run the mutating IFC check.
+        ifc.check.assert_not_called()
+
+    def test_ifc_labels_use_max_clearance(self):
+        ifc = MagicMock()
+        state = _snapshot(
+            taints=[
+                _taint(clearance="internal", source_event_key="k1"),
+                _taint(clearance="secret", source_event_key="k2"),
+            ]
+        )
+        labeler = GovernanceLabeler(ifc_checker=ifc)
+
+        result = labeler.label(_ctx(session_state=state))
+
+        assert result.classification.source_labels == frozenset({"ifc:secret"})
+
+
+# ────────────── capability / structure union + MCP capability ────────────
+
+
+class TestCapabilityStructureUnion:
+    def test_capability_and_structure_are_unioned_with_base(self):
+        base = Classification(
+            mechanism="shell.execute",
+            effect="read_only",
+            capability=frozenset({"base_cap"}),
+            structure=frozenset({"base_struct"}),
+        )
+
+        def _scan(ctx, cap, struct):
+            cap.add("credential_exposure")
+            struct.add("tainted_flow")
+
+        pii = MagicMock()
+        pii.scan.side_effect = _scan
+        labeler = GovernanceLabeler(pii_scanner=pii)
+
+        result = labeler.label(_ctx(classification=base))
+
+        assert result.classification.capability == frozenset({"base_cap", "credential_exposure"})
+        assert result.classification.structure == frozenset({"base_struct", "tainted_flow"})
+
+    def test_mcp_capability_unions_and_marks_semantic_drift(self):
+        base = Classification(
+            mechanism="mcp.tool_call",
+            effect="read_only",
+            capability=frozenset({"base_cap"}),
+        )
+
+        def _scan(ctx, cap):
+            cap.add("mcp_drift")
+            return MCPScanResult(alerts=(_alert("warning"),), is_new=False, deferred_writes=())
+
+        mcp = MagicMock()
+        mcp.scan.side_effect = _scan
+        labeler = GovernanceLabeler(mcp_scanner=mcp)
+
+        result = labeler.label(_ctx(classification=base, engine="mcp"))
+
+        assert "mcp_drift" in result.classification.capability
+        assert "base_cap" in result.classification.capability
+        assert "semantic_drift" in result.classification.structure
+
+    def test_no_mcp_alerts_no_semantic_drift(self):
+        mcp = MagicMock()
+        mcp.scan.return_value = MCPScanResult(alerts=(), is_new=True, deferred_writes=())
+        labeler = GovernanceLabeler(mcp_scanner=mcp)
+
+        result = labeler.label(_ctx())
+
+        assert "semantic_drift" not in result.classification.structure
+        assert result.risk_modifiers.mcp_drift_bonus == 0
+
+
+# ─────────────── mock-scanner call-order / input invariants ──────────────
+
+
+class TestScannerInvocation:
+    def _all_scanners(self):
+        pii = MagicMock(name="pii")
+        integrity = MagicMock(name="integrity")
+        integrity.pending_writes.return_value = ()
+        mcp = MagicMock(name="mcp")
+        mcp.scan.return_value = MCPScanResult(alerts=(), is_new=True, deferred_writes=())
+        ifc = MagicMock(name="ifc")
+        drift = MagicMock(name="drift")
+        drift.detect.return_value = None
+        return pii, integrity, mcp, ifc, drift
+
+    def test_scanners_invoked_in_documented_order(self):
+        pii, integrity, mcp, ifc, drift = self._all_scanners()
+        order: list[str] = []
+        pii.scan.side_effect = lambda ctx, cap, struct: order.append("pii.scan")
+
+        def _check(ctx, cap):
+            order.append("integrity.check_event")
+
+        integrity.check_event.side_effect = _check
+
+        def _pending(ctx):
+            order.append("integrity.pending_writes")
+            return ()
+
+        integrity.pending_writes.side_effect = _pending
+
+        def _mcp_scan(ctx, cap):
+            order.append("mcp.scan")
+            return MCPScanResult(alerts=(), is_new=True, deferred_writes=())
+
+        mcp.scan.side_effect = _mcp_scan
+
+        def _detect(ctx, state, cap):
+            order.append("drift.detect")
+            return None
+
+        drift.detect.side_effect = _detect
+
+        labeler = GovernanceLabeler(
+            pii_scanner=pii,
+            integrity_verifier=integrity,
+            mcp_scanner=mcp,
+            ifc_checker=ifc,
+            drift_detector=drift,
+        )
+        labeler.label(_ctx(session_state=_snapshot()))
+
+        assert order == [
+            "pii.scan",
+            "integrity.check_event",
+            "integrity.pending_writes",
+            "mcp.scan",
+            "drift.detect",
+        ]
+
+    def test_scanners_share_one_capability_accumulator(self):
+        pii, integrity, mcp, ifc, drift = self._all_scanners()
+        labeler = GovernanceLabeler(
+            pii_scanner=pii,
+            integrity_verifier=integrity,
+            mcp_scanner=mcp,
+            ifc_checker=ifc,
+            drift_detector=drift,
+        )
+        ctx = _ctx(session_state=_snapshot())
+        labeler.label(ctx)
+
+        cap = pii.scan.call_args.args[1]
+        assert isinstance(cap, set)
+        # The very same cap set object is threaded through every scanner.
+        assert integrity.check_event.call_args.args[1] is cap
+        assert mcp.scan.call_args.args[1] is cap
+        assert drift.detect.call_args.args[2] is cap
+
+    def test_scanner_inputs_are_the_context_and_snapshot(self):
+        pii, integrity, mcp, ifc, drift = self._all_scanners()
+        labeler = GovernanceLabeler(
+            pii_scanner=pii,
+            integrity_verifier=integrity,
+            mcp_scanner=mcp,
+            ifc_checker=ifc,
+            drift_detector=drift,
+        )
+        ctx = _ctx(session_state=_snapshot())
+        labeler.label(ctx)
+
+        # ctx flows to every scanner as the first positional argument.
+        assert pii.scan.call_args.args[0] is ctx
+        assert integrity.check_event.call_args.args[0] is ctx
+        assert integrity.pending_writes.call_args.args[0] is ctx
+        assert mcp.scan.call_args.args[0] is ctx
+        # PII also receives the struct accumulator (distinct from cap).
+        assert isinstance(pii.scan.call_args.args[2], set)
+        assert pii.scan.call_args.args[2] is not pii.scan.call_args.args[1]
+        # Drift receives the session-state snapshot as its second argument.
+        assert drift.detect.call_args.args[1] is ctx.session_state
+
+    def test_label_is_side_effect_free_never_runs_mutating_ifc_check(self):
+        _, _, _, ifc, _ = self._all_scanners()
+        labeler = GovernanceLabeler(ifc_checker=ifc)
+        labeler.label(_ctx(session_state=_snapshot(taints=[_taint()])))
+        ifc.check.assert_not_called()
+
+    def test_drift_skipped_without_session_state(self):
+        drift = MagicMock()
+        labeler = GovernanceLabeler(drift_detector=drift)
+        labeler.label(_ctx(session_state=None))
+        drift.detect.assert_not_called()
+
+    def test_unconfigured_scanners_are_noop(self):
+        # Bare labeler must not raise and yields empty modifiers.
+        result = GovernanceLabeler().label(_ctx())
+        assert isinstance(result, GovernanceResult)
+        assert result.risk_modifiers == RiskModifiers()
+        assert result.mcp_alerts == ()
+        assert result.mcp_deferred_writes == ()
+        assert result.integrity_deferred_writes == ()
+
+
+# ─────────────────── MCP alert / deferred-write propagation ──────────────
+
+
+class TestMcpPropagation:
+    def test_alerts_and_deferred_writes_flow_to_result(self):
+        alerts = (_alert("info"),)
+        writes = ("w1", "w2")
+        mcp = MagicMock()
+        mcp.scan.return_value = MCPScanResult(alerts=alerts, is_new=False, deferred_writes=writes)
+        labeler = GovernanceLabeler(mcp_scanner=mcp)
+
+        result = labeler.label(_ctx())
+
+        assert result.mcp_alerts == alerts
+        assert result.mcp_deferred_writes == writes
+
+    def test_severity_weighting_sums_before_cap(self):
+        # critical(20) + warning(10) + info(5) = 35 (< 40 cap) => passthrough.
+        mcp = MagicMock()
+        mcp.scan.return_value = MCPScanResult(
+            alerts=(_alert("critical"), _alert("warning"), _alert("info")),
+            is_new=False,
+            deferred_writes=(),
+        )
+        labeler = GovernanceLabeler(mcp_scanner=mcp)
+
+        result = labeler.label(_ctx())
+
+        assert result.risk_modifiers.mcp_drift_bonus == 35
+
+
+# ──────────────────── budget / integrity / ifc bonuses ───────────────────
+
+
+class TestBonuses:
+    def test_budget_pressure_adds_capability_and_bonus(self):
+        result = GovernanceLabeler().label(_ctx(session_state=_snapshot(pressure=True)))
+        assert "budget_pressure" in result.classification.capability
+        assert result.risk_modifiers.budget_bonus == 5
+
+    def test_no_budget_pressure_no_bonus(self):
+        result = GovernanceLabeler().label(_ctx(session_state=_snapshot(pressure=False)))
+        assert "budget_pressure" not in result.classification.capability
+        assert result.risk_modifiers.budget_bonus == 0
+
+    def test_integrity_unverified_yields_bonus(self):
+        def _check(ctx, cap):
+            cap.add("integrity_unverified")
+
+        integrity = MagicMock()
+        integrity.check_event.side_effect = _check
+        integrity.pending_writes.return_value = ()
+        labeler = GovernanceLabeler(integrity_verifier=integrity)
+
+        result = labeler.label(_ctx())
+
+        assert result.risk_modifiers.integrity_bonus == 10
+
+    def test_integrity_deferred_writes_propagated(self):
+        integrity = MagicMock()
+        integrity.check_event.return_value = None
+        integrity.pending_writes.return_value = ["deferred"]
+        labeler = GovernanceLabeler(integrity_verifier=integrity)
+
+        result = labeler.label(_ctx())
+
+        assert result.integrity_deferred_writes == ("deferred",)
+
+    def test_ifc_violation_on_prior_taint_with_mutating_effect(self):
+        base = Classification(mechanism="shell.execute", effect="destructive")
+        ifc = MagicMock()
+        state = _snapshot(taints=[_taint(source_event_key="other-key")])
+        labeler = GovernanceLabeler(ifc_checker=ifc)
+
+        result = labeler.label(_ctx(classification=base, session_state=state))
+
+        assert "ifc_violation" in result.classification.structure
+        assert result.risk_modifiers.ifc_violations == 1
+
+    def test_ifc_self_taint_does_not_violate(self):
+        # Only the current event's own taint is present => no prior taint => no
+        # violation even though the effect is destructive.
+        base = Classification(mechanism="shell.execute", effect="destructive")
+        ifc = MagicMock()
+        state = _snapshot(taints=[_taint(source_event_key="evt-key")])  # == event key
+        labeler = GovernanceLabeler(ifc_checker=ifc)
+
+        result = labeler.label(
+            _ctx(classification=base, session_state=state, event=_event(source_event_key="evt-key"))
+        )
+
+        assert "ifc_violation" not in result.classification.structure
+        assert result.risk_modifiers.ifc_violations == 0


### PR DESCRIPTION
## Summary

Closes the remaining Phase 2 `GovernanceLabeler` work enumerated in issue #11. Gap-closing on an already-shipped feature; scope is confined to `src/tracemill/governance/labeler.py` and a new test file.

### Changes

- **`_RiskModifiersBuilder.freeze()` enforcing caps.** New private accumulator whose `freeze()` bounds every governance risk modifier to its documented `RiskModifiers` cap — phase_drift **20**, mcp_drift **40**, ifc_violations count **3**, integrity **10**, budget **5**. `label()` now accumulates bonuses through the builder instead of constructing `RiskModifiers` inline, so cap enforcement lives in exactly one place. This also fixes a latent gap: `drift.py` can emit a phase `risk_bonus` up to 25, which previously flowed through uncapped past the documented "up to 20" ceiling — `freeze()` now clamps it.

- **`source_labels` set fresh per event.** Changed from `base_classification.source_labels | frozenset(src_labels)` to `frozenset(src_labels)`. `source_labels` are dynamic IFC clearance labels (excluded from the canonical action hash), so they must reflect the current event rather than accumulate across events. `capability` and `structure` remain cumulative (unioned with the base).

### Tests

New `tests/unit/test_governance_labeler.py` (42 tests):
- `_bounded` / `_RiskModifiersBuilder` cap-enforcement units (including phase 25→20, mcp sum→40, freeze purity/idempotency, negative flooring).
- End-to-end cap clamping through `label()`.
- `source_labels`-fresh regression (base labels dropped; fresh IFC label reflects current max-clearance taint).
- Capability/structure union + MCP-capability coverage (`mcp_drift`/`semantic_drift`), plus severity weighting and alert/deferred-write propagation.
- Mock-scanner call-order/input invariants: scanners invoked in order `pii → integrity.check_event → integrity.pending_writes → mcp.scan → drift.detect`; one shared `cap` accumulator threaded through all scanners; drift receives the session snapshot; and `label()` never invokes the mutating `ifc.check` (side-effect-free invariant).

Scanners are mocked; `pii.py`/`ifc.py` and other governance modules are untouched.

### Verification

- Full suite: **1969 passed, 4 skipped** (baseline 1927 + 42 new tests, no regressions).
- `ruff check .` clean and `ruff format --check .` clean (pinned `ruff==0.15.20`).

Closes #11