### PR TITLE
EventBus subscribe() + opt-in pipeline self-metrics (#47, #48)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -913,24 +913,37 @@ No separate `tracemill init` command needed.
 
 ## §14 — Telemetry / OTEL
 
-🚧 **Partial** — span export is implemented; the `telemetry/` package (self-metrics) is still an empty stub.
+✅ **Implemented** — both export *and* self-observability are delivered, with **no telemetry SDK dependency** on either side.
 
 **Done:**
 - `OtelSink` (`OtelExporterSink`) exports events / spans / usage / title-updates to an OpenTelemetry collector via **OTLP/HTTP JSON**. It is intentionally hand-rolled with **no `opentelemetry-sdk` dependency** (simplified OTLP JSON, not protobuf) to stay lightweight — this is a settled design decision, not a gap.
 - Span generation from tool-call pairs (enricher pairing + `TelemetrySpan` + `OtelExporterSink._event_to_span`).
-
-**Planned (tracked by #48):**
-- Pipeline-level **self-metrics** (events/sec, enrichment latency, sink write time): opt-in and near-zero-footprint by default, surfaced through a metrics hook on `EventPipeline` rather than a global registry. Must not pull in a heavyweight metrics framework as a hard dependency.
+- Pipeline-level **self-metrics** (`tracemill.telemetry`): `PipelineMetrics` is an opt-in, in-process accumulator attached via `EventPipeline(..., metrics=PipelineMetrics())`. It records throughput (events/sec), enrichment latency, per-sink write time, and dropped / failed-sink counts, read back as an immutable `MetricsSnapshot` (surfaced on `flush()` / `close()`, and logged at DEBUG on flush).
+  - **Disabled path is a true no-op.** Without a `metrics=` instance the hot path makes **no timing calls and no metrics allocations** — every instrumentation site is guarded on `metrics is not None`, and the sink fan-out takes its original unwrapped path. This is enforced by a test that spies on `time.perf_counter` and asserts zero calls on the disabled path.
+  - **No metrics-framework dependency.** Deliberately **no `opentelemetry-sdk`** and **no `prometheus`** — no background threads, no parallel transport, no unbounded accumulation (state is bounded: scalar counters plus one entry per sink). This mirrors the hand-rolled OTLP decision above: tracemill's self-observability is a plain accumulator, not a vendored SDK.
 
 ---
 
 ## §15 — EventBus
 
-✅ **Effectively delivered** via the sink model — no separate bus module is needed.
+✅ **Delivered** via the sink model plus a subscribe convenience — no separate bus module is needed.
 
-An in-process consumer can react to events without implementing a full sink today: `StorageSink` makes only `on_event` abstract (`flush`/`close`/`on_span`/`on_usage`/`on_title_update` are default no-ops), and `CallbackSink` lets a consumer subscribe with a single async callback. `EventPipeline`'s error-isolated fan-out is the publish side. `EventPipeline(sinks=[CallbackSink(on_event=handler)])` **is** the pub/sub pattern — no flush/close lifecycle, no persistence contract.
+An in-process consumer can react to events without implementing a full sink: `StorageSink` makes only `on_event` abstract (`flush`/`close`/`on_span`/`on_usage`/`on_title_update` are default no-ops), and `CallbackSink` lets a consumer subscribe with a single callback. `EventPipeline`'s error-isolated fan-out is the publish side, so one failing subscriber never blocks the others or the pipeline.
 
-**Remaining (tracked by #47, low priority):** optional ergonomics only — a one-line `EventPipeline.subscribe(on_event=...)` sugar and a sync-callback adapter. No message broker / cross-process transport — that is the wrong tier for an embedded library; external egress is handled by the `OtelExporterSink` (OpenTelemetry is the boundary contract).
+**The official lightweight pub/sub API is `EventPipeline.subscribe`:**
+
+```python
+pipeline.subscribe(on_event, *, kind=None, to_thread=False) -> CallbackSink
+pipeline.unsubscribe(sink) -> bool
+```
+
+- `subscribe` wraps `on_event` in a `CallbackSink` and appends it to the fan-out; it returns that sink, which doubles as the handle for `unsubscribe`.
+- `on_event` may be **async or a plain sync callable** — the one genuinely new capability. Sync callbacks run inline on the event loop by default (right for append-to-list / put-on-queue consumers); pass `to_thread=True` to run a blocking callback via `asyncio.to_thread` so it never stalls the loop. (Adapter: `tracemill.sinks.callback.as_async_event_callback`.)
+- `kind` is an optional per-subscriber filter checked **before** dispatch: an exact kind, a `"prefix.*"` wildcard (e.g. `"tool.*"`), an iterable of those, or a predicate over the event.
+
+`EventPipeline(sinks=[CallbackSink(on_event=handler)])` remains equivalent for construction-time wiring; `subscribe` is the ergonomic path for adding/removing consumers on a live pipeline — no sink subclassing, no flush/close lifecycle, no persistence contract.
+
+**Out of scope by design:** no message broker / cross-process transport — that is the wrong tier for an embedded library; external egress is handled by the `OtelExporterSink` (OpenTelemetry is the boundary contract).
 
 ---
 
@@ -1311,6 +1324,8 @@ tracemill/
 | Risk scoring | ✅ Complete | Structural + flags + injection + taint + context. MITRE mappings. |
 | EventPipeline | ✅ Complete | Fan-out, error isolation, enricher integration |
 | Storage sinks (8) | ✅ Complete | Callback, Console, Jsonl, Sqlite, S3, Parquet, OtelExporter, Webhook |
+| Telemetry self-metrics | ✅ Complete | `tracemill.telemetry.PipelineMetrics`: opt-in `EventPipeline(metrics=...)` accumulator — throughput, enrichment latency, per-sink write time, dropped / failed-sink counts, immutable `MetricsSnapshot`. Disabled path is a true no-op (no timers/allocs on the hot path); no `opentelemetry-sdk` / `prometheus` dep. §14. Closed #48 |
+| EventBus subscribe / pub-sub | ✅ Complete | `EventPipeline.subscribe(on_event, *, kind=None, to_thread=False)` + `unsubscribe()` over the error-isolated fan-out; sync-or-async callbacks, optional per-subscriber `kind` filter. §15. Closed #47 |
 | CLI | ✅ Complete | `cli/` (Click): watch, replay, score, gate, detect, config, status, init, download-model |
 | Gate module | ✅ Complete | Sync scoring path + PII gate + registry (`gate/`, `gates/`) |
 | Live structuring (phase / boundary / title) | ✅ Complete | Packaged CPU-only ONNX models: PhaseInferencer + BoundaryInferencer default-on, TitleInferencer opt-in (emits `TitleUpdate`) |
@@ -1324,9 +1339,7 @@ tracemill/
 
 | Item | Priority | Dependencies | Notes |
 |------|----------|--------------|-------|
-| **Telemetry self-metrics** | Medium | None | OTLP span export is done (`OtelExporterSink`, §14). Remaining is opt-in pipeline self-metrics (events/sec, enrichment latency, sink write time), near-zero footprint, no `opentelemetry-sdk` dep. Tracked by #48. |
 | **PyPI release** | Medium | None | Publish `tracemill` + `tracemill-title-model` to PyPI. Packaging and CI publish workflow are already in place. |
-| **EventBus sugar** | Low | None | Pub/sub is already delivered via `CallbackSink` + `EventPipeline` fan-out (§15). Remaining is optional only: a `subscribe()` convenience + sync-callback adapter. Tracked by #47. |
 
 > **Delivered since this table was first written:** the live structuring subsystem
 > (`phase/` + `boundary/` + `title/`, formerly PR #35) and the full governance epic
@@ -1336,10 +1349,8 @@ tracemill/
 ### Implementation Order (Recommended)
 
 `
-1. Telemetry self-metrics (#48)   → opt-in observability of tracemill itself
-2. PyPI release                   → publish tracemill + tracemill-title-model
-3. EventBus sugar (#47)           → optional subscribe() convenience
-4. Close governance epic issues (#9–#27) → tracker hygiene; work already delivered
+1. PyPI release                   → publish tracemill + tracemill-title-model
+2. Close governance epic issues (#9–#27) → tracker hygiene; work already delivered
 `
 
 ---

--- a/src/tracemill/pipeline.py
+++ b/src/tracemill/pipeline.py
@@ -4,16 +4,24 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Iterable
 from typing import TYPE_CHECKING
 
 from tracemill.enricher import Enricher
 from tracemill.sinks.base import StorageSink
+from tracemill.sinks.callback import (
+    CallbackSink,
+    EventCallback,
+    KindFilter,
+    as_async_event_callback,
+)
 from tracemill.types import EventMetadata, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
 
 if TYPE_CHECKING:
     from tracemill.governance.results import SessionMeta
+    from tracemill.telemetry import PipelineMetrics
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +32,20 @@ logger = logging.getLogger(__name__)
 #: does not grow unbounded. Generous enough that realistic concurrent workloads
 #: never evict an active session; pass ``max_sessions=None`` to disable.
 _DEFAULT_MAX_SESSIONS = 4096
+
+
+def _sink_label(index: int, sink: StorageSink) -> str:
+    """Stable, human-readable per-sink metrics label (class name + position).
+
+    The index disambiguates two sinks of the same class (``"JsonlSink#0"`` vs
+    ``"JsonlSink#1"``) so their write timings never merge.
+    """
+    return f"{type(sink).__name__}#{index}"
+
+
+def _sink_labels_for(sinks: list[StorageSink]) -> list[str]:
+    """Per-sink metrics labels aligned by position with ``sinks``."""
+    return [_sink_label(i, sink) for i, sink in enumerate(sinks)]
 
 
 class EventPipeline:
@@ -82,6 +104,7 @@ class EventPipeline:
         enable_title: bool = False,
         max_sessions: int | None = _DEFAULT_MAX_SESSIONS,
         governance=None,
+        metrics: PipelineMetrics | None = None,
     ) -> None:
         self._sinks = list(sinks)
         self._enricher = enricher
@@ -137,6 +160,76 @@ class EventPipeline:
         # (unbounded, reclaimed only at :meth:`flush`).
         self._session_order: OrderedDict[str, None] = OrderedDict()
         self._max_sessions = max_sessions
+
+        # Opt-in self-metrics (SPEC §14 / #48). When ``None`` (the default) the
+        # hot path never times or allocates for metrics: every instrumentation
+        # site is guarded on ``self._metrics is not None``, and ``_sink_labels``
+        # stays ``None`` so :meth:`_fanout` takes its original, unwrapped path.
+        # Sink labels are precomputed once (bounded by sink count) only when
+        # metrics are enabled, so per-event fan-out pays nothing when they are off.
+        self._metrics = metrics
+        self._sink_labels: list[str] | None = (
+            _sink_labels_for(self._sinks) if metrics is not None else None
+        )
+
+    @property
+    def metrics(self) -> PipelineMetrics | None:
+        """The attached :class:`~tracemill.telemetry.PipelineMetrics`, or ``None``.
+
+        Metrics update live; read a stable summary with ``pipeline.metrics.snapshot()``
+        (e.g. after :meth:`flush` / :meth:`close`).
+        """
+        return self._metrics
+
+    def subscribe(
+        self,
+        on_event: EventCallback,
+        *,
+        kind: KindFilter = None,
+        to_thread: bool = False,
+    ) -> CallbackSink:
+        """Register a lightweight event subscriber (SPEC §15 / #47).
+
+        One-line sugar over the sink model: wraps ``on_event`` in a
+        :class:`~tracemill.sinks.callback.CallbackSink` and appends it, so the
+        subscriber joins the pipeline's existing error-isolated fan-out — a
+        failing subscriber never blocks other sinks or the pipeline. This *is* the
+        publish/subscribe story: no sink subclassing, no flush/close lifecycle, no
+        persistence contract.
+
+        ``on_event`` may be async *or* a plain sync callable (adapted via
+        :func:`~tracemill.sinks.callback.as_async_event_callback`); pass
+        ``to_thread=True`` to run a blocking sync callback off the event loop.
+        ``kind`` optionally filters which events reach this subscriber — an exact
+        kind, a ``"prefix.*"`` wildcard (e.g. ``"tool.*"``), an iterable of those,
+        or a predicate over the event — checked before dispatch.
+
+        Returns the created :class:`CallbackSink`, which doubles as the handle for
+        :meth:`unsubscribe`.
+        """
+        sink = CallbackSink(
+            on_event=as_async_event_callback(on_event, kind=kind, to_thread=to_thread)
+        )
+        self._sinks.append(sink)
+        if self._sink_labels is not None:
+            self._sink_labels.append(_sink_label(len(self._sinks) - 1, sink))
+        return sink
+
+    def unsubscribe(self, sink: StorageSink) -> bool:
+        """Remove a previously :meth:`subscribe`-d (or otherwise added) sink.
+
+        Returns ``True`` if the sink was present and removed, ``False`` otherwise.
+        Safe to call between pushes (the pipeline is single-threaded); an in-flight
+        fan-out already holds its coroutines, so removal only affects later pushes.
+        """
+        try:
+            self._sinks.remove(sink)
+        except ValueError:
+            return False
+        if self._sink_labels is not None:
+            # Positions shifted; recompute so labels stay index-aligned with sinks.
+            self._sink_labels = _sink_labels_for(self._sinks)
+        return True
 
     def _session_lock(self, session_id: str) -> asyncio.Lock:
         lock = self._session_locks.get(session_id)
@@ -272,6 +365,10 @@ class EventPipeline:
 
     async def _push_locked(self, event: SessionEvent) -> None:
         if self._enricher is not None:
+            metrics = self._metrics
+            # Time the enrichment step only when metrics are on: the conditional
+            # never calls the clock on the disabled path (it binds ``0.0``).
+            start = time.perf_counter() if metrics is not None else 0.0
             try:
                 enriched = self._enricher.process(event)
             except Exception as exc:
@@ -282,8 +379,12 @@ class EventPipeline:
                     exc_info=True,
                 )
                 enriched = event
+            if metrics is not None:
+                metrics.record_enrichment(time.perf_counter() - start)
 
             if enriched is None:
+                if metrics is not None:
+                    metrics.record_drop()
                 return
             if isinstance(enriched, list):
                 for e in enriched:
@@ -529,13 +630,27 @@ class EventPipeline:
             for update in updates:
                 await self._push_title_update(update)
 
-    async def _fanout(self, coros: Iterable[Awaitable], action: str) -> None:
+    async def _fanout(
+        self,
+        coros: Iterable[Awaitable],
+        action: str,
+        labels: list[str] | None = None,
+    ) -> None:
         """Await sink coroutines concurrently, error-isolated.
 
         One failing sink is logged (with ``action`` naming the operation) and
         skipped; it never blocks the others. The result order matches
         ``self._sinks``, so the logged index identifies the failing sink.
+
+        When self-metrics are enabled and ``labels`` (one per sink, aligned with
+        ``coros``) is supplied, each sink call is wrapped to record its per-sink
+        write time and failure count. When metrics are off — or no labels are
+        passed — this is a strict no-op over the original behaviour: ``coros`` is
+        awaited exactly as before, with no wrapping and no clock.
         """
+        metrics = self._metrics
+        if metrics is not None and labels is not None:
+            coros = [self._timed_write(label, coro) for label, coro in zip(labels, coros)]
         results = await asyncio.gather(*coros, return_exceptions=True)
         for i, result in enumerate(results):
             if isinstance(result, BaseException):
@@ -546,6 +661,25 @@ class EventPipeline:
                     result,
                     exc_info=(type(result), result, result.__traceback__),
                 )
+
+    async def _timed_write(self, label: str, coro: Awaitable) -> None:
+        """Await one sink call, recording its wall time and failure into metrics.
+
+        Only reached on the metrics-enabled path. Re-raises so :meth:`_fanout`'s
+        error isolation still logs and contains the failure exactly as it would
+        for an unwrapped sink call.
+        """
+        metrics = self._metrics
+        if metrics is None:  # defensive; unreachable via _fanout's guard
+            await coro
+            return
+        start = time.perf_counter()
+        try:
+            await coro
+        except BaseException:
+            metrics.record_sink_write(label, time.perf_counter() - start, failed=True)
+            raise
+        metrics.record_sink_write(label, time.perf_counter() - start, failed=False)
 
     async def _push_title_update(self, update: TitleUpdate) -> None:
         """Fan-out an append-only title update to all sinks. Error-isolated."""
@@ -609,6 +743,9 @@ class EventPipeline:
 
         await self._fanout((sink.flush() for sink in self._sinks), "flush")
 
+        if self._metrics is not None:
+            logger.debug("EventPipeline self-metrics at flush: %s", self._metrics.snapshot())
+
     async def _push_to_sinks(self, event: SessionEvent) -> None:
         """Push event to sinks, stamping governance first if a stage is wired in.
 
@@ -628,14 +765,22 @@ class EventPipeline:
         wired, or produces no meta for this event kind, the bare event goes to
         ``on_event`` exactly as before.
         """
+        if self._metrics is not None:
+            self._metrics.record_event()
         if self._governance is None:
-            await self._fanout((sink.on_event(event) for sink in self._sinks), f"event {event.id}")
+            await self._fanout(
+                (sink.on_event(event) for sink in self._sinks),
+                f"event {event.id}",
+                self._sink_labels,
+            )
             return
 
         stamped, meta = self._annotate_governance(event)
         if meta is None:
             await self._fanout(
-                (sink.on_event(stamped) for sink in self._sinks), f"event {stamped.id}"
+                (sink.on_event(stamped) for sink in self._sinks),
+                f"event {stamped.id}",
+                self._sink_labels,
             )
             return
 
@@ -645,6 +790,7 @@ class EventPipeline:
         await self._fanout(
             (sink.on_enriched_event(enriched) for sink in self._sinks),
             f"enriched event {stamped.id}",
+            self._sink_labels,
         )
 
     def _annotate_governance(

--- a/src/tracemill/sinks/callback.py
+++ b/src/tracemill/sinks/callback.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable, Iterable
 
 from tracemill.sinks.base import StorageSink
 from tracemill.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+
+#: Accepted shapes for a lightweight event subscriber: a coroutine function or a
+#: plain sync callable (both taking a single :class:`SessionEvent`).
+EventCallback = Callable[[SessionEvent], Awaitable[None] | None]
+
+#: Accepted shapes for a per-subscriber kind filter. ``None`` means "all events".
+#: A string is an exact kind, or a ``"prefix.*"`` wildcard matching that dotted
+#: namespace (e.g. ``"tool.*"`` matches ``tool.call``/``tool.result`` but not
+#: ``tool`` or ``toolbar``). An iterable of such strings matches if *any* does. A
+#: callable is used verbatim as a predicate over the event.
+KindFilter = str | Iterable[str] | Callable[[SessionEvent], bool] | None
 
 
 class CallbackSink(StorageSink):
@@ -38,3 +51,82 @@ class CallbackSink(StorageSink):
     async def on_title_update(self, update: TitleUpdate) -> None:
         if self._on_title_update is not None:
             await self._on_title_update(update)
+
+
+def _kind_predicate(kind: KindFilter) -> Callable[[SessionEvent], bool] | None:
+    """Compile a :data:`KindFilter` into a predicate over :class:`SessionEvent`.
+
+    Returns ``None`` (meaning "no filtering") for ``None`` or an empty iterable,
+    so the dispatch wrapper can skip the check entirely in the common case.
+    """
+    if kind is None:
+        return None
+    if isinstance(kind, str):
+        patterns: tuple[str, ...] = (kind,)
+    elif callable(kind):
+        return kind
+    else:
+        patterns = tuple(kind)
+        if not patterns:
+            return None
+
+    def predicate(event: SessionEvent) -> bool:
+        return any(_pattern_matches(pattern, event.kind) for pattern in patterns)
+
+    return predicate
+
+
+def _pattern_matches(pattern: str, kind: str) -> bool:
+    """Match one kind string against an exact or ``"prefix.*"`` wildcard pattern."""
+    if pattern.endswith(".*"):
+        # ``"tool.*"`` -> prefix ``"tool."`` -> matches ``tool.call`` but not
+        # bare ``tool`` or an unrelated ``toolbar``.
+        return kind.startswith(pattern[:-1])
+    return kind == pattern
+
+
+def as_async_event_callback(
+    callback: EventCallback,
+    *,
+    kind: KindFilter = None,
+    to_thread: bool = False,
+) -> Callable[[SessionEvent], Awaitable[None]]:
+    """Adapt a sync-or-async event callback into the ``async on_event`` shape.
+
+    This is the adapter behind :meth:`~tracemill.pipeline.EventPipeline.subscribe`:
+    it lets a plain ``Callable[[SessionEvent], None]`` act as a first-class event
+    subscriber without the caller writing ``async def`` or a full sink, and it
+    applies an optional per-subscriber ``kind`` filter *before* dispatch so a
+    filtered-out event never touches the callback.
+
+    - **async callables** (coroutine functions) are awaited directly.
+    - **sync callables** are called inline on the event loop by default — right
+      for the lightweight consumers this exists for (append to a list, put on a
+      queue). Pass ``to_thread=True`` to instead run a blocking sync callback via
+      :func:`asyncio.to_thread`, so it never stalls the loop.
+    - A sync callable that unexpectedly returns an awaitable (e.g. an object whose
+      ``__call__`` is ``async`` and so is not flagged by
+      :func:`asyncio.iscoroutinefunction`) is awaited defensively.
+
+    Raises ``TypeError`` if ``callback`` is not callable.
+    """
+    if not callable(callback):
+        raise TypeError(f"event callback must be callable, got {type(callback).__name__}")
+
+    predicate = _kind_predicate(kind)
+    is_async = asyncio.iscoroutinefunction(callback)
+
+    async def on_event(event: SessionEvent) -> None:
+        if predicate is not None and not predicate(event):
+            return
+        if is_async:
+            await callback(event)
+            return
+        if to_thread:
+            await asyncio.to_thread(callback, event)
+            return
+        result = callback(event)
+        if inspect.isawaitable(result):
+            await result
+
+    return on_event

--- a/src/tracemill/telemetry/__init__.py
+++ b/src/tracemill/telemetry/__init__.py
@@ -1,0 +1,192 @@
+"""Opt-in, near-zero-footprint self-metrics for :class:`~tracemill.pipeline.EventPipeline`.
+
+This package is tracemill's *self*-observability seam (SPEC §14). It is distinct
+from OTLP *export* (``sinks/otel_exporter.OtelExporterSink``, which ships events /
+spans / usage to an external collector): this measures the pipeline's **own**
+operation — throughput, enrichment latency, per-sink write time, and dropped /
+failed-sink counts.
+
+Design contract (why this stays honest to the "must not add per-event cost"
+constraint of #48):
+
+- **Opt-in.** A pipeline created without a :class:`PipelineMetrics` instance does
+  no timing and makes no metrics allocations on the hot path — the pipeline
+  guards every instrumentation site on ``metrics is not None`` and never calls a
+  clock when disabled. Attaching an instance is the *only* way to turn it on.
+- **In-process, no dependencies.** No ``opentelemetry-sdk``, no ``prometheus``,
+  no background threads, no parallel transport. It is a plain accumulator read
+  back off the same object you passed in (surfaced on ``flush()`` / ``close()``).
+- **Bounded.** Every field is a scalar counter or timing sum, plus exactly one
+  entry per sink. Nothing grows per event, so a long-lived daemon never
+  accumulates unbounded state.
+
+Usage::
+
+    from tracemill import EventPipeline
+    from tracemill.telemetry import PipelineMetrics
+
+    metrics = PipelineMetrics()
+    pipeline = EventPipeline(sinks=[...], metrics=metrics)
+    ...
+    await pipeline.close()
+    snap = metrics.snapshot()
+    print(snap.events_per_second, snap.mean_enrichment_ms)
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+__all__ = ["MetricsSnapshot", "PipelineMetrics", "SinkMetrics"]
+
+
+@dataclass(frozen=True)
+class SinkMetrics:
+    """Immutable per-sink write totals within a :class:`MetricsSnapshot`.
+
+    ``label`` identifies the sink by class name and position in the pipeline's
+    sink list (e.g. ``"JsonlSink#1"``), so two sinks of the same class stay
+    distinguishable.
+    """
+
+    label: str
+    writes: int
+    failures: int
+    write_seconds: float
+
+    @property
+    def mean_write_ms(self) -> float:
+        """Mean wall time this sink spent per write, in milliseconds."""
+        return (self.write_seconds / self.writes * 1000.0) if self.writes else 0.0
+
+
+@dataclass(frozen=True)
+class MetricsSnapshot:
+    """An immutable point-in-time read of a :class:`PipelineMetrics`.
+
+    Returned by :meth:`PipelineMetrics.snapshot`. Raw counters are captured
+    verbatim; rates and means are exposed as derived properties so no divide-by-
+    zero can leak to callers.
+    """
+
+    events: int
+    dropped_events: int
+    sink_failures: int
+    enrichment_calls: int
+    enrichment_seconds: float
+    active_seconds: float
+    sinks: tuple[SinkMetrics, ...]
+
+    @property
+    def events_per_second(self) -> float:
+        """Throughput over the span from the first to the most recent event.
+
+        ``0.0`` until at least two events have been recorded far enough apart for
+        the monotonic clock to advance (a single event has no measurable span).
+        """
+        return (self.events / self.active_seconds) if self.active_seconds > 0 else 0.0
+
+    @property
+    def mean_enrichment_ms(self) -> float:
+        """Mean wall time spent in the enricher per event, in milliseconds."""
+        return (
+            (self.enrichment_seconds / self.enrichment_calls * 1000.0)
+            if self.enrichment_calls
+            else 0.0
+        )
+
+
+class PipelineMetrics:
+    """Mutable, in-process accumulator of :class:`EventPipeline` self-metrics.
+
+    Attach one instance per pipeline via ``EventPipeline(..., metrics=...)`` to
+    turn metrics on; leave it unset (the default) and the pipeline stays a true
+    no-op on the hot path. The pipeline calls the ``record_*`` methods; consumers
+    call :meth:`snapshot` (any time — the counters update live) to read a stable,
+    immutable summary.
+
+    Not thread-safe by design: the pipeline is asyncio single-threaded, so every
+    ``record_*`` call runs on the one event loop; there is nothing to lock.
+    """
+
+    __slots__ = (
+        "_dropped_events",
+        "_enrichment_calls",
+        "_enrichment_seconds",
+        "_events",
+        "_first_perf",
+        "_last_perf",
+        "_sink_failures",
+        "_sink_seconds",
+        "_sink_writes",
+    )
+
+    def __init__(self) -> None:
+        self._events = 0
+        self._dropped_events = 0
+        self._enrichment_calls = 0
+        self._enrichment_seconds = 0.0
+        self._first_perf: float | None = None
+        self._last_perf = 0.0
+        # Per-sink accumulators, keyed by the pipeline-assigned sink label. Bounded
+        # by the number of sinks; never grows per event.
+        self._sink_writes: dict[str, int] = {}
+        self._sink_failures: dict[str, int] = {}
+        self._sink_seconds: dict[str, float] = {}
+
+    def record_event(self) -> None:
+        """Count one event reaching the sink fan-out and stamp its arrival time."""
+        now = time.perf_counter()
+        if self._first_perf is None:
+            self._first_perf = now
+        self._last_perf = now
+        self._events += 1
+
+    def record_drop(self) -> None:
+        """Count one event dropped by the enricher (``process`` returned ``None``)."""
+        self._dropped_events += 1
+
+    def record_enrichment(self, seconds: float) -> None:
+        """Record one enrichment call and the wall time it took."""
+        self._enrichment_calls += 1
+        self._enrichment_seconds += seconds
+
+    def record_sink_write(self, label: str, seconds: float, *, failed: bool) -> None:
+        """Record one sink write: its wall time and whether it raised.
+
+        A failed write still counts as a write (the sink was invoked); ``failed``
+        additionally bumps that sink's failure tally.
+        """
+        self._sink_writes[label] = self._sink_writes.get(label, 0) + 1
+        self._sink_seconds[label] = self._sink_seconds.get(label, 0.0) + seconds
+        if failed:
+            self._sink_failures[label] = self._sink_failures.get(label, 0) + 1
+
+    @property
+    def active_seconds(self) -> float:
+        """Span from the first to the most recent recorded event, in seconds."""
+        if self._first_perf is None:
+            return 0.0
+        return max(0.0, self._last_perf - self._first_perf)
+
+    def snapshot(self) -> MetricsSnapshot:
+        """Return an immutable summary of the metrics recorded so far."""
+        sinks = tuple(
+            SinkMetrics(
+                label=label,
+                writes=writes,
+                failures=self._sink_failures.get(label, 0),
+                write_seconds=self._sink_seconds.get(label, 0.0),
+            )
+            for label, writes in self._sink_writes.items()
+        )
+        return MetricsSnapshot(
+            events=self._events,
+            dropped_events=self._dropped_events,
+            sink_failures=sum(self._sink_failures.values()),
+            enrichment_calls=self._enrichment_calls,
+            enrichment_seconds=self._enrichment_seconds,
+            active_seconds=self.active_seconds,
+            sinks=sinks,
+        )

--- a/tests/unit/test_pipeline_subscribe.py
+++ b/tests/unit/test_pipeline_subscribe.py
@@ -1,0 +1,285 @@
+"""Tests for ``EventPipeline.subscribe`` / ``unsubscribe`` and the sync/async
+callback adapter (SPEC §15 / issue #47).
+
+These exercise the *ergonomics* layer over the existing error-isolated sink
+fan-out: a plain sync or async ``Callable[[SessionEvent], ...]`` can join the
+pipeline as a first-class subscriber, with an optional per-subscriber ``kind``
+filter, and be removed again — without the caller ever writing a sink subclass.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from tracemill import CallbackSink, EventKind, EventPipeline, SessionEvent, StorageSink
+from tracemill.sinks.callback import as_async_event_callback
+from tests.conftest import RecordingSink, make_event
+
+
+def _plain_pipeline(sinks: list[StorageSink] | None = None) -> EventPipeline:
+    """A pipeline with live inference off so event kinds stay pristine for filters."""
+    return EventPipeline(
+        sinks=sinks or [],
+        enable_phase=False,
+        enable_boundary=False,
+    )
+
+
+class _RaisingSubscriber:
+    """A sync subscriber that always raises, to probe error isolation."""
+
+    def __call__(self, event: SessionEvent) -> None:
+        raise RuntimeError("subscriber boom")
+
+
+class _AsyncCallable:
+    """An object whose ``__call__`` is async (not flagged by iscoroutinefunction)."""
+
+    def __init__(self) -> None:
+        self.seen: list[SessionEvent] = []
+
+    async def __call__(self, event: SessionEvent) -> None:
+        self.seen.append(event)
+
+
+class TestSubscribeDispatch:
+    """A subscriber joins the fan-out and receives events."""
+
+    async def test_async_callback_receives_events(self) -> None:
+        got: list[SessionEvent] = []
+
+        async def on_event(event: SessionEvent) -> None:
+            got.append(event)
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(on_event)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert len(got) == 1
+
+    async def test_sync_callback_receives_events_inline(self) -> None:
+        got: list[SessionEvent] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(got.append)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert len(got) == 1
+
+    async def test_sync_callback_runs_on_loop_thread_by_default(self) -> None:
+        seen: dict[str, int] = {}
+        main_ident = threading.get_ident()
+
+        def on_event(event: SessionEvent) -> None:
+            seen["ident"] = threading.get_ident()
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(on_event)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert seen["ident"] == main_ident
+
+    async def test_sync_callback_to_thread_runs_off_loop_thread(self) -> None:
+        seen: dict[str, int] = {}
+        main_ident = threading.get_ident()
+
+        def on_event(event: SessionEvent) -> None:
+            seen["ident"] = threading.get_ident()
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(on_event, to_thread=True)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert seen["ident"] != main_ident
+
+    async def test_async_dunder_call_object_is_awaited(self) -> None:
+        obj = _AsyncCallable()
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(obj)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert len(obj.seen) == 1
+
+    async def test_subscriber_joins_existing_sinks(self) -> None:
+        recording = RecordingSink()
+        got: list[SessionEvent] = []
+
+        pipeline = _plain_pipeline([recording.sink])
+        pipeline.subscribe(got.append)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert len(recording.events) == 1
+        assert len(got) == 1
+
+    async def test_multiple_subscribers_all_receive(self) -> None:
+        a: list[SessionEvent] = []
+        b: list[SessionEvent] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(a.append)
+        pipeline.subscribe(b.append)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert len(a) == 1
+        assert len(b) == 1
+
+
+class TestSubscribeKindFilter:
+    """The optional per-subscriber ``kind`` filter runs before dispatch."""
+
+    async def test_exact_kind(self) -> None:
+        got: list[str] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(lambda e: got.append(e.kind), kind=EventKind.MESSAGE_USER)
+        await pipeline.push(make_event(kind=EventKind.MESSAGE_USER))
+        await pipeline.push(make_event(kind=EventKind.TOOL_CALL_STARTED))
+        await pipeline.close()
+
+        assert got == [EventKind.MESSAGE_USER]
+
+    async def test_wildcard_prefix(self) -> None:
+        got: list[str] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(lambda e: got.append(e.kind), kind="tool.*")
+        await pipeline.push(make_event(kind=EventKind.MESSAGE_USER))
+        await pipeline.push(make_event(kind=EventKind.TOOL_CALL_STARTED))
+        await pipeline.push(make_event(kind=EventKind.TOOL_CALL_COMPLETED))
+        await pipeline.close()
+
+        assert got == [EventKind.TOOL_CALL_STARTED, EventKind.TOOL_CALL_COMPLETED]
+
+    async def test_iterable_of_kinds(self) -> None:
+        got: list[str] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(
+            lambda e: got.append(e.kind),
+            kind=[EventKind.MESSAGE_USER, EventKind.TOOL_CALL_COMPLETED],
+        )
+        await pipeline.push(make_event(kind=EventKind.MESSAGE_USER))
+        await pipeline.push(make_event(kind=EventKind.TOOL_CALL_STARTED))
+        await pipeline.push(make_event(kind=EventKind.TOOL_CALL_COMPLETED))
+        await pipeline.close()
+
+        assert got == [EventKind.MESSAGE_USER, EventKind.TOOL_CALL_COMPLETED]
+
+    async def test_callable_predicate(self) -> None:
+        got: list[str] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(
+            lambda e: got.append(e.session_id),
+            kind=lambda e: e.session_id == "keep",
+        )
+        await pipeline.push(make_event(session_id="keep"))
+        await pipeline.push(make_event(session_id="drop"))
+        await pipeline.close()
+
+        assert got == ["keep"]
+
+    async def test_empty_iterable_means_no_filter(self) -> None:
+        got: list[SessionEvent] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(got.append, kind=[])
+        await pipeline.push(make_event(kind=EventKind.MESSAGE_USER))
+        await pipeline.push(make_event(kind=EventKind.TOOL_CALL_STARTED))
+        await pipeline.close()
+
+        assert len(got) == 2
+
+
+class TestUnsubscribe:
+    """Subscribers can be removed by the handle ``subscribe`` returns."""
+
+    async def test_subscribe_returns_callback_sink(self) -> None:
+        pipeline = _plain_pipeline()
+        handle = pipeline.subscribe(lambda e: None)
+        assert isinstance(handle, CallbackSink)
+
+    async def test_unsubscribe_stops_delivery(self) -> None:
+        got: list[SessionEvent] = []
+
+        pipeline = _plain_pipeline()
+        handle = pipeline.subscribe(got.append)
+        await pipeline.push(make_event())
+
+        assert pipeline.unsubscribe(handle) is True
+
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert len(got) == 1
+
+    async def test_unsubscribe_twice_returns_false(self) -> None:
+        pipeline = _plain_pipeline()
+        handle = pipeline.subscribe(lambda e: None)
+
+        assert pipeline.unsubscribe(handle) is True
+        assert pipeline.unsubscribe(handle) is False
+
+    async def test_unsubscribe_unknown_sink_returns_false(self) -> None:
+        pipeline = _plain_pipeline()
+        assert pipeline.unsubscribe(CallbackSink()) is False
+
+
+class TestSubscribeErrors:
+    """Failure modes: bad input rejected, failing subscriber isolated."""
+
+    async def test_non_callable_raises_type_error(self) -> None:
+        pipeline = _plain_pipeline()
+        with pytest.raises(TypeError):
+            pipeline.subscribe(42)  # type: ignore[arg-type]
+
+    async def test_failing_subscriber_is_isolated(self) -> None:
+        recording = RecordingSink()
+
+        pipeline = _plain_pipeline([recording.sink])
+        pipeline.subscribe(_RaisingSubscriber())
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        # The raising subscriber must not stop the recording sink.
+        assert len(recording.events) == 1
+
+
+class TestAdapterDirect:
+    """Direct unit tests of the ``as_async_event_callback`` adapter itself."""
+
+    async def test_wildcard_does_not_match_bare_or_unrelated(self) -> None:
+        got: list[str] = []
+        adapted = as_async_event_callback(lambda e: got.append(e.kind), kind="tool.*")
+
+        await adapted(make_event(kind="tool"))
+        await adapted(make_event(kind="toolbar"))
+        await adapted(make_event(kind="tool.call"))
+
+        assert got == ["tool.call"]
+
+    async def test_filtered_out_event_never_touches_callback(self) -> None:
+        calls = 0
+
+        def on_event(event: SessionEvent) -> None:
+            nonlocal calls
+            calls += 1
+
+        adapted = as_async_event_callback(on_event, kind=EventKind.MESSAGE_USER)
+        await adapted(make_event(kind=EventKind.TOOL_CALL_STARTED))
+
+        assert calls == 0
+
+    def test_non_callable_raises_type_error(self) -> None:
+        with pytest.raises(TypeError):
+            as_async_event_callback(object())  # type: ignore[arg-type]

--- a/tests/unit/test_telemetry_metrics.py
+++ b/tests/unit/test_telemetry_metrics.py
@@ -1,0 +1,343 @@
+"""Tests for opt-in pipeline self-metrics (SPEC §14 / issue #48).
+
+Two things matter here and are asserted directly:
+
+1. **When enabled**, the pipeline records throughput, enrichment latency,
+   per-sink write time, and dropped / failed-sink counts — surfaced as an
+   immutable :class:`MetricsSnapshot`.
+2. **When disabled (the default)**, the path is a *genuine* no-op: the hot path
+   never reads the clock and never allocates a metrics object. This is asserted
+   by spying on ``time.perf_counter`` and proving zero calls.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import time
+
+import pytest
+
+from tracemill import EventPipeline, SessionEvent, StorageSink
+from tracemill.telemetry import MetricsSnapshot, PipelineMetrics, SinkMetrics
+from tests.conftest import RecordingSink, make_event
+
+
+class _PassEnricher:
+    """Enricher that passes every event through unchanged."""
+
+    def process(self, event: SessionEvent) -> SessionEvent:
+        return event
+
+    def flush(self) -> list[SessionEvent]:
+        return []
+
+
+class _DropEnricher:
+    """Enricher that drops every event (``process`` returns ``None``)."""
+
+    def process(self, event: SessionEvent) -> SessionEvent | None:
+        return None
+
+    def flush(self) -> list[SessionEvent]:
+        return []
+
+
+class _BoomSink(StorageSink):
+    """A sink whose ``on_event`` always raises."""
+
+    async def on_event(self, event: SessionEvent) -> None:
+        raise RuntimeError("boom")
+
+
+def _plain_pipeline(**kwargs) -> EventPipeline:
+    kwargs.setdefault("enable_phase", False)
+    kwargs.setdefault("enable_boundary", False)
+    return EventPipeline(**kwargs)
+
+
+class TestDisabledIsNoOp:
+    """The default (no metrics) path must not time or allocate on the hot path."""
+
+    def test_metrics_is_none_by_default(self) -> None:
+        assert _plain_pipeline(sinks=[]).metrics is None
+
+    async def test_disabled_path_never_reads_the_clock(self, monkeypatch) -> None:
+        calls = 0
+        real = time.perf_counter
+
+        def spy() -> float:
+            nonlocal calls
+            calls += 1
+            return real()
+
+        # Patch the shared ``time`` module used by both pipeline and telemetry.
+        monkeypatch.setattr(time, "perf_counter", spy)
+
+        pipeline = _plain_pipeline(sinks=[], enricher=_PassEnricher())
+        got: list[SessionEvent] = []
+        pipeline.subscribe(got.append)
+        for _ in range(20):
+            await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert calls == 0
+        assert len(got) == 20
+
+    async def test_enabled_path_does_read_the_clock(self, monkeypatch) -> None:
+        calls = 0
+        real = time.perf_counter
+
+        def spy() -> float:
+            nonlocal calls
+            calls += 1
+            return real()
+
+        monkeypatch.setattr(time, "perf_counter", spy)
+
+        pipeline = _plain_pipeline(sinks=[], enricher=_PassEnricher(), metrics=PipelineMetrics())
+        pipeline.subscribe(lambda e: None)
+        for _ in range(5):
+            await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert calls > 0
+
+    async def test_metrics_does_not_alter_delivered_events(self) -> None:
+        recording = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[recording.sink], metrics=PipelineMetrics())
+        event = make_event()
+
+        await pipeline.push(event)
+        await pipeline.close()
+
+        assert len(recording.events) == 1
+        assert recording.events[0].id == event.id
+        assert recording.events[0].kind == event.kind
+
+
+class TestEnabledCounters:
+    """When enabled, the pipeline records the documented counters and timings."""
+
+    def test_metrics_property_returns_attached_instance(self) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], metrics=metrics)
+        assert pipeline.metrics is metrics
+
+    async def test_events_are_counted(self) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], metrics=metrics)
+        pipeline.subscribe(lambda e: None)
+        for _ in range(5):
+            await pipeline.push(make_event())
+        await pipeline.close()
+
+        assert metrics.snapshot().events == 5
+
+    async def test_enrichment_latency_recorded(self) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], enricher=_PassEnricher(), metrics=metrics)
+        for _ in range(3):
+            await pipeline.push(make_event())
+        await pipeline.close()
+
+        snap = metrics.snapshot()
+        assert snap.enrichment_calls == 3
+        assert snap.enrichment_seconds >= 0.0
+        assert snap.mean_enrichment_ms >= 0.0
+
+    async def test_dropped_events_counted(self) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], enricher=_DropEnricher(), metrics=metrics)
+        for _ in range(4):
+            await pipeline.push(make_event())
+        await pipeline.close()
+
+        snap = metrics.snapshot()
+        assert snap.dropped_events == 4
+        assert snap.events == 0
+        assert snap.enrichment_calls == 4
+
+    async def test_per_sink_write_time_and_labels(self) -> None:
+        metrics = PipelineMetrics()
+        r1 = RecordingSink()
+        r2 = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[r1.sink, r2.sink], metrics=metrics)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        snap = metrics.snapshot()
+        by_label = {s.label: s for s in snap.sinks}
+        assert set(by_label) == {"CallbackSink#0", "CallbackSink#1"}
+        for sink_metrics in snap.sinks:
+            assert sink_metrics.writes == 1
+            assert sink_metrics.failures == 0
+            assert sink_metrics.write_seconds >= 0.0
+            assert sink_metrics.mean_write_ms >= 0.0
+
+    async def test_sink_failure_counted_and_isolated(self) -> None:
+        metrics = PipelineMetrics()
+        recording = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[_BoomSink(), recording.sink], metrics=metrics)
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        snap = metrics.snapshot()
+        by_label = {s.label: s for s in snap.sinks}
+        assert snap.sink_failures == 1
+        assert by_label["_BoomSink#0"].writes == 1
+        assert by_label["_BoomSink#0"].failures == 1
+        assert by_label["CallbackSink#1"].failures == 0
+        # Error isolation: the healthy sink still received the event.
+        assert len(recording.events) == 1
+
+    async def test_snapshot_reflects_live_updates(self) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], metrics=metrics)
+        pipeline.subscribe(lambda e: None)
+
+        await pipeline.push(make_event())
+        first = metrics.snapshot()
+        await pipeline.push(make_event())
+        second = metrics.snapshot()
+        await pipeline.close()
+
+        assert first.events == 1
+        assert second.events == 2
+
+
+class TestSubscribeMetricsInterplay:
+    """Sink labels stay index-aligned across subscribe / unsubscribe."""
+
+    async def test_subscribe_labels_align_when_metrics_on(self) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], metrics=metrics)
+        got: list[SessionEvent] = []
+        pipeline.subscribe(got.append)
+
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        snap = metrics.snapshot()
+        assert {s.label for s in snap.sinks} == {"CallbackSink#0"}
+        assert snap.sinks[0].writes == 1
+        assert len(got) == 1
+
+    async def test_unsubscribe_recomputes_labels(self) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], metrics=metrics)
+        first: list[SessionEvent] = []
+        second: list[SessionEvent] = []
+        handle = pipeline.subscribe(first.append)
+        pipeline.subscribe(second.append)
+
+        assert pipeline.unsubscribe(handle) is True
+
+        await pipeline.push(make_event())
+        await pipeline.close()
+
+        snap = metrics.snapshot()
+        # Only the surviving sink recorded, relabeled to index 0.
+        assert {s.label for s in snap.sinks} == {"CallbackSink#0"}
+        assert len(first) == 0
+        assert len(second) == 1
+
+
+class TestFlushLogging:
+    """``flush`` emits a DEBUG snapshot only when metrics are enabled."""
+
+    async def test_flush_logs_snapshot_when_enabled(self, caplog) -> None:
+        metrics = PipelineMetrics()
+        pipeline = _plain_pipeline(sinks=[], metrics=metrics)
+        pipeline.subscribe(lambda e: None)
+        await pipeline.push(make_event())
+
+        with caplog.at_level(logging.DEBUG, logger="tracemill.pipeline"):
+            await pipeline.flush()
+
+        assert any("self-metrics" in r.getMessage() for r in caplog.records)
+
+    async def test_flush_does_not_log_when_disabled(self, caplog) -> None:
+        pipeline = _plain_pipeline(sinks=[])
+        pipeline.subscribe(lambda e: None)
+        await pipeline.push(make_event())
+
+        with caplog.at_level(logging.DEBUG, logger="tracemill.pipeline"):
+            await pipeline.flush()
+
+        assert not any("self-metrics" in r.getMessage() for r in caplog.records)
+
+
+class TestSnapshotImmutability:
+    """Snapshots and their per-sink entries are frozen value objects."""
+
+    def test_snapshot_is_frozen(self) -> None:
+        metrics = PipelineMetrics()
+        metrics.record_event()
+        snap = metrics.snapshot()
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            snap.events = 999  # type: ignore[misc]
+
+    def test_sink_metrics_is_frozen(self) -> None:
+        sink_metrics = SinkMetrics(label="x", writes=1, failures=0, write_seconds=0.0)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            sink_metrics.writes = 999  # type: ignore[misc]
+
+
+class TestDerivedAndZeroSafety:
+    """Derived rates/means are divide-by-zero safe and behave sensibly."""
+
+    def test_empty_snapshot_is_zero_safe(self) -> None:
+        snap = PipelineMetrics().snapshot()
+        assert snap.events == 0
+        assert snap.dropped_events == 0
+        assert snap.sink_failures == 0
+        assert snap.events_per_second == 0.0
+        assert snap.mean_enrichment_ms == 0.0
+        assert snap.sinks == ()
+
+    def test_single_event_has_zero_throughput(self) -> None:
+        metrics = PipelineMetrics()
+        metrics.record_event()
+        snap = metrics.snapshot()
+        assert snap.active_seconds == 0.0
+        assert snap.events_per_second == 0.0
+
+    def test_multiple_events_throughput_nonnegative(self) -> None:
+        metrics = PipelineMetrics()
+        for _ in range(5):
+            metrics.record_event()
+        snap = metrics.snapshot()
+        assert snap.events == 5
+        assert snap.active_seconds >= 0.0
+        assert snap.events_per_second >= 0.0
+
+    def test_sink_metrics_mean_write_ms_zero_safe(self) -> None:
+        assert SinkMetrics(label="x", writes=0, failures=0, write_seconds=0.0).mean_write_ms == 0.0
+
+    def test_record_sink_write_failed_still_counts_as_write(self) -> None:
+        metrics = PipelineMetrics()
+        metrics.record_sink_write("S#0", 0.001, failed=True)
+        metrics.record_sink_write("S#0", 0.002, failed=False)
+        snap = metrics.snapshot()
+
+        assert snap.sink_failures == 1
+        sink_metrics = snap.sinks[0]
+        assert sink_metrics.writes == 2
+        assert sink_metrics.failures == 1
+        assert sink_metrics.write_seconds == pytest.approx(0.003)
+        assert sink_metrics.mean_write_ms >= 0.0
+
+    def test_record_enrichment_accumulates(self) -> None:
+        metrics = PipelineMetrics()
+        metrics.record_enrichment(0.01)
+        metrics.record_enrichment(0.02)
+        snap = metrics.snapshot()
+
+        assert snap.enrichment_calls == 2
+        assert snap.enrichment_seconds == pytest.approx(0.03)
+        assert snap.mean_enrichment_ms == pytest.approx(15.0)
+
+    def test_snapshot_type(self) -> None:
+        assert isinstance(PipelineMetrics().snapshot(), MetricsSnapshot)


### PR DESCRIPTION
Closes two gap-closing infra issues over already-shipped plane-A machinery, as one coherent PR. **No new runtime dependencies.**

## #47 — EventBus ergonomics (SPEC §15)
Path A (no from-scratch bus, no broker): the in-process pub/sub story was already delivered by the error-isolated `CallbackSink` fan-out. This adds the missing ergonomics:

- **`EventPipeline.subscribe(on_event, *, kind=None, to_thread=False) -> CallbackSink`** — one-line sugar that wraps a callback in a `CallbackSink` and appends it to the existing fan-out. Returns the sink, which doubles as the `unsubscribe()` handle.
- **`EventPipeline.unsubscribe(sink) -> bool`**.
- **Sync-callback support** (the one genuinely new capability): plain `Callable[[SessionEvent], None]` runs inline on the loop by default, or off-loop via `asyncio.to_thread` when `to_thread=True`. Async callables and async-`__call__` objects are handled too.
- **Optional per-subscriber `kind` filter** checked *before* dispatch: exact kind, `"prefix.*"` wildcard (e.g. `"tool.*"`), an iterable of those, or a predicate. Implemented as `as_async_event_callback` in `sinks/callback.py`.

## #48 — Pipeline self-metrics (SPEC §14)
Seam (b): an opt-in `metrics` accumulator on `EventPipeline`, filling the previously-empty `telemetry/` stub. **No `opentelemetry-sdk`, no `prometheus`** (consistent with the hand-rolled OTLP `OtelExporterSink` decision).

- **`tracemill.telemetry.PipelineMetrics`** — attach via `EventPipeline(..., metrics=PipelineMetrics())`. Records throughput (events/sec), enrichment latency, per-sink write time, and dropped / failed-sink counts; read back as an immutable `MetricsSnapshot` (+ per-sink `SinkMetrics`), surfaced on `flush()` / `close()` and logged at DEBUG on flush.
- **Disabled path is a true no-op.** Without a `metrics=` instance the hot path makes **no timing calls and no metrics allocations** — every site is guarded on `metrics is not None`, the clock is never read, and the fan-out keeps its original unwrapped path. Enforced by a test that spies on `time.perf_counter` and asserts **zero** calls on the disabled path.
- **Bounded, in-process, no background threads** — scalar counters plus one entry per sink; nothing grows per event.

## Docs
SPEC §14 and §15 flipped to Done (with the "no `opentelemetry-sdk` dep" decision recorded explicitly); §21 roadmap rows moved from Planned → Done.

## Verification
- Adds **45 tests** across `tests/unit/test_pipeline_subscribe.py` and `tests/unit/test_telemetry_metrics.py`.
- Full suite: **1972 passed, 4 skipped** (baseline 1927 + 45, zero regressions).
- `ruff check` and `ruff format --check` clean (ruff 0.15.20).

Scope: only `src/tracemill/pipeline.py`, `src/tracemill/telemetry/`, `src/tracemill/sinks/callback.py`, `SPEC.md`, and tests. No `governance/` files touched.

Closes #47
Closes #48