### PR TITLE
Normalize governance persistence as a single source of truth (#9)

### DIFF
--- a/src/tracemill/cli/status.py
+++ b/src/tracemill/cli/status.py
@@ -36,9 +36,9 @@ def status(as_json: bool, db_path: str | None) -> None:
     row = conn.execute("SELECT COUNT(*) FROM processed_events").fetchone()
     stats["processed_events"] = row[0] if row else 0
 
-    # MCP fingerprints
-    row = conn.execute("SELECT COUNT(*) FROM mcp_fingerprints").fetchone()
-    stats["mcp_fingerprints"] = row[0] if row else 0
+    # MCP tool profiles
+    row = conn.execute("SELECT COUNT(*) FROM mcp_profiles").fetchone()
+    stats["mcp_profiles"] = row[0] if row else 0
 
     # Session summaries
     row = conn.execute("SELECT COUNT(*) FROM session_summaries").fetchone()
@@ -59,7 +59,7 @@ def status(as_json: bool, db_path: str | None) -> None:
         click.echo("─" * 40)
         click.echo(f"  Active sessions:    {stats['active_sessions']}")
         click.echo(f"  Processed events:   {stats['processed_events']}")
-        click.echo(f"  MCP fingerprints:   {stats['mcp_fingerprints']}")
+        click.echo(f"  MCP profiles:       {stats['mcp_profiles']}")
         click.echo(f"  Completed sessions: {stats['completed_sessions']}")
         if stats["last_session_recommendations"]:
             click.echo(f"  Last session recs:  {stats['last_session_recommendations']}")

--- a/src/tracemill/governance/mcp_drift.py
+++ b/src/tracemill/governance/mcp_drift.py
@@ -142,13 +142,9 @@ class MCPIntegrityScanner:
                             "description_hash": desc_hash,
                             "schema_hash": schema_hash,
                             "registered_effect": cls.effect,
-                            "registered_role": json.dumps(sorted(cls.role)) if cls.role else None,
-                            "registered_capabilities": json.dumps(sorted(cls.capability))
-                            if cls.capability
-                            else None,
-                            "registered_scope": json.dumps(sorted(cls.scope))
-                            if cls.scope
-                            else None,
+                            "role": sorted(cls.role),
+                            "capability": sorted(cls.capability),
+                            "scope": sorted(cls.scope),
                             "clearance": None,
                             "first_seen": now.isoformat(),
                             "last_seen": now.isoformat(),
@@ -261,8 +257,7 @@ class MCPIntegrityScanner:
                 )
 
         # Capability gain
-        reg_caps_raw = stored.get("registered_capabilities")
-        reg_caps = frozenset(json.loads(reg_caps_raw)) if reg_caps_raw else frozenset()
+        reg_caps = frozenset(stored.get("capability") or ())
         new_caps = current.capability - reg_caps
         dangerous_new = new_caps & _DANGEROUS_CAPS
         if dangerous_new:
@@ -279,8 +274,7 @@ class MCPIntegrityScanner:
             )
 
         # Scope expansion
-        reg_scope_raw = stored.get("registered_scope")
-        reg_scope = frozenset(json.loads(reg_scope_raw)) if reg_scope_raw else frozenset()
+        reg_scope = frozenset(stored.get("scope") or ())
         new_scope = current.scope - reg_scope
         if new_scope:
             max_prev = max((_SCOPE_ORDER.get(s, 0) for s in reg_scope), default=0)

--- a/src/tracemill/governance/monitor.py
+++ b/src/tracemill/governance/monitor.py
@@ -200,12 +200,12 @@ class SessionMonitor:
             }
             reservation_json = json.dumps(reservation_data)
             try:
-                state.persist_no_commit()
-                self._store.execute_in_transaction(
-                    "INSERT OR IGNORE INTO processed_events (source_event_key, session_id, session_meta_json, processed_at) VALUES (?, ?, ?, ?)",
-                    (event.source_event_key, session_id, reservation_json, now),
-                )
-                self._store.commit()
+                with self._store.write_transaction():
+                    state.persist_no_commit()
+                    self._store.execute_in_transaction(
+                        "INSERT OR IGNORE INTO processed_events (source_event_key, session_id, session_meta_json, processed_at) VALUES (?, ?, ?, ?)",
+                        (event.source_event_key, session_id, reservation_json, now),
+                    )
                 self._write_failures[session_id] = 0
                 self._store.cache_processed(event.source_event_key, reservation_json)
             except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
@@ -216,8 +216,8 @@ class SessionMonitor:
                     session_id,
                     e,
                 )
-                self._store.rollback()
-                # Discard corrupted in-memory state — reload clean from DB
+                # write_transaction already rolled back — discard the corrupted
+                # in-memory state and reload a clean copy from the DB.
                 self._registry.evict(session_id)
                 state = self.get_or_create_state(session_id)
                 # Return degraded response — event will be re-delivered
@@ -236,11 +236,16 @@ class SessionMonitor:
         # For retries (existing=reserved), use the persisted event-time snapshot
         if existing:
             snapshot_data = meta_dict.get("snapshot")
-            if snapshot_data:
-                snapshot = self._codec.deserialize_snapshot(snapshot_data)
-            else:
-                # Legacy reservation without snapshot — fall back to current state
-                snapshot = state.snapshot()
+            if not snapshot_data:
+                # Every reservation persists an event-time snapshot (see the
+                # reservation write below), so its absence is a corrupt/foreign
+                # record, not a recoverable state — fail loudly rather than
+                # silently reassessing against drifted current state.
+                raise ValueError(
+                    f"reserved event {event.source_event_key} has no persisted "
+                    "snapshot; refusing to reassess against current state"
+                )
+            snapshot = self._codec.deserialize_snapshot(snapshot_data)
         else:
             snapshot = snapshot_for_reservation
         try:
@@ -280,11 +285,11 @@ class SessionMonitor:
                     }
                 )
                 try:
-                    self._store.execute_in_transaction(
-                        "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
-                        (degraded_json, event.source_event_key),
-                    )
-                    self._store.commit()
+                    with self._store.write_transaction():
+                        self._store.execute_in_transaction(
+                            "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
+                            (degraded_json, event.source_event_key),
+                        )
                     self._store.cache_processed(event.source_event_key, degraded_json)
                     # Only clear attempts after successful dead-letter persistence
                     del self._phase23_attempts[event.source_event_key]
@@ -295,8 +300,9 @@ class SessionMonitor:
                         if not dl_keys:
                             del self._phase23_session_keys[session_id]
                 except (sqlite3.OperationalError, sqlite3.IntegrityError):
-                    self._store.rollback()
-                    # Keep attempt count — next retry will try dead-lettering again
+                    # write_transaction already rolled back — keep the attempt
+                    # count so the next retry re-attempts dead-lettering.
+                    pass
                 return degraded_meta
             else:
                 logger.warning(
@@ -316,14 +322,14 @@ class SessionMonitor:
                             "snapshot": self._codec.serialize_snapshot(snapshot),
                         }
                     )
-                    self._store.execute_in_transaction(
-                        "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
-                        (reservation_json, event.source_event_key),
-                    )
-                    self._store.commit()
+                    with self._store.write_transaction():
+                        self._store.execute_in_transaction(
+                            "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
+                            (reservation_json, event.source_event_key),
+                        )
                     self._store.cache_processed(event.source_event_key, reservation_json)
                 except (sqlite3.OperationalError, sqlite3.IntegrityError):
-                    self._store.rollback()
+                    pass  # write_transaction already rolled back
                 return SessionMeta(
                     classification=None,
                     risk_assessment=None,
@@ -343,15 +349,15 @@ class SessionMonitor:
         # Finalize idempotency record + deferred MCP writes in single transaction
         try:
             meta_json = json.dumps(self._codec.serialize_meta(meta))
-            self._store.execute_in_transaction(
-                "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
-                (meta_json, event.source_event_key),
-            )
-            if assessment.mcp_deferred_writes:
-                self._commit_mcp_writes_no_commit(assessment.mcp_deferred_writes)
-            if assessment.integrity_deferred_writes:
-                self._commit_integrity_writes_no_commit(assessment.integrity_deferred_writes)
-            self._store.commit()
+            with self._store.write_transaction():
+                self._store.execute_in_transaction(
+                    "UPDATE processed_events SET session_meta_json = ? WHERE source_event_key = ?",
+                    (meta_json, event.source_event_key),
+                )
+                if assessment.mcp_deferred_writes:
+                    self._commit_mcp_writes_no_commit(assessment.mcp_deferred_writes)
+                if assessment.integrity_deferred_writes:
+                    self._commit_integrity_writes_no_commit(assessment.integrity_deferred_writes)
             self._store.cache_processed(event.source_event_key, meta_json)
         except (
             sqlite3.OperationalError,
@@ -369,9 +375,8 @@ class SessionMonitor:
                 event.source_event_key,
                 e,
             )
-            self._store.rollback()
-            # Event stays reserved; next delivery re-runs Phase 2/3
-            # Do NOT clear retry counter — finalization did not commit
+            # write_transaction already rolled back — event stays reserved so the
+            # next delivery re-runs Phase 2/3. Do NOT clear the retry counter.
             return SessionMeta(
                 classification=meta.classification,
                 risk_assessment=meta.risk_assessment,
@@ -393,33 +398,20 @@ class SessionMonitor:
         return meta
 
     def _commit_mcp_writes_no_commit(self, writes: tuple) -> None:
-        """Execute deferred MCP writes without committing — caller owns transaction."""
+        """Execute deferred MCP writes without committing — caller owns transaction.
+
+        Delegates to the store's ``*_no_commit`` helpers so each write lands in the
+        normalized tables (``mcp_profiles`` + ``mcp_profile_attributes``) inside the
+        caller's :meth:`SystemStore.write_transaction`.
+        """
         for write in writes:
             if write.kind == "upsert":
-                profile = json.loads(write.payload)
-                self._store.execute_in_transaction(
-                    """INSERT OR IGNORE INTO mcp_fingerprints
-                       (server, tool_name, description_hash, schema_hash, registered_effect,
-                        registered_role, registered_capabilities, registered_scope, clearance, first_seen, last_seen)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        write.server,
-                        write.tool_name,
-                        profile["description_hash"],
-                        profile["schema_hash"],
-                        profile.get("registered_effect"),
-                        profile.get("registered_role"),
-                        profile.get("registered_capabilities"),
-                        profile.get("registered_scope"),
-                        profile.get("clearance"),
-                        profile["first_seen"],
-                        profile["last_seen"],
-                    ),
+                self._store.write_mcp_profile_no_commit(
+                    write.server, write.tool_name, json.loads(write.payload)
                 )
             elif write.kind == "last_seen":
-                self._store.execute_in_transaction(
-                    "UPDATE mcp_fingerprints SET last_seen = ? WHERE server = ? AND tool_name = ?",
-                    (write.payload, write.server, write.tool_name),
+                self._store.write_mcp_last_seen_no_commit(
+                    write.server, write.tool_name, write.payload
                 )
 
     def _commit_integrity_writes_no_commit(self, writes: tuple) -> None:
@@ -444,7 +436,7 @@ class SessionMonitor:
         import logging
 
         now = datetime.now(timezone.utc).isoformat()
-        budget_json = json_mod.dumps(
+        budget_snapshot_json = json_mod.dumps(
             {
                 "total_tool_calls": snapshot.budget.total_tool_calls,
                 "total_tokens": snapshot.budget.total_tokens,
@@ -452,14 +444,24 @@ class SessionMonitor:
             }
         )
         try:
-            # INSERT OR IGNORE: first delivery records started_at/ended_at; duplicates are no-ops
-            self._store.connection.execute(
-                """INSERT OR IGNORE INTO session_summaries
-                   (session_id, started_at, ended_at, total_events, dropped_events, budget_snapshot_json)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
-                (session_id, now, now, snapshot.event_count, snapshot.dropped_events, budget_json),
-            )
-            self._store.connection.commit()
+            # INSERT OR IGNORE: first delivery records started_at/ended_at; duplicates are no-ops.
+            # Routed through write_transaction so the commit is serialized on the
+            # shared connection (single writer) rather than racing another writer's
+            # open transaction with a bare connection.commit().
+            with self._store.write_transaction():
+                self._store.execute_in_transaction(
+                    """INSERT OR IGNORE INTO session_summaries
+                       (session_id, started_at, ended_at, total_events, dropped_events, budget_snapshot_json)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        now,
+                        now,
+                        snapshot.event_count,
+                        snapshot.dropped_events,
+                        budget_snapshot_json,
+                    ),
+                )
         except sqlite3.OperationalError as e:
             logging.getLogger(__name__).warning(
                 "Failed to write session summary for %s: %s", session_id, e

--- a/src/tracemill/governance/persistence.py
+++ b/src/tracemill/governance/persistence.py
@@ -2,18 +2,21 @@
 
 Schema is managed by Alembic migrations (src/tracemill/migrations/).
 On initialization, SystemStore runs ``alembic upgrade head`` to apply
-any pending migrations. For existing databases created before Alembic was
-introduced, we stamp the initial revision so future migrations apply cleanly.
+any pending migrations, creating the full normalized schema on a fresh
+database.
 """
 
 from __future__ import annotations
 
-import logging
+import json
 import sqlite3
 import threading
+from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _LRU_CACHE_SIZE = 10_000
 
@@ -64,49 +67,28 @@ def _run_alembic(conn: sqlite3.Connection) -> None:
         conn.isolation_level = original_isolation_level
 
 
-def _stamp_existing_db(conn: sqlite3.Connection) -> None:
-    """Stamp an existing (pre-Alembic) database with the initial revision.
-
-    If the database already has tables but no alembic_version table, this
-    creates the version table and stamps it so migrations start from 0001.
-    """
-    cursor = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='alembic_version'"
-    )
-    if cursor.fetchone() is not None:
-        return  # Already managed by Alembic
-
-    # Check if this is an existing database (has our tables)
-    cursor = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='session_state'"
-    )
-    if cursor.fetchone() is None:
-        return  # Fresh database — Alembic will create everything
-
-    # Existing database without Alembic — stamp it at the initial revision
-    logger.info("Stamping existing database with initial Alembic revision")
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS alembic_version "
-        "(version_num VARCHAR(32) NOT NULL, PRIMARY KEY (version_num))"
-    )
-    conn.execute("INSERT OR IGNORE INTO alembic_version (version_num) VALUES ('0001_initial')")
-
-    # Also ensure gate_endpoints exists (was previously managed separately)
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS gate_endpoints (
-            session_id TEXT PRIMARY KEY,
-            sock_path TEXT NOT NULL,
-            pid INTEGER NOT NULL,
-            registered_at TEXT NOT NULL DEFAULT (datetime('now'))
-        )
-    """)
-    conn.commit()
-
-
 class SystemStore:
     """SQLite-backed persistence for governance state.
 
     On construction, runs Alembic migrations to ensure the schema is at HEAD.
+
+    Single-writer guarantee
+    -----------------------
+    The store is a *synchronous* durability layer over a single ``sqlite3``
+    connection opened with ``check_same_thread=False``. The pipeline is asyncio
+    single-threaded and offloads store writes to a worker thread (via
+    ``asyncio.to_thread``), so writes can originate on *different* OS threads even
+    though they are never logically concurrent per session. An ``asyncio.Queue``
+    or ``asyncio.Lock`` cannot serialize work that runs off-loop on arbitrary
+    threads, so the correct primitive for this sync store is a
+    :class:`threading.Lock` — not a second, async concurrency primitive.
+
+    Every mutation is serialized by :attr:`_lock`. Single-statement writes take
+    the lock around ``execute`` + ``commit``. Multi-statement transactions MUST
+    go through :meth:`write_transaction`, which holds the lock for the *entire*
+    transaction (not just the terminal ``commit``), guaranteeing that no two
+    writers ever interleave statements on the shared connection. This is the one
+    and only write-serialization mechanism; callers must never open a second one.
     """
 
     def __init__(self, db_path: str | Path) -> None:
@@ -122,9 +104,6 @@ class SystemStore:
         self._conn.execute("PRAGMA busy_timeout = 5000")
         self._conn.execute("PRAGMA synchronous = NORMAL")
 
-        # Stamp existing databases so Alembic doesn't try to re-create tables
-        _stamp_existing_db(self._conn)
-
         # Run migrations to HEAD
         _run_alembic(self._conn)
 
@@ -136,6 +115,36 @@ class SystemStore:
     def lock(self):
         """Threading lock for callers needing multi-statement transactions."""
         return self._lock
+
+    @contextmanager
+    def write_transaction(self) -> "Iterator[sqlite3.Connection]":
+        """Serialize a full multi-statement write transaction under the writer lock.
+
+        This is the formal single-writer entry point for any write that spans more
+        than one statement (state persist + idempotency reservation, deferred MCP
+        writes + finalization, etc.). It:
+
+        * acquires :attr:`_lock` for the whole transaction — every statement the
+          body issues on the connection is covered, not merely the final commit —
+          so concurrent writers can never interleave on the shared connection;
+        * commits on clean exit; and
+        * rolls back and re-raises on *any* exception, leaving no dangling
+          transaction behind.
+
+        The body MUST issue its statements without re-acquiring the lock (use
+        :meth:`execute_in_transaction` / the ``*_no_commit`` helpers, which do not
+        lock). ``_lock`` is a non-reentrant :class:`threading.Lock`, so calling a
+        self-locking method (e.g. :meth:`commit`) from inside the body would
+        deadlock.
+        """
+        with self._lock:
+            try:
+                yield self._conn
+            except BaseException:
+                self._conn.rollback()
+                raise
+            else:
+                self._conn.commit()
 
     def is_duplicate(self, source_event_key: str) -> str | None:
         """Check if event was already processed. Returns cached meta JSON or None."""
@@ -187,60 +196,129 @@ class SystemStore:
         self._processed_cache[source_event_key] = meta_json
 
     def get_mcp_profile(self, server: str, tool_name: str) -> dict | None:
-        """Get stored MCP fingerprint."""
+        """Read an MCP tool profile from the normalized tables.
+
+        Returns the scalar fingerprint fields plus ``role``/``capability``/
+        ``scope`` as sorted lists reconstructed from ``mcp_profile_attributes``,
+        or ``None`` when the tool has never been registered.
+        """
         with self._lock:
             row = self._conn.execute(
-                "SELECT * FROM mcp_fingerprints WHERE server = ? AND tool_name = ?",
+                """SELECT server, tool_name, description_hash, schema_hash, registered_effect,
+                          clearance, first_seen, last_seen
+                   FROM mcp_profiles WHERE server = ? AND tool_name = ?""",
                 (server, tool_name),
             ).fetchone()
-        if not row:
-            return None
+            if not row:
+                return None
+            attr_rows = self._conn.execute(
+                "SELECT attr_type, attr_value FROM mcp_profile_attributes "
+                "WHERE server = ? AND tool_name = ?",
+                (server, tool_name),
+            ).fetchall()
+        attributes: dict[str, list[str]] = {"role": [], "capability": [], "scope": []}
+        for attr_type, attr_value in attr_rows:
+            attributes.setdefault(attr_type, []).append(attr_value)
         return {
             "server": row[0],
             "tool_name": row[1],
             "description_hash": row[2],
             "schema_hash": row[3],
             "registered_effect": row[4],
-            "registered_role": row[5],
-            "registered_capabilities": row[6],
-            "registered_scope": row[7],
-            "clearance": row[8],
-            "first_seen": row[9],
-            "last_seen": row[10],
+            "clearance": row[5],
+            "first_seen": row[6],
+            "last_seen": row[7],
+            "role": sorted(attributes["role"]),
+            "capability": sorted(attributes["capability"]),
+            "scope": sorted(attributes["scope"]),
         }
 
     def upsert_mcp_profile(self, server: str, tool_name: str, profile: dict) -> None:
         """Insert MCP profile only if not already registered (preserves first-seen baseline)."""
         with self._lock:
-            self._conn.execute(
-                """INSERT OR IGNORE INTO mcp_fingerprints
-                   (server, tool_name, description_hash, schema_hash, registered_effect,
-                    registered_role, registered_capabilities, registered_scope, clearance, first_seen, last_seen)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    server,
-                    tool_name,
-                    profile["description_hash"],
-                    profile["schema_hash"],
-                    profile.get("registered_effect"),
-                    profile.get("registered_role"),
-                    profile.get("registered_capabilities"),
-                    profile.get("registered_scope"),
-                    profile.get("clearance"),
-                    profile["first_seen"],
-                    profile["last_seen"],
-                ),
-            )
+            self.write_mcp_profile_no_commit(server, tool_name, profile)
             self._conn.commit()
+
+    def write_mcp_profile_no_commit(self, server: str, tool_name: str, profile: dict) -> None:
+        """Write an MCP profile within the caller's transaction (no lock, no commit).
+
+        Writes the scalar ``mcp_profiles`` row plus one ``mcp_profile_attributes``
+        row per role/capability/scope value. ``INSERT OR IGNORE`` on every table
+        preserves the first-seen baseline (a re-registration of an existing tool
+        is a no-op).
+        """
+        self._conn.execute(
+            """INSERT OR IGNORE INTO mcp_profiles
+               (server, tool_name, description_hash, schema_hash, registered_effect,
+                clearance, first_seen, last_seen)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                server,
+                tool_name,
+                profile["description_hash"],
+                profile["schema_hash"],
+                profile.get("registered_effect"),
+                profile.get("clearance"),
+                profile["first_seen"],
+                profile["last_seen"],
+            ),
+        )
+        for attr_type in ("role", "capability", "scope"):
+            for value in profile.get(attr_type) or ():
+                self._conn.execute(
+                    """INSERT OR IGNORE INTO mcp_profile_attributes
+                       (server, tool_name, attr_type, attr_value) VALUES (?, ?, ?, ?)""",
+                    (server, tool_name, attr_type, value),
+                )
 
     def update_mcp_last_seen(self, server: str, tool_name: str, last_seen: str) -> None:
         """Update only last_seen timestamp — preserves registered baseline."""
         with self._lock:
-            self._conn.execute(
-                "UPDATE mcp_fingerprints SET last_seen = ? WHERE server = ? AND tool_name = ?",
-                (last_seen, server, tool_name),
-            )
+            self.write_mcp_last_seen_no_commit(server, tool_name, last_seen)
             self._conn.commit()
+
+    def write_mcp_last_seen_no_commit(self, server: str, tool_name: str, last_seen: str) -> None:
+        """Bump last_seen on the profile within the caller's transaction."""
+        self._conn.execute(
+            "UPDATE mcp_profiles SET last_seen = ? WHERE server = ? AND tool_name = ?",
+            (last_seen, server, tool_name),
+        )
+
+    def get_budget_counters(self, session_id: str) -> dict[str, dict[str, int]]:
+        """Read a session's normalized dimensional budget counters.
+
+        Returns ``{dimension: {key: count}}`` reconstructed from
+        ``budget_counters``. The atomic scalar budget fields (total_tool_calls,
+        etc.) are columns on ``session_state``, not part of this projection.
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT dimension, key, count FROM budget_counters WHERE session_id = ?",
+                (session_id,),
+            ).fetchall()
+        counters: dict[str, dict[str, int]] = {}
+        for dimension, key, count in rows:
+            counters.setdefault(dimension, {})[key] = count
+        return counters
+
+    def get_taint_entries(self, session_id: str) -> list[dict]:
+        """Read a session's normalized taint ledger, ordered by append ordinal."""
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT event_id, source_event_key, clearance, source, payload_pointer
+                   FROM taint_entries WHERE session_id = ? ORDER BY ordinal""",
+                (session_id,),
+            ).fetchall()
+        return [
+            {
+                "event_id": r[0],
+                "source_event_key": r[1],
+                "clearance": r[2],
+                "source": r[3],
+                "payload_pointer": r[4],
+            }
+            for r in rows
+        ]
 
     def get_content_hash(self, repo: str, file_path: str) -> str | None:
         with self._lock:
@@ -280,8 +358,6 @@ class SystemStore:
             ).fetchone()
         if not row:
             return None
-        import json
-
         return {"phase_counts": json.loads(row[0]), "total_events": row[1]}
 
     def execute_in_transaction(self, sql: str, params: tuple = ()) -> None:
@@ -308,13 +384,9 @@ class SystemStore:
 
         Accepts tuple[MCPDeferredWrite, ...] from MCPScanResult.
         """
-        import json as json_mod
-
         for write in writes:
             if write.kind == "upsert":
-                self.upsert_mcp_profile(
-                    write.server, write.tool_name, json_mod.loads(write.payload)
-                )
+                self.upsert_mcp_profile(write.server, write.tool_name, json.loads(write.payload))
             elif write.kind == "last_seen":
                 self.update_mcp_last_seen(write.server, write.tool_name, write.payload)
 

--- a/src/tracemill/governance/registry.py
+++ b/src/tracemill/governance/registry.py
@@ -67,7 +67,7 @@ class SessionRegistry:
 
         if session_id not in self._durable_states:
             self._durable_states[session_id] = SessionState.load_from_db(
-                session_id, self._store.connection
+                session_id, self._store.connection, self._store.lock
             )
         return self._durable_states[session_id]
 

--- a/src/tracemill/governance/state.py
+++ b/src/tracemill/governance/state.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from collections import Counter, deque
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+
+_BUDGET_DIMENSIONS = (
+    "effect",
+    "mechanism",
+    "scope",
+    "role",
+    "phase",
+    "capability",
+    "action",
+    "structure",
+)
 
 
 @dataclass(frozen=True)
@@ -90,6 +103,10 @@ class SessionState:
     _last_sequence: int | None = None
     _gap_ordinal: int = 0
     _db: sqlite3.Connection | None = None
+    # Writer lock shared with the owning SystemStore. When present, a standalone
+    # ``persist`` acquires it for the whole transaction so it is serialized against
+    # the monitor's ``write_transaction`` on the shared connection (single writer).
+    _lock: "threading.Lock | None" = None
     # Shield (enforcement) decision log. The tool-call counter itself is NOT
     # here — it is _total_tool_calls above, advanced only by increment_budget.
     _denied_count: int = 0
@@ -112,8 +129,11 @@ class SessionState:
                 "structure": Counter(),
             }
 
-    def attach_db(self, db: sqlite3.Connection | None) -> None:
+    def attach_db(
+        self, db: sqlite3.Connection | None, lock: "threading.Lock | None" = None
+    ) -> None:
         self._db = db
+        self._lock = lock
 
     def increment_budget(
         self,
@@ -285,58 +305,31 @@ class SessionState:
             gap_ordinal=self._gap_ordinal,
         )
 
-    def persist(self) -> None:
-        """Write-through to SQLite."""
-        if self._db is None:
-            return
-        budget_json = json.dumps(
-            {
-                "version": 1,
-                "total_tool_calls": self._total_tool_calls,
-                "total_tokens": self._total_tokens,
-                "elapsed_seconds": self._elapsed_seconds,
-                "by_effect": dict(self._budget_counters["effect"]),
-                "by_mechanism": dict(self._budget_counters["mechanism"]),
-                "by_scope": dict(self._budget_counters["scope"]),
-                "by_role": dict(self._budget_counters["role"]),
-                "by_phase": dict(self._budget_counters["phase"]),
-                "by_capability": dict(self._budget_counters["capability"]),
-                "by_action": dict(self._budget_counters["action"]),
-                "by_structure": dict(self._budget_counters["structure"]),
-                "pressure": self._pressure,
-            }
-        )
-        phase_json = json.dumps(self._phase_window)
-        taints_json = (
-            json.dumps(
-                [
-                    {
-                        "event_id": t.event_id,
-                        "source_event_key": t.source_event_key,
-                        "clearance": t.clearance,
-                        "source": t.source,
-                        "payload_pointer": t.payload_pointer,
-                    }
-                    for t in self._taint_ledger
-                ]
-            )
-            if self._taint_ledger
-            else None
-        )
+    def _write_state_rows(self) -> None:
+        """Write every durable row for this session on the OPEN transaction.
+
+        Writes the ``session_state`` scalar row plus the normalized projections
+        (``budget_counters`` dimensional maps, ``taint_entries`` ledger). Does not
+        commit and does not lock — the caller owns both (either :meth:`persist`
+        under the writer lock, or the monitor's ``write_transaction``).
+        """
+        assert self._db is not None  # guarded by callers
         now = datetime.now(timezone.utc).isoformat()
         self._db.execute(
             """INSERT OR REPLACE INTO session_state
-               (session_id, budget_json, phase_window_json, last_assistant_json,
-                last_user_json, pii_taints_json, event_count, dropped_events,
-                last_sequence, last_event_id, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               (session_id, total_tool_calls, total_tokens, elapsed_seconds, pressure,
+                phase_window_json, last_assistant_json, last_user_json,
+                event_count, dropped_events, last_sequence, last_event_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 self.session_id,
-                budget_json,
-                phase_json,
+                self._total_tool_calls,
+                self._total_tokens,
+                self._elapsed_seconds,
+                int(self._pressure),
+                json.dumps(self._phase_window),
                 self._last_assistant_event_id,
                 self._last_user_event_id,
-                taints_json,
                 self._event_count,
                 self._dropped_events,
                 self._last_sequence,
@@ -344,111 +337,130 @@ class SessionState:
                 now,
             ),
         )
-        self._db.commit()
+        # Normalized budget counters: full rewrite mirrors the write-through
+        # semantics of INSERT OR REPLACE above (the in-memory Counters are the
+        # single source of truth for this session).
+        self._db.execute("DELETE FROM budget_counters WHERE session_id = ?", (self.session_id,))
+        for dimension, counter in self._budget_counters.items():
+            for key, count in counter.items():
+                self._db.execute(
+                    "INSERT INTO budget_counters (session_id, dimension, key, count) "
+                    "VALUES (?, ?, ?, ?)",
+                    (self.session_id, dimension, key, count),
+                )
+        # Normalized taint ledger: ordinal preserves append order so the bounded
+        # ring-buffer trim behaves identically after a reload.
+        self._db.execute("DELETE FROM taint_entries WHERE session_id = ?", (self.session_id,))
+        for ordinal, t in enumerate(self._taint_ledger):
+            self._db.execute(
+                "INSERT INTO taint_entries (session_id, ordinal, event_id, source_event_key, "
+                "clearance, source, payload_pointer) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    self.session_id,
+                    ordinal,
+                    t.event_id,
+                    t.source_event_key,
+                    t.clearance,
+                    t.source,
+                    t.payload_pointer,
+                ),
+            )
+
+    def persist(self) -> None:
+        """Write-through to SQLite (self-committing, single-writer safe).
+
+        Acquires the store's writer lock (when one was attached) for the whole
+        transaction, so a standalone persist — e.g. the emitter's drop-recording
+        path — is serialized against the monitor's ``write_transaction`` on the
+        shared connection instead of racing it.
+        """
+        if self._db is None:
+            return
+        with self._lock if self._lock is not None else nullcontext():
+            self._write_state_rows()
+            self._db.commit()
 
     def persist_no_commit(self) -> None:
         """Write state to SQLite WITHOUT committing — caller must commit.
-        Used for atomic state+reservation transactions."""
+
+        Used for atomic state+reservation transactions; the caller (the monitor's
+        ``write_transaction``) already holds the writer lock, so this must not lock
+        or commit.
+        """
         if self._db is None:
             return
-        budget_json = json.dumps(
-            {
-                "version": 1,
-                "total_tool_calls": self._total_tool_calls,
-                "total_tokens": self._total_tokens,
-                "elapsed_seconds": self._elapsed_seconds,
-                "by_effect": dict(self._budget_counters["effect"]),
-                "by_mechanism": dict(self._budget_counters["mechanism"]),
-                "by_scope": dict(self._budget_counters["scope"]),
-                "by_role": dict(self._budget_counters["role"]),
-                "by_phase": dict(self._budget_counters["phase"]),
-                "by_capability": dict(self._budget_counters["capability"]),
-                "by_action": dict(self._budget_counters["action"]),
-                "by_structure": dict(self._budget_counters["structure"]),
-                "pressure": self._pressure,
-            }
-        )
-        phase_json = json.dumps(self._phase_window)
-        taints_json = (
-            json.dumps(
-                [
-                    {
-                        "event_id": t.event_id,
-                        "source_event_key": t.source_event_key,
-                        "clearance": t.clearance,
-                        "source": t.source,
-                        "payload_pointer": t.payload_pointer,
-                    }
-                    for t in self._taint_ledger
-                ]
+        self._write_state_rows()
+
+    @staticmethod
+    def _read_budget_counters(db: sqlite3.Connection, session_id: str) -> dict[str, dict[str, int]]:
+        """Read the normalized dimensional counters as ``{dimension: {key: count}}``."""
+        rows = db.execute(
+            "SELECT dimension, key, count FROM budget_counters WHERE session_id = ?",
+            (session_id,),
+        ).fetchall()
+        counters: dict[str, dict[str, int]] = {}
+        for dimension, key, count in rows:
+            counters.setdefault(dimension, {})[key] = count
+        return counters
+
+    @staticmethod
+    def _read_taint_entries(db: sqlite3.Connection, session_id: str) -> list["TaintEntry"]:
+        """Read the normalized taint ledger, ordered by append ordinal."""
+        rows = db.execute(
+            "SELECT event_id, source_event_key, clearance, source, payload_pointer "
+            "FROM taint_entries WHERE session_id = ? ORDER BY ordinal",
+            (session_id,),
+        ).fetchall()
+        return [
+            TaintEntry(
+                event_id=r[0],
+                source_event_key=r[1],
+                clearance=r[2],
+                source=r[3],
+                payload_pointer=r[4],
             )
-            if self._taint_ledger
-            else None
-        )
-        now = datetime.now(timezone.utc).isoformat()
-        self._db.execute(
-            """INSERT OR REPLACE INTO session_state
-               (session_id, budget_json, phase_window_json, last_assistant_json,
-                last_user_json, pii_taints_json, event_count, dropped_events,
-                last_sequence, last_event_id, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                self.session_id,
-                budget_json,
-                phase_json,
-                self._last_assistant_event_id,
-                self._last_user_event_id,
-                taints_json,
-                self._event_count,
-                self._dropped_events,
-                self._last_sequence,
-                None,
-                now,
-            ),
-        )
+            for r in rows
+        ]
 
     @classmethod
-    def load_from_db(cls, session_id: str, db: sqlite3.Connection) -> "SessionState":
-        """Load state from SQLite on restart."""
-        row = db.execute(
-            "SELECT * FROM session_state WHERE session_id = ?", (session_id,)
-        ).fetchone()
+    def load_from_db(
+        cls,
+        session_id: str,
+        db: sqlite3.Connection,
+        lock: "threading.Lock | None" = None,
+    ) -> "SessionState":
+        """Load state from SQLite on restart.
+
+        SQLite is authoritative: the atomic budget scalars are read from
+        ``session_state`` columns, the dimensional counters from
+        ``budget_counters``, and the taint ledger from ``taint_entries``. The
+        whole read runs under the writer lock (when provided) for a consistent
+        snapshot against a concurrent ``write_transaction``.
+        """
         state = cls(session_id=session_id)
-        state.attach_db(db)
-        if row is None:
-            return state
-        budget_data = json.loads(row[1]) if row[1] else {}
-        state._total_tool_calls = budget_data.get("total_tool_calls", 0)
-        state._total_tokens = budget_data.get("total_tokens", 0)
-        state._elapsed_seconds = budget_data.get("elapsed_seconds", 0.0)
-        state._pressure = budget_data.get("pressure", False)
-        for dim in (
-            "effect",
-            "mechanism",
-            "scope",
-            "role",
-            "phase",
-            "capability",
-            "action",
-            "structure",
-        ):
-            state._budget_counters[dim] = Counter(budget_data.get(f"by_{dim}", {}))
-        state._phase_window = json.loads(row[2]) if row[2] else []
-        state._last_assistant_event_id = row[3]
-        state._last_user_event_id = row[4]
-        if row[5]:
-            taints = json.loads(row[5])
-            state._taint_ledger = [
-                TaintEntry(
-                    event_id=t["event_id"],
-                    source_event_key=t.get("source_event_key") or t["event_id"],
-                    clearance=t["clearance"],
-                    source=t["source"],
-                    payload_pointer=t["payload_pointer"],
-                )
-                for t in taints
-            ]
-        state._event_count = row[6] or 0
-        state._dropped_events = row[7] or 0
-        state._last_sequence = row[8]
+        state.attach_db(db, lock)
+        with lock if lock is not None else nullcontext():
+            row = db.execute(
+                """SELECT total_tool_calls, total_tokens, elapsed_seconds, pressure,
+                          phase_window_json, last_assistant_json, last_user_json,
+                          event_count, dropped_events, last_sequence
+                   FROM session_state WHERE session_id = ?""",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return state
+            state._total_tool_calls = row[0] or 0
+            state._total_tokens = row[1] or 0
+            state._elapsed_seconds = row[2] or 0.0
+            state._pressure = bool(row[3])
+            counters = cls._read_budget_counters(db, session_id)
+            for dim in _BUDGET_DIMENSIONS:
+                state._budget_counters[dim] = Counter(counters.get(dim, {}))
+            state._phase_window = json.loads(row[4]) if row[4] else []
+            state._last_assistant_event_id = row[5]
+            state._last_user_event_id = row[6]
+            state._taint_ledger = cls._read_taint_entries(db, session_id)
+            state._event_count = row[7] or 0
+            state._dropped_events = row[8] or 0
+            state._last_sequence = row[9]
         return state

--- a/src/tracemill/migrations/models.py
+++ b/src/tracemill/migrations/models.py
@@ -15,16 +15,13 @@ session_state = Table(
     "session_state",
     metadata,
     Column("session_id", Text, primary_key=True),
-    Column(
-        "budget_json",
-        Text,
-        nullable=False,
-        server_default='{"version":1,"total_tool_calls":0,"total_tokens":0,"elapsed_seconds":0.0,"pressure":false}',
-    ),
+    Column("total_tool_calls", Integer, nullable=False, server_default="0"),
+    Column("total_tokens", Integer, nullable=False, server_default="0"),
+    Column("elapsed_seconds", Float, nullable=False, server_default="0.0"),
+    Column("pressure", Integer, nullable=False, server_default="0"),
     Column("phase_window_json", Text, nullable=False, server_default="[]"),
     Column("last_assistant_json", Text),
     Column("last_user_json", Text),
-    Column("pii_taints_json", Text),
     Column("event_count", Integer, nullable=False, server_default="0"),
     Column("dropped_events", Integer, nullable=False, server_default="0"),
     Column("last_sequence", Integer),
@@ -39,23 +36,6 @@ processed_events = Table(
     Column("session_id", Text, nullable=False),
     Column("session_meta_json", Text),
     Column("processed_at", Text, nullable=False),
-)
-
-mcp_fingerprints = Table(
-    "mcp_fingerprints",
-    metadata,
-    Column("server", Text, nullable=False),
-    Column("tool_name", Text, nullable=False),
-    Column("description_hash", Text, nullable=False),
-    Column("schema_hash", Text, nullable=False),
-    Column("registered_effect", Text),
-    Column("registered_role", Text),
-    Column("registered_capabilities", Text),
-    Column("registered_scope", Text),
-    Column("clearance", Text),
-    Column("first_seen", Text, nullable=False),
-    Column("last_seen", Text, nullable=False),
-    PrimaryKeyConstraint("server", "tool_name"),
 )
 
 drift_baselines = Table(
@@ -102,4 +82,64 @@ gate_endpoints = Table(
     Column("sock_path", Text, nullable=False),
     Column("pid", Integer, nullable=False),
     Column("registered_at", Text, nullable=False, server_default="(datetime('now'))"),
+)
+
+# ── Normalized 1NF tables ───────────────────────────────────────────────────
+# Budget dimensions, the taint ledger, and MCP tool attributes are stored in
+# first normal form from the outset — there is no JSON-blob/JSON-array shape to
+# migrate away from. These are the single source of truth for their data.
+
+# One row per (session, budget dimension, key). The atomic budget scalars
+# (total_tool_calls, total_tokens, elapsed_seconds, pressure) are columns on
+# session_state — they are already atomic and need no decomposition.
+budget_counters = Table(
+    "budget_counters",
+    metadata,
+    Column("session_id", Text, nullable=False),
+    Column("dimension", Text, nullable=False),
+    Column("key", Text, nullable=False),
+    Column("count", Integer, nullable=False),
+    PrimaryKeyConstraint("session_id", "dimension", "key"),
+)
+
+# One row per taint-ledger entry. ``ordinal`` preserves append order so the
+# bounded ring-buffer semantics survive a reload.
+taint_entries = Table(
+    "taint_entries",
+    metadata,
+    Column("session_id", Text, nullable=False),
+    Column("ordinal", Integer, nullable=False),
+    Column("event_id", Text, nullable=False),
+    Column("source_event_key", Text, nullable=False),
+    Column("clearance", Text, nullable=False),
+    Column("source", Text, nullable=False),
+    Column("payload_pointer", Text, nullable=False),
+    PrimaryKeyConstraint("session_id", "ordinal"),
+)
+
+# Scalar MCP tool fingerprint. The many-valued role/capability/scope attributes
+# live in mcp_profile_attributes below (1NF), one row per value.
+mcp_profiles = Table(
+    "mcp_profiles",
+    metadata,
+    Column("server", Text, nullable=False),
+    Column("tool_name", Text, nullable=False),
+    Column("description_hash", Text, nullable=False),
+    Column("schema_hash", Text, nullable=False),
+    Column("registered_effect", Text),
+    Column("clearance", Text),
+    Column("first_seen", Text, nullable=False),
+    Column("last_seen", Text, nullable=False),
+    PrimaryKeyConstraint("server", "tool_name"),
+)
+
+# One row per many-valued MCP attribute (role / capability / scope).
+mcp_profile_attributes = Table(
+    "mcp_profile_attributes",
+    metadata,
+    Column("server", Text, nullable=False),
+    Column("tool_name", Text, nullable=False),
+    Column("attr_type", Text, nullable=False),  # 'role' | 'capability' | 'scope'
+    Column("attr_value", Text, nullable=False),
+    PrimaryKeyConstraint("server", "tool_name", "attr_type", "attr_value"),
 )

--- a/src/tracemill/migrations/versions/0001_initial.py
+++ b/src/tracemill/migrations/versions/0001_initial.py
@@ -1,4 +1,10 @@
-"""Initial schema — captures existing tables.
+"""Initial schema — the single, normalized system database.
+
+Budget dimensions, the taint ledger, and MCP tool profiles are stored in
+first-normal-form tables from the outset (``budget_counters``,
+``taint_entries``, ``mcp_profiles`` + ``mcp_profile_attributes``); the atomic
+budget scalars are plain columns on ``session_state``. No JSON-blob or
+JSON-array representation of these ever exists.
 
 Revision ID: 0001_initial
 Revises: None
@@ -29,11 +35,13 @@ def upgrade() -> None:
     conn.exec_driver_sql("""
         CREATE TABLE IF NOT EXISTS session_state (
             session_id TEXT PRIMARY KEY,
-            budget_json TEXT NOT NULL DEFAULT '{"version":1,"total_tool_calls":0,"total_tokens":0,"elapsed_seconds":0.0,"pressure":false}',
+            total_tool_calls INTEGER NOT NULL DEFAULT 0,
+            total_tokens INTEGER NOT NULL DEFAULT 0,
+            elapsed_seconds REAL NOT NULL DEFAULT 0.0,
+            pressure INTEGER NOT NULL DEFAULT 0,
             phase_window_json TEXT NOT NULL DEFAULT '[]',
             last_assistant_json TEXT,
             last_user_json TEXT,
-            pii_taints_json TEXT,
             event_count INTEGER NOT NULL DEFAULT 0,
             dropped_events INTEGER NOT NULL DEFAULT 0,
             last_sequence INTEGER,
@@ -51,20 +59,60 @@ def upgrade() -> None:
         )
     """)
 
+    # ── Normalized MCP tool profiles ──
+    # Scalar fingerprint per (server, tool). The many-valued role/capability/
+    # scope attributes live in mcp_profile_attributes (1NF), one row per value.
     conn.exec_driver_sql("""
-        CREATE TABLE IF NOT EXISTS mcp_fingerprints (
+        CREATE TABLE IF NOT EXISTS mcp_profiles (
             server TEXT NOT NULL,
             tool_name TEXT NOT NULL,
             description_hash TEXT NOT NULL,
             schema_hash TEXT NOT NULL,
             registered_effect TEXT,
-            registered_role TEXT,
-            registered_capabilities TEXT,
-            registered_scope TEXT,
             clearance TEXT,
             first_seen TEXT NOT NULL,
             last_seen TEXT NOT NULL,
             PRIMARY KEY (server, tool_name)
+        )
+    """)
+
+    conn.exec_driver_sql("""
+        CREATE TABLE IF NOT EXISTS mcp_profile_attributes (
+            server TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            attr_type TEXT NOT NULL,
+            attr_value TEXT NOT NULL,
+            PRIMARY KEY (server, tool_name, attr_type, attr_value)
+        )
+    """)
+
+    # ── Normalized budget counters ──
+    # One row per (session, dimension, key). Replaces the by_* maps that a JSON
+    # budget blob would otherwise carry; the atomic scalars are columns on
+    # session_state.
+    conn.exec_driver_sql("""
+        CREATE TABLE IF NOT EXISTS budget_counters (
+            session_id TEXT NOT NULL,
+            dimension TEXT NOT NULL,
+            key TEXT NOT NULL,
+            count INTEGER NOT NULL,
+            PRIMARY KEY (session_id, dimension, key)
+        )
+    """)
+
+    # ── Normalized taint ledger ──
+    # One row per taint entry; ordinal preserves append order so the bounded
+    # ring-buffer semantics survive a reload.
+    conn.exec_driver_sql("""
+        CREATE TABLE IF NOT EXISTS taint_entries (
+            session_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            event_id TEXT NOT NULL,
+            source_event_key TEXT NOT NULL,
+            clearance TEXT NOT NULL,
+            source TEXT NOT NULL,
+            payload_pointer TEXT NOT NULL,
+            PRIMARY KEY (session_id, ordinal)
         )
     """)
 
@@ -120,6 +168,9 @@ def downgrade() -> None:
     op.drop_table("session_summaries")
     op.drop_table("content_hashes")
     op.drop_table("drift_baselines")
-    op.drop_table("mcp_fingerprints")
+    op.drop_table("taint_entries")
+    op.drop_table("budget_counters")
+    op.drop_table("mcp_profile_attributes")
+    op.drop_table("mcp_profiles")
     op.drop_table("processed_events")
     op.drop_table("session_state")

--- a/tests/unit/test_governance_migrations.py
+++ b/tests/unit/test_governance_migrations.py
@@ -1,0 +1,187 @@
+"""Migration schema tests for the initial normalized schema (issue #9).
+
+Covers the "up tests beyond table-existence" requirement against the single
+``0001_initial`` migration: exact column shape, enforced primary keys, and NOT
+NULL constraints on the normalized budget/taint/MCP tables that are part of the
+initial schema. There is no JSON-blob representation to migrate away from, so the
+schema is asserted directly on a fresh store.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tracemill.governance.persistence import SystemStore
+
+_NORMALIZED_TABLES = {
+    "budget_counters",
+    "taint_entries",
+    "mcp_profiles",
+    "mcp_profile_attributes",
+}
+
+
+def _tables(path) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        conn.close()
+
+
+def _version(path) -> str | None:
+    conn = sqlite3.connect(path)
+    try:
+        row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = SystemStore(tmp_path / "system.db")
+    yield s
+    s.close()
+
+
+class TestInitialSchema:
+    def test_fresh_store_is_at_head_with_normalized_tables(self, store, tmp_path):
+        assert _version(tmp_path / "system.db") == "0001_initial"
+        assert _NORMALIZED_TABLES <= _tables(tmp_path / "system.db")
+
+    def test_no_json_blob_fingerprint_table(self, store, tmp_path):
+        # The old JSON-array fingerprint table was replaced by the normalized
+        # mcp_profiles + mcp_profile_attributes pair; it must never be created.
+        assert "mcp_fingerprints" not in _tables(tmp_path / "system.db")
+
+    def test_session_state_columns(self, store):
+        cols = [r[1] for r in store.connection.execute("PRAGMA table_info(session_state)")]
+        assert cols == [
+            "session_id",
+            "total_tool_calls",
+            "total_tokens",
+            "elapsed_seconds",
+            "pressure",
+            "phase_window_json",
+            "last_assistant_json",
+            "last_user_json",
+            "event_count",
+            "dropped_events",
+            "last_sequence",
+            "last_event_id",
+            "updated_at",
+        ]
+
+    def test_session_state_has_no_json_blob_columns(self, store):
+        cols = {r[1] for r in store.connection.execute("PRAGMA table_info(session_state)")}
+        assert "budget_json" not in cols
+        assert "pii_taints_json" not in cols
+
+    def test_budget_counters_columns(self, store):
+        cols = [r[1] for r in store.connection.execute("PRAGMA table_info(budget_counters)")]
+        assert cols == ["session_id", "dimension", "key", "count"]
+
+    def test_taint_entries_columns(self, store):
+        cols = [r[1] for r in store.connection.execute("PRAGMA table_info(taint_entries)")]
+        assert cols == [
+            "session_id",
+            "ordinal",
+            "event_id",
+            "source_event_key",
+            "clearance",
+            "source",
+            "payload_pointer",
+        ]
+
+    def test_mcp_profiles_columns(self, store):
+        cols = [r[1] for r in store.connection.execute("PRAGMA table_info(mcp_profiles)")]
+        assert cols == [
+            "server",
+            "tool_name",
+            "description_hash",
+            "schema_hash",
+            "registered_effect",
+            "clearance",
+            "first_seen",
+            "last_seen",
+        ]
+
+    def test_mcp_profile_attributes_columns(self, store):
+        cols = [r[1] for r in store.connection.execute("PRAGMA table_info(mcp_profile_attributes)")]
+        assert cols == ["server", "tool_name", "attr_type", "attr_value"]
+
+
+class TestConstraints:
+    def test_budget_counters_primary_key(self, store):
+        c = store.connection
+        c.execute(
+            "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+            ("s", "effect", "read", 1),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            c.execute(
+                "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+                ("s", "effect", "read", 9),
+            )
+
+    def test_budget_counters_count_not_null(self, store):
+        with pytest.raises(sqlite3.IntegrityError):
+            store.connection.execute(
+                "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+                ("s", "effect", "read", None),
+            )
+
+    def test_taint_entries_primary_key(self, store):
+        c = store.connection
+        row = ("s", 0, "e", "k", "PUBLIC", "user_input", "p")
+        c.execute(
+            "INSERT INTO taint_entries (session_id, ordinal, event_id, source_event_key, "
+            "clearance, source, payload_pointer) VALUES (?,?,?,?,?,?,?)",
+            row,
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            c.execute(
+                "INSERT INTO taint_entries (session_id, ordinal, event_id, source_event_key, "
+                "clearance, source, payload_pointer) VALUES (?,?,?,?,?,?,?)",
+                ("s", 0, "e2", "k2", "SECRET", "file_read", "p2"),
+            )
+
+    def test_taint_entries_not_null(self, store):
+        with pytest.raises(sqlite3.IntegrityError):
+            store.connection.execute(
+                "INSERT INTO taint_entries (session_id, ordinal, event_id, source_event_key, "
+                "clearance, source, payload_pointer) VALUES (?,?,?,?,?,?,?)",
+                ("s", 1, None, "k", "PUBLIC", "user_input", "p"),
+            )
+
+    def test_mcp_profiles_primary_key(self, store):
+        c = store.connection
+        row = ("srv", "tool", "dh", "sh", "read", None, "t0", "t1")
+        sql = (
+            "INSERT INTO mcp_profiles (server, tool_name, description_hash, schema_hash, "
+            "registered_effect, clearance, first_seen, last_seen) VALUES (?,?,?,?,?,?,?,?)"
+        )
+        c.execute(sql, row)
+        with pytest.raises(sqlite3.IntegrityError):
+            c.execute(sql, ("srv", "tool", "dh2", "sh2", "write", None, "t0", "t1"))
+
+    def test_mcp_profiles_description_hash_not_null(self, store):
+        with pytest.raises(sqlite3.IntegrityError):
+            store.connection.execute(
+                "INSERT INTO mcp_profiles (server, tool_name, description_hash, schema_hash, "
+                "first_seen, last_seen) VALUES (?,?,?,?,?,?)",
+                ("srv", "tool", None, "sh", "t0", "t1"),
+            )
+
+    def test_mcp_profile_attributes_primary_key(self, store):
+        c = store.connection
+        sql = (
+            "INSERT INTO mcp_profile_attributes (server, tool_name, attr_type, attr_value) "
+            "VALUES (?,?,?,?)"
+        )
+        c.execute(sql, ("srv", "tool", "role", "admin"))
+        with pytest.raises(sqlite3.IntegrityError):
+            c.execute(sql, ("srv", "tool", "role", "admin"))

--- a/tests/unit/test_governance_persistence.py
+++ b/tests/unit/test_governance_persistence.py
@@ -21,7 +21,10 @@ class TestSystemStore:
         table_names = {t[0] for t in tables}
         assert "session_state" in table_names
         assert "processed_events" in table_names
-        assert "mcp_fingerprints" in table_names
+        assert "mcp_profiles" in table_names
+        assert "mcp_profile_attributes" in table_names
+        assert "budget_counters" in table_names
+        assert "taint_entries" in table_names
         assert "drift_baselines" in table_names
         assert "content_hashes" in table_names
         assert "session_summaries" in table_names
@@ -44,9 +47,9 @@ class TestSystemStore:
             "description_hash": "abc123",
             "schema_hash": "def456",
             "registered_effect": "mutating",
-            "registered_role": None,
-            "registered_capabilities": None,
-            "registered_scope": None,
+            "role": ["admin"],
+            "capability": ["network_outbound"],
+            "scope": [],
             "clearance": "internal",
             "first_seen": "2024-01-01T00:00:00Z",
             "last_seen": "2024-01-01T00:00:00Z",
@@ -56,6 +59,10 @@ class TestSystemStore:
         assert result is not None
         assert result["description_hash"] == "abc123"
         assert result["clearance"] == "internal"
+        assert result["registered_effect"] == "mutating"
+        assert result["role"] == ["admin"]
+        assert result["capability"] == ["network_outbound"]
+        assert result["scope"] == []
 
     def test_mcp_profile_not_found(self, store):
         assert store.get_mcp_profile("none", "none") is None

--- a/tests/unit/test_governance_persistence_normalized.py
+++ b/tests/unit/test_governance_persistence_normalized.py
@@ -1,0 +1,161 @@
+"""Normalized read/write + restart-recovery tests for governance persistence.
+
+Proves the normalized tables are the single source of truth — written through and
+read back — and that SQLite is authoritative across a simulated process restart
+(issue #9 requirements 1 and 4).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tracemill.governance.persistence import SystemStore
+from tracemill.governance.state import SessionState, TaintEntry
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = SystemStore(tmp_path / "system.db")
+    yield s
+    s.close()
+
+
+def _make_state(store, session_id="sess") -> SessionState:
+    s = SessionState(session_id=session_id)
+    s.attach_db(store.connection, store.lock)
+    return s
+
+
+class TestNormalizedBudgetTaint:
+    def test_persist_writes_budget_counters(self, store):
+        s = _make_state(store)
+        s.increment_budget(effect="read_only", scope=frozenset({"repo", "host"}))
+        s.increment_budget(effect="read_only")
+        s.persist()
+        counters = store.get_budget_counters("sess")
+        assert counters["effect"] == {"read_only": 2}
+        assert counters["scope"] == {"repo": 1, "host": 1}
+
+    def test_persist_writes_taint_entries_in_order(self, store):
+        s = _make_state(store)
+        s.add_taint(TaintEntry("e1", "k1", "SECRET", "file_read", "p1"))
+        s.add_taint(TaintEntry("e2", "k2", "PUBLIC", "user_input", "p2"))
+        s.persist()
+        entries = store.get_taint_entries("sess")
+        assert [e["event_id"] for e in entries] == ["e1", "e2"]
+        assert entries[0]["clearance"] == "SECRET"
+        assert entries[1]["source"] == "user_input"
+
+    def test_persist_is_full_rewrite(self, store):
+        """A later persist must not leave stale normalized rows behind."""
+        s = _make_state(store)
+        s.add_taint(TaintEntry("e1", "k1", "SECRET", "file_read", "p1"))
+        s.add_taint(TaintEntry("e2", "k2", "PUBLIC", "user_input", "p2"))
+        s.persist()
+        # Shrink the ledger and re-persist.
+        s._taint_ledger = [TaintEntry("e1", "k1", "SECRET", "file_read", "p1")]
+        s.persist()
+        entries = store.get_taint_entries("sess")
+        assert [e["event_id"] for e in entries] == ["e1"]
+
+    def test_persist_no_commit_defers_write(self, store):
+        s = _make_state(store)
+        s.increment_budget(effect="read_only")
+        s.persist_no_commit()  # writes on the shared connection, but does NOT commit
+        store.connection.rollback()  # a rollback must be able to discard it
+        assert store.get_budget_counters("sess") == {}
+
+
+class TestMcpNormalizedWrite:
+    def _profile(self):
+        return {
+            "description_hash": "dh",
+            "schema_hash": "sh",
+            "registered_effect": "execute",
+            "role": ["admin", "user"],
+            "capability": ["net"],
+            "scope": [],
+            "clearance": "internal",
+            "first_seen": "t0",
+            "last_seen": "t1",
+        }
+
+    def test_upsert_writes_normalized_profile(self, store):
+        store.upsert_mcp_profile("srv", "tool", self._profile())
+
+        prof = store.get_mcp_profile("srv", "tool")
+        assert prof["registered_effect"] == "execute"
+        assert prof["clearance"] == "internal"
+        assert prof["role"] == ["admin", "user"]
+        assert prof["capability"] == ["net"]
+        assert prof["scope"] == []
+
+    def test_missing_returns_none(self, store):
+        assert store.get_mcp_profile("nope", "nope") is None
+
+    def test_last_seen_updates_profile(self, store):
+        store.upsert_mcp_profile("srv", "tool", self._profile())
+        store.update_mcp_last_seen("srv", "tool", "t2")
+        assert store.get_mcp_profile("srv", "tool")["last_seen"] == "t2"
+
+    def test_upsert_preserves_first_seen_baseline(self, store):
+        store.upsert_mcp_profile("srv", "tool", self._profile())
+        second = self._profile()
+        second["registered_effect"] = "destructive"
+        second["first_seen"] = "LATER"
+        store.upsert_mcp_profile("srv", "tool", second)  # INSERT OR IGNORE → no-op
+        prof = store.get_mcp_profile("srv", "tool")
+        assert prof["registered_effect"] == "execute"
+        assert prof["first_seen"] == "t0"
+
+
+class TestRestartRecovery:
+    def test_sqlite_is_authoritative_across_restart(self, tmp_path):
+        """Persist, tear the store down, reopen a fresh store: full recovery."""
+        path = tmp_path / "system.db"
+        store = SystemStore(path)
+        s = SessionState(session_id="live")
+        s.attach_db(store.connection, store.lock)
+        s.increment_budget(
+            mechanism="mcp",
+            effect="destructive",
+            scope=frozenset({"host"}),
+            capability=frozenset({"network_outbound"}),
+        )
+        s.update_phase_window("exploration")
+        s.add_taint(TaintEntry("evt-1", "k-1", "SECRET", "file_read", "ptr"))
+        s.record_event(sequence=7)
+        s.persist()
+        store.close()  # simulate process exit; drop all in-memory state
+
+        # Reopen — nothing in memory, everything must come from disk.
+        store2 = SystemStore(path)
+        recovered = SessionState.load_from_db("live", store2.connection, store2.lock)
+        snap = recovered.snapshot()
+        assert snap.budget.total_tool_calls == 1
+        assert snap.budget.count("effect", "destructive") == 1
+        assert snap.budget.count("scope", "host") == 1
+        assert snap.budget.count("capability", "network_outbound") == 1
+        assert snap.phase_window == ("exploration",)
+        assert snap.last_sequence == 7
+        assert [t.event_id for t in recovered.taint_ledger] == ["evt-1"]
+        assert recovered.taint_ledger[0].clearance == "SECRET"
+        store2.close()
+
+    def test_unpersisted_mutations_do_not_survive_restart(self, tmp_path):
+        """In-memory mutations without persist are lost — disk is the truth."""
+        path = tmp_path / "system.db"
+        store = SystemStore(path)
+        s = SessionState(session_id="live")
+        s.attach_db(store.connection, store.lock)
+        s.increment_budget(effect="read_only")
+        s.persist()  # persisted baseline: 1 call
+        s.increment_budget(effect="read_only")  # mutate WITHOUT persisting
+        store.close()
+
+        store2 = SystemStore(path)
+        recovered = SessionState.load_from_db("live", store2.connection, store2.lock)
+        # Only the persisted state survives.
+        assert recovered.snapshot().budget.total_tool_calls == 1
+        assert recovered.snapshot().budget.count("effect", "read_only") == 1
+        store2.close()

--- a/tests/unit/test_governance_single_writer.py
+++ b/tests/unit/test_governance_single_writer.py
@@ -1,0 +1,145 @@
+"""Single-writer guarantee tests for the SystemStore write path (issue #9 #2).
+
+The store is a synchronous durability layer reached from multiple OS threads (the
+pipeline offloads writes via ``asyncio.to_thread``). ``write_transaction`` holds
+the writer lock for the *whole* multi-statement transaction, so concurrent writers
+can never interleave or lose updates on the shared connection. These tests pin
+that contract down: commit/rollback semantics, exception propagation, and
+serialization of hammering threads.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+from tracemill.governance.persistence import SystemStore
+from tracemill.governance.state import SessionState
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = SystemStore(tmp_path / "system.db")
+    yield s
+    s.close()
+
+
+def _count(store, session_id="c", dimension="d", key="k") -> int:
+    row = store.connection.execute(
+        "SELECT count FROM budget_counters WHERE session_id=? AND dimension=? AND key=?",
+        (session_id, dimension, key),
+    ).fetchone()
+    return row[0] if row else 0
+
+
+class TestWriteTransactionSemantics:
+    def test_commit_is_durable_on_separate_connection(self, store):
+        with store.write_transaction() as conn:
+            conn.execute(
+                "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+                ("x", "d", "k", 3),
+            )
+        # A wholly separate connection must see it → it really committed to disk.
+        other = sqlite3.connect(str(store._db_path))
+        try:
+            row = other.execute("SELECT count FROM budget_counters WHERE session_id='x'").fetchone()
+        finally:
+            other.close()
+        assert row[0] == 3
+
+    def test_rolls_back_and_reraises_on_exception(self, store):
+        with pytest.raises(RuntimeError, match="boom"):
+            with store.write_transaction() as conn:
+                conn.execute(
+                    "INSERT INTO budget_counters (session_id, dimension, key, count) "
+                    "VALUES (?,?,?,?)",
+                    ("r", "d", "k", 1),
+                )
+                raise RuntimeError("boom")
+        # The partial write was rolled back.
+        assert store.get_budget_counters("r") == {}
+
+    def test_lock_is_released_after_transaction(self, store):
+        with store.write_transaction() as conn:
+            conn.execute(
+                "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+                ("a", "d", "k", 1),
+            )
+        # If the lock had leaked, this second acquisition would deadlock.
+        with store.write_transaction() as conn:
+            conn.execute(
+                "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+                ("b", "d", "k", 1),
+            )
+        assert _count(store, "a") == 1
+        assert _count(store, "b") == 1
+
+    def test_lock_released_even_after_rollback(self, store):
+        with pytest.raises(ValueError):
+            with store.write_transaction():
+                raise ValueError("x")
+        # Lock must be free for subsequent writers.
+        with store.write_transaction() as conn:
+            conn.execute(
+                "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+                ("after", "d", "k", 5),
+            )
+        assert _count(store, "after") == 5
+
+
+class TestConcurrentSerialization:
+    def test_read_modify_write_never_loses_updates(self, store):
+        """Interleaved RMW increments from many threads must all land.
+
+        Each iteration reads the current counter and writes count+1 *inside* one
+        write_transaction. Without the whole-transaction lock these would race and
+        lose updates; with it, the final total is exact.
+        """
+        threads_n, iters = 8, 60
+
+        def worker():
+            for _ in range(iters):
+                with store.write_transaction() as conn:
+                    row = conn.execute(
+                        "SELECT count FROM budget_counters "
+                        "WHERE session_id='c' AND dimension='d' AND key='k'"
+                    ).fetchone()
+                    current = row[0] if row else 0
+                    conn.execute(
+                        "INSERT OR REPLACE INTO budget_counters "
+                        "(session_id, dimension, key, count) VALUES ('c','d','k',?)",
+                        (current + 1,),
+                    )
+
+        threads = [threading.Thread(target=worker) for _ in range(threads_n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert _count(store) == threads_n * iters
+
+    def test_concurrent_persist_across_sessions_is_consistent(self, store):
+        """state.persist() self-locks; concurrent persists must not corrupt rows."""
+        threads_n, iters = 6, 25
+
+        def worker(idx):
+            s = SessionState(session_id=f"s{idx}")
+            s.attach_db(store.connection, store.lock)
+            for _ in range(iters):
+                s.increment_budget(effect="read_only")
+                s.persist()
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(threads_n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        for i in range(threads_n):
+            loaded = SessionState.load_from_db(f"s{i}", store.connection, store.lock)
+            snap = loaded.snapshot()
+            assert snap.budget.total_tool_calls == iters
+            assert snap.budget.count("effect", "read_only") == iters


### PR DESCRIPTION
## Issue #9 — Session state & persistence (SQLite + Alembic)

Closes #9

Reworks #9 to a **single source of truth**. tracemill has never been released — no alpha, no deployed databases, no external consumers — so there is no legacy data to preserve. The normalized tables are folded into the **initial** migration `0001`; the JSON-blob representation never exists.

Scope is confined to the persistence seam: `governance/persistence.py`, `governance/state.py`, `governance/registry.py`, `governance/monitor.py`, `governance/mcp_drift.py`, `cli/status.py`, `migrations/*`, and their tests.

> ⚠️ **Dev/CI scratch databases must be recreated.** The schema is defined fresh in `0001`; nothing is deployed, so this affects only local/CI scratch DBs, never real data.

### 1. Normalized schema (single representation, in `0001`)
The 1NF-violating repeating groups are stored directly as normalized tables — there is no JSON form to migrate away from:

- `budget_counters(session_id, dimension, key, count)` — the dimensional `by_*` counters. The atomic budget scalars (`total_tool_calls`, `total_tokens`, `elapsed_seconds`, `pressure`) are plain columns on `session_state`.
- `taint_entries(session_id, ordinal, event_id, source_event_key, clearance, source, payload_pointer)` — the taint ledger; `ordinal` preserves append order so the bounded ring-buffer survives a reload.
- `mcp_profiles(server, tool_name, description_hash, schema_hash, registered_effect, clearance, first_seen, last_seen)` + `mcp_profile_attributes(server, tool_name, attr_type, attr_value)` — scalar fingerprint plus the many-valued role/capability/scope attributes in 1NF.

`session_state.budget_json` / `pii_taints_json` and the `mcp_fingerprints` JSON-array table are **gone**. `persistence.py`/`state.py` read and write **only** the normalized tables — no dual-write, no backfill, no normalized-first-with-JSON-fallback. Migration `0002` is deleted; `alembic upgrade head` on a fresh DB builds the normalized schema directly.

### 2. Single-writer guarantee (formalized)
The store is a **synchronous** durability layer over one `sqlite3` connection (`check_same_thread=False`), reached cross-thread because the pipeline offloads writes via `asyncio.to_thread`. An `asyncio.Queue`/`Lock` cannot serialize work that runs off-loop on arbitrary threads, so `threading.Lock` is the correct primitive.

- `SystemStore.write_transaction()` holds the writer lock for the **entire** multi-statement transaction (previously only the terminal `commit()` was under the lock), commits on clean exit, and rolls back + re-raises on error.
- The monitor's atomic write blocks route through it.
- `SessionState.persist()` self-locks via the store lock (threaded through `registry.get_or_create → load_from_db → attach_db`), so the emitter's standalone drop-recording path is serialized against the monitor. `persist_no_commit()` stays lock-free (it runs inside the monitor's `write_transaction`). No reentrancy needed — standalone vs nested persist never occur on the same thread.

### 3. Event-time accuracy fix (monitor.py)
A reservation always persists its snapshot, so the *"reservation without snapshot — fall back to current state"* branch was dead code that could only corrupt event-time assessment. It now **requires** the snapshot (raises if absent) rather than silently reassessing against current state.

### 4. Tests
- `test_governance_migrations.py`: schema assertions on the initial `0001` — exact column sets (`PRAGMA table_info`), PK and NOT NULL constraints on all four normalized tables, and that the JSON-blob columns / `mcp_fingerprints` table do not exist.
- `test_governance_persistence_normalized.py`: normalized read/write round-trips, MCP normalized-profile writes, and **restart recovery** (persist → discard in-memory → reopen store → full recovery).
- `test_governance_single_writer.py`: `write_transaction` commit durability (verified on a separate connection), rollback + re-raise, lock release after commit/rollback, N-thread read-modify-write with no lost updates, and concurrent cross-session `persist()`.

### Verification
- Full suite: **1958 passed, 4 skipped**.
- `ruff check` and `ruff format --check` both clean (pinned `0.15.20`).
- `git grep -i -e legacy -e backfill -e "dual-write" -e "fall back" -e budget_json -e pii_taints_json -e mcp_fingerprints` over the persistence/migration/state/monitor paths in `src/` returns nothing.