### PR TITLE
Harden IFC clearance lattice, span taint propagation, and coverage (#13)

### DIFF
--- a/src/tracemill/governance/ifc.py
+++ b/src/tracemill/governance/ifc.py
@@ -1,13 +1,41 @@
-"""Information Flow Control (IFC) source labeling and taint tracking."""
+"""Information Flow Control (IFC) source labeling and taint tracking.
+
+IFCChecker is the Phase-1 taint engine. It runs once per event (from
+``phase1.py`` via ``labeler.check_ifc``) and its durable effect is the taint
+ledger it accumulates on the mutable :class:`SessionState`. Phase-2 labeling
+(``labeler.py``) reads the resulting ledger snapshot to emit the ``ifc_violation``
+structure label and ``ifc:{clearance}`` source labels on egress.
+
+The ``src_labels`` set populated by :meth:`IFCChecker.check` is part of the
+method's contract (and is asserted directly in unit tests); the live pipeline
+discards it, so the ledger is the channel that reaches downstream consumers.
+
+Model (deterministic, CPU-only):
+
+* **Clearance lattice** ``PUBLIC < INTERNAL < CONFIDENTIAL < SECRET``.
+* **Data clearance** — sensitivity of the data an event reads or carries,
+  inferred from sensitive file paths / extensions in tool args (call) or the
+  result payload (result). Recorded as taint at ``CONFIDENTIAL`` or above.
+* **Tool clearance** — the registered ceiling of a tool, taken from its MCP
+  profile. When data the tool handles (accumulated ledger taint or the event's
+  own data) strictly dominates that ceiling, the flow violates the partial
+  order and is flagged as a clearance violation.
+* **span_id propagation** — taint follows a span through the pre/post
+  (ToolCallEvent -> ToolResultEvent) chain: a result inherits the clearance of
+  a prior same-span taint (matched by span id, or by ``pre_call_event_id`` back
+  to the call's event id). The originating span id is carried on each taint via
+  ``TaintEntry.payload_pointer`` so lineage survives serialization.
+"""
 
 from __future__ import annotations
 
+import re
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from tracemill.governance.state import SessionState
-    from tracemill.governance.types import EnrichmentContext
+    from tracemill.governance.state import SessionState, TaintEntry
+    from tracemill.governance.types import EnrichmentContext, SessionEvent
 
 
 class Clearance(StrEnum):
@@ -20,6 +48,9 @@ class Clearance(StrEnum):
 
 
 _CLEARANCE_ORDER = {c: i for i, c in enumerate(Clearance)}
+
+# Clearance at or above which accessed/carried data is recorded as taint.
+_TAINT_THRESHOLD = Clearance.CONFIDENTIAL
 
 # Public constants for IFC label rules (referenced by spec)
 SCOPE_TO_LABEL: dict[str, str] = {
@@ -46,6 +77,58 @@ PATH_LABEL_RULES: dict[str, Clearance] = {
 _SENSITIVE_PATHS = frozenset(PATH_LABEL_RULES.keys())
 _SENSITIVE_EXTENSIONS = frozenset({".pem", ".key", ".p12", ".pfx", ".jks"})
 
+# Precompiled, boundary-aware patterns. Sensitive names must sit on a path
+# separator or string boundary so substrings (e.g. "prevent") never match.
+_PATH_PATTERNS: tuple[tuple[re.Pattern[str], Clearance], ...] = tuple(
+    (
+        re.compile(r'(?:^|[/\\\s"\':])' + re.escape(path) + r'(?:$|[/\\\s"\',})\]])'),
+        PATH_LABEL_RULES.get(path, Clearance.SECRET),
+    )
+    for path in _SENSITIVE_PATHS
+)
+_EXT_PATTERNS: tuple[tuple[re.Pattern[str], Clearance], ...] = tuple(
+    (re.compile(re.escape(ext) + r'(?:$|["\s,}\]\)])'), Clearance.CONFIDENTIAL)
+    for ext in _SENSITIVE_EXTENSIONS
+)
+
+
+def _rank(clearance: object) -> int:
+    """Lattice rank of a clearance value (accepts Clearance or its str value)."""
+    return _CLEARANCE_ORDER.get(clearance, -1)  # type: ignore[arg-type]
+
+
+def _higher(a: Clearance | None, b: Clearance | None) -> Clearance | None:
+    """Return the higher-ranked of two optional clearances."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if _rank(a) >= _rank(b) else b
+
+
+def _max_clearance(values) -> Clearance | str | None:
+    """Return the highest-ranked clearance in ``values`` (skipping ``None``).
+
+    Accepts a mix of :class:`Clearance` members and their raw string values
+    (ledger entries store the value as ``str``); the original object is returned
+    so callers can render it verbatim.
+    """
+    best: Clearance | str | None = None
+    best_rank = -1
+    for value in values:
+        if value is None:
+            continue
+        rank = _rank(value)
+        if rank > best_rank:
+            best_rank = rank
+            best = value
+    return best
+
+
+def _dominates(higher: object, lower: object) -> bool:
+    """True when ``higher`` sits strictly above ``lower`` in the lattice."""
+    return _rank(higher) > _rank(lower)
+
 
 class IFCChecker:
     """Information Flow Control — assigns source labels and tracks taints."""
@@ -56,99 +139,217 @@ class IFCChecker:
         src_labels: set[str],
         session_state: "SessionState",
     ) -> None:
-        """Assign IFC labels based on event content and taint history."""
-        from tracemill.governance.state import TaintEntry
+        """Assign IFC labels and accumulate taint for a single event.
+
+        Populates ``src_labels`` (the method's contract) and records taint on
+        ``session_state`` via the bounded :meth:`SessionState.add_taint`, which
+        FIFO-evicts oldest entries past the ledger cap.
+        """
+        event = ctx.event
+        ledger = session_state.taint_ledger
+        span_id = self._span_id(event)
+
+        # 1) Inbound span propagation — inherit taint from a prior event on the
+        #    same span (pre/post chain), so a result carries its call's taint.
+        inherited = self._inherited_span_clearance(event, ledger)
+        if inherited is not None:
+            src_labels.add(f"ifc:tainted_span:{inherited}")
+
+        # 2) Egress of accumulated taint: a mutating/destructive action while
+        #    the session already carries taint is an outbound flow.
+        if ledger and ctx.base_classification.effect in ("mutating", "destructive"):
+            accumulated = _max_clearance(t.clearance for t in ledger)
+            if accumulated is not None:
+                src_labels.add(f"ifc:tainted_write:{accumulated}")
+
+        # 3) Clearance of the data this event reads or carries, combined with
+        #    any clearance inherited along its span.
+        data_clearance = self._infer_data_clearance(ctx)
+        effective = _max_clearance((data_clearance, inherited))
+
+        # 4) Record taint when the effective clearance is CONFIDENTIAL or above.
+        recorded = False
+        if effective is not None and _rank(effective) >= _rank(_TAINT_THRESHOLD):
+            src_labels.add(f"ifc:{effective}")
+            self._record_taint(
+                session_state,
+                event,
+                clearance=effective,
+                source=self._classify_source(ctx),
+                span_id=span_id,
+            )
+            recorded = True
+
+        # 5) Tool-clearance partial-order violation: the tool's registered
+        #    ceiling is dominated by data it is handling (accumulated or own).
+        self._check_tool_clearance(
+            ctx, src_labels, session_state, effective=effective, recorded=recorded
+        )
+
+    # ── clearance inference ────────────────────────────────────────────────
+
+    def _infer_data_clearance(self, ctx: "EnrichmentContext") -> Clearance | None:
+        """Clearance of the data an event reads (call args) or carries (result)."""
+        from tracemill.governance.types import ToolCallEvent, ToolResultEvent
 
         event = ctx.event
+        if isinstance(event, ToolCallEvent):
+            return self._clearance_from_args(event.tool_args_json)
+        if isinstance(event, ToolResultEvent):
+            return self._scan_sensitive_text((event.result_payload_json or "").lower())
+        return None
 
-        # Check taint propagation BEFORE adding new taint (prevent self-taint)
-        if session_state.taint_ledger:
-            # If tool is writing and there's prior taint, propagate
-            if ctx.base_classification.effect in ("mutating", "destructive"):
-                max_clearance = max(
-                    (t.clearance for t in session_state.taint_ledger),
-                    key=lambda c: _CLEARANCE_ORDER.get(c, 0),
-                    default=None,
-                )
-                if max_clearance:
-                    src_labels.add(f"ifc:tainted_write:{max_clearance}")
-
-        # Determine clearance of data being accessed by current event
-        clearance = self._infer_clearance(ctx)
-        if clearance and _CLEARANCE_ORDER[clearance] >= _CLEARANCE_ORDER[Clearance.CONFIDENTIAL]:
-            src_labels.add(f"ifc:{clearance}")
-            # Record taint for future events (not current)
-            session_state.add_taint(
-                TaintEntry(
-                    event_id=event.event_id,
-                    source_event_key=event.source_event_key,
-                    clearance=clearance,
-                    source=self._classify_source(ctx),
-                    payload_pointer="",
-                )
-            )
-
-    def _infer_clearance(self, ctx: "EnrichmentContext") -> Clearance | None:
-        """Infer clearance level from event context."""
-        from tracemill.governance.types import ToolCallEvent
+    def _clearance_from_args(self, tool_args_json: str) -> Clearance | None:
+        """Infer clearance from tool-call args (structured path + text scan)."""
         import json as json_mod
 
-        if not isinstance(ctx.event, ToolCallEvent):
-            return None
-
-        # Try structured path extraction first
+        structured: Clearance | None = None
         try:
-            args_dict = json_mod.loads(ctx.event.tool_args_json)
+            args_dict = json_mod.loads(tool_args_json)
             file_path = (
                 args_dict.get("path") or args_dict.get("file") or args_dict.get("filename") or ""
             )
-            if isinstance(file_path, str):
-                # Check path segments and basename for sensitive file matches
-                path_lower = file_path.lower()
-                basename = path_lower.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
-                for sensitive_path in _SENSITIVE_PATHS:
-                    if (
-                        basename == sensitive_path
-                        or path_lower.endswith(f"/{sensitive_path}")
-                        or path_lower.endswith(f"\\{sensitive_path}")
-                    ):
-                        return PATH_LABEL_RULES.get(sensitive_path, Clearance.SECRET)
-                for ext in _SENSITIVE_EXTENSIONS:
-                    if basename.endswith(ext):
-                        return Clearance.CONFIDENTIAL
+            if isinstance(file_path, str) and file_path:
+                structured = self._clearance_from_path(file_path.lower())
         except (json_mod.JSONDecodeError, TypeError, AttributeError):
-            pass
+            structured = None
 
-        # Fallback: boundary-aware text search on raw args
-        args = ctx.event.tool_args_json.lower()
-        for path in _SENSITIVE_PATHS:
-            # Require path separator or string boundary before the sensitive name
-            import re
+        return _higher(structured, self._scan_sensitive_text(tool_args_json.lower()))
 
-            pattern = r'(?:^|[/\\\s"\':])' + re.escape(path) + r'(?:$|[/\\\s"\',})\]])'
-            if re.search(pattern, args):
-                return PATH_LABEL_RULES.get(path, Clearance.SECRET)
-
+    def _clearance_from_path(self, path_lower: str) -> Clearance | None:
+        """Exact basename / suffix match against known sensitive files."""
+        basename = path_lower.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        best: Clearance | None = None
+        for sensitive_path in _SENSITIVE_PATHS:
+            if (
+                basename == sensitive_path
+                or path_lower.endswith(f"/{sensitive_path}")
+                or path_lower.endswith(f"\\{sensitive_path}")
+            ):
+                best = _higher(best, PATH_LABEL_RULES.get(sensitive_path, Clearance.SECRET))
+        if best is not None:
+            return best
         for ext in _SENSITIVE_EXTENSIONS:
-            # Extension must be at word boundary
-            import re
-
-            if re.search(re.escape(ext) + r'(?:$|["\s,}\]\)])', args):
+            if basename.endswith(ext):
                 return Clearance.CONFIDENTIAL
-
-        # Check MCP profile clearance if available
-        if ctx.mcp_profiles:
-            key = ctx.mcp_profile_key
-            if key and key in ctx.mcp_profiles:
-                profile_clearance = ctx.mcp_profiles[key].get("clearance")
-                if profile_clearance:
-                    try:
-                        return Clearance(profile_clearance)
-                    except ValueError:
-                        # Unknown clearance value in MCP profile — treat as no clearance
-                        pass
-
         return None
+
+    def _scan_sensitive_text(self, text_lower: str) -> Clearance | None:
+        """Boundary-aware scan for sensitive names/extensions in raw text.
+
+        Returns the highest-ranked clearance across all matches so the result is
+        independent of pattern iteration order.
+        """
+        if not text_lower:
+            return None
+        best: Clearance | None = None
+        for pattern, clearance in _PATH_PATTERNS:
+            if pattern.search(text_lower):
+                best = _higher(best, clearance)
+        if best is not None:
+            return best
+        for pattern, clearance in _EXT_PATTERNS:
+            if pattern.search(text_lower):
+                return clearance
+        return None
+
+    def _tool_clearance(self, ctx: "EnrichmentContext") -> Clearance | None:
+        """The current tool's registered clearance ceiling from its MCP profile."""
+        if not ctx.mcp_profiles:
+            return None
+        key = ctx.mcp_profile_key
+        if not key or key not in ctx.mcp_profiles:
+            return None
+        raw = ctx.mcp_profiles[key].get("clearance")
+        if not raw:
+            return None
+        try:
+            return Clearance(raw)
+        except ValueError:
+            # Unknown clearance value in MCP profile — treat as unbounded (no ceiling).
+            return None
+
+    # ── span lineage ───────────────────────────────────────────────────────
+
+    def _span_id(self, event: "SessionEvent") -> str | None:
+        """Span identifier for an event, when the event type carries one."""
+        span = getattr(event, "span_id", None)
+        return span if isinstance(span, str) and span else None
+
+    def _inherited_span_clearance(
+        self, event: "SessionEvent", ledger: list["TaintEntry"]
+    ) -> Clearance | str | None:
+        """Highest clearance already tainted on this event's span.
+
+        Matches prior taint by span id (carried in ``payload_pointer``) or, for a
+        result event, by ``pre_call_event_id`` back to the call's ``event_id``.
+        """
+        if not ledger:
+            return None
+        span_id = self._span_id(event)
+        pre_call_id = getattr(event, "pre_call_event_id", None)
+        matches = [
+            t.clearance
+            for t in ledger
+            if (span_id and t.payload_pointer == span_id)
+            or (pre_call_id and t.event_id == pre_call_id)
+        ]
+        return _max_clearance(matches)
+
+    # ── taint recording ────────────────────────────────────────────────────
+
+    def _check_tool_clearance(
+        self,
+        ctx: "EnrichmentContext",
+        src_labels: set[str],
+        session_state: "SessionState",
+        *,
+        effective: Clearance | str | None,
+        recorded: bool,
+    ) -> None:
+        """Flag a partial-order violation when data dominates the tool ceiling."""
+        ceiling = self._tool_clearance(ctx)
+        if ceiling is None:
+            return
+        candidates = [t.clearance for t in session_state.taint_ledger]
+        if effective is not None:
+            candidates.append(effective)
+        offending = _max_clearance(candidates)
+        if offending is None or not _dominates(offending, ceiling):
+            return
+        src_labels.add(f"ifc:ifc_violation:{offending}>{ceiling}")
+        # Persist the violation so a downstream egress sees a prior taint, unless
+        # this event already left an equivalent taint above.
+        if not recorded:
+            self._record_taint(
+                session_state,
+                ctx.event,
+                clearance=offending,
+                source="ifc_violation",
+                span_id=self._span_id(ctx.event),
+            )
+
+    def _record_taint(
+        self,
+        session_state: "SessionState",
+        event: "SessionEvent",
+        *,
+        clearance: Clearance | str,
+        source: str,
+        span_id: str | None,
+    ) -> None:
+        """Append a taint entry through the bounded, FIFO-evicting ledger."""
+        from tracemill.governance.state import TaintEntry
+
+        session_state.add_taint(
+            TaintEntry(
+                event_id=event.event_id,
+                source_event_key=event.source_event_key,
+                clearance=str(clearance),
+                source=source,
+                payload_pointer=span_id or "",
+            )
+        )
 
     def _classify_source(self, ctx: "EnrichmentContext") -> str:
         """Classify the source type of the data access."""

--- a/tests/unit/test_governance_ifc.py
+++ b/tests/unit/test_governance_ifc.py
@@ -1,0 +1,697 @@
+"""Unit tests for Information Flow Control (IFCChecker) — issue #13.
+
+Covers the four gap-closing work items:
+
+1. Clearance lattice partial-order helpers + tool-clearance (MCP ceiling)
+   violation checks.
+2. span_id taint propagation across the pre/post (ToolCallEvent ->
+   ToolResultEvent) chain.
+3. Per-type ``tainted_flow`` / ``ifc_violation`` label emission (integration
+   through the real PIIScanner + GovernanceLabeler egress rules), for both
+   ToolCallEvent and ToolResultEvent.
+4. FIFO eviction of the bounded taint ledger, driven entirely through
+   ``check()``, plus fresh (per-call) source-label isolation.
+
+``IFCChecker.check`` reads only the mutable ``SessionState`` (3rd arg) and the
+event/classification on ``ctx``; it never reads ``ctx.session_state`` (the
+snapshot). The snapshot is what the Phase-2 labeler consumes, so the
+label-integration tests snapshot the ledger that ``check()`` produced and feed
+it to ``GovernanceLabeler.label``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tracemill.classify.core import Classification
+from tracemill.governance.ifc import (
+    Clearance,
+    IFCChecker,
+    PATH_LABEL_RULES,
+    SCOPE_TO_LABEL,
+    _dominates,
+    _higher,
+    _max_clearance,
+    _rank,
+)
+from tracemill.governance.labeler import GovernanceLabeler
+from tracemill.governance.pii import PIIScanner
+from tracemill.governance.state import SessionState
+from tracemill.governance.types import (
+    EnrichmentContext,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+
+_TS = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+# ── builders ───────────────────────────────────────────────────────────────
+
+
+def _call_event(
+    *,
+    event_id="evt-call",
+    source_event_key="key-call",
+    span_id="span-1",
+    args='{"command": "echo hi"}',
+    session_id="s1",
+    server_namespace=None,
+) -> ToolCallEvent:
+    return ToolCallEvent(
+        event_id=event_id,
+        session_id=session_id,
+        timestamp=_TS,
+        source_event_key=source_event_key,
+        span_id=span_id,
+        tool_name="bash",
+        server_namespace=server_namespace,
+        tool_args_json=args,
+        source_event_id=None,
+    )
+
+
+def _result_event(
+    *,
+    event_id="evt-res",
+    source_event_key="key-res",
+    span_id="span-1",
+    payload='{"ok": true}',
+    pre_call_event_id="evt-call",
+    session_id="s1",
+    server_namespace=None,
+) -> ToolResultEvent:
+    return ToolResultEvent(
+        event_id=event_id,
+        session_id=session_id,
+        timestamp=_TS,
+        source_event_key=source_event_key,
+        span_id=span_id,
+        tool_name="bash",
+        server_namespace=server_namespace,
+        result_payload_json=payload,
+        result_status="success",
+        pre_call_event_id=pre_call_event_id,
+    )
+
+
+def _cls(*, effect="read", capability=frozenset(), mechanism="shell.execute", scope=frozenset()):
+    return Classification(
+        mechanism=mechanism, effect=effect, scope=scope, capability=frozenset(capability)
+    )
+
+
+def _ctx(
+    event,
+    *,
+    classification=None,
+    mcp_profiles=None,
+    mcp_profile_key=None,
+    snapshot=None,
+) -> EnrichmentContext:
+    return EnrichmentContext(
+        event=event,
+        base_classification=classification or _cls(),
+        command_analysis=None,
+        session_state=snapshot,
+        mcp_profiles=mcp_profiles,
+        project_root=None,
+        engine="shell",
+        drift_baseline=None,
+        mcp_profile_key=mcp_profile_key,
+    )
+
+
+def _state() -> SessionState:
+    return SessionState(session_id="s1")
+
+
+def _run(checker, ctx, state):
+    """Run check() with a fresh src_labels set and return it."""
+    labels: set[str] = set()
+    checker.check(ctx, labels, state)
+    return labels
+
+
+# ── 1a. Lattice helpers ──────────────────────────────────────────────────────
+
+
+class TestClearanceLattice:
+    def test_strict_total_order(self):
+        order = [Clearance.PUBLIC, Clearance.INTERNAL, Clearance.CONFIDENTIAL, Clearance.SECRET]
+        ranks = [_rank(c) for c in order]
+        assert ranks == sorted(ranks)
+        assert len(set(ranks)) == 4
+
+    def test_rank_accepts_str_value(self):
+        # Ledger entries store the clearance as a raw str; rank must still work.
+        assert _rank("secret") == _rank(Clearance.SECRET)
+        assert _rank("confidential") == _rank(Clearance.CONFIDENTIAL)
+
+    def test_rank_unknown_is_negative(self):
+        assert _rank("bogus") == -1
+        assert _rank(None) == -1
+
+    def test_dominates_is_strict(self):
+        assert _dominates(Clearance.SECRET, Clearance.INTERNAL)
+        assert _dominates(Clearance.CONFIDENTIAL, Clearance.PUBLIC)
+        assert not _dominates(Clearance.INTERNAL, Clearance.SECRET)
+        # Equal clearances do not dominate each other (strict partial order).
+        assert not _dominates(Clearance.SECRET, Clearance.SECRET)
+
+    def test_higher_picks_max_and_handles_none(self):
+        assert _higher(Clearance.PUBLIC, Clearance.SECRET) is Clearance.SECRET
+        assert _higher(Clearance.SECRET, Clearance.PUBLIC) is Clearance.SECRET
+        assert _higher(None, Clearance.INTERNAL) is Clearance.INTERNAL
+        assert _higher(Clearance.INTERNAL, None) is Clearance.INTERNAL
+        assert _higher(None, None) is None
+
+    def test_max_clearance_mixed_str_and_enum(self):
+        # Returns the highest-ranked value verbatim (str preserved).
+        assert _max_clearance((Clearance.INTERNAL, "secret")) == "secret"
+        assert _max_clearance(("public", Clearance.CONFIDENTIAL)) is Clearance.CONFIDENTIAL
+        assert _max_clearance((None, None)) is None
+        assert _max_clearance(()) is None
+
+
+# ── 1b. Data clearance -> taint recording ────────────────────────────────────
+
+
+class TestDataClearanceTaint:
+    def test_confidential_path_records_taint(self):
+        state = _state()
+        ctx = _ctx(_call_event(args='{"path": ".npmrc"}'))
+        labels = _run(IFCChecker(), ctx, state)
+        assert "ifc:confidential" in labels
+        ledger = state.taint_ledger
+        assert len(ledger) == 1
+        assert ledger[0].clearance == "confidential"
+        # span_id lineage is carried on the taint via payload_pointer.
+        assert ledger[0].payload_pointer == "span-1"
+
+    def test_secret_env_file_records_taint(self):
+        state = _state()
+        ctx = _ctx(_call_event(args='{"path": "/app/.env"}'))
+        labels = _run(IFCChecker(), ctx, state)
+        assert "ifc:secret" in labels
+        assert state.taint_ledger[0].clearance == "secret"
+
+    def test_pem_extension_is_confidential(self):
+        state = _state()
+        ctx = _ctx(_call_event(args='{"file": "server.pem"}'))
+        labels = _run(IFCChecker(), ctx, state)
+        assert "ifc:confidential" in labels
+        assert state.taint_ledger[0].clearance == "confidential"
+
+    def test_result_payload_secret_records_tool_output(self):
+        state = _state()
+        payload = '{"stdout": "contents of ~/.ssh/id_rsa here"}'
+        ctx = _ctx(_result_event(payload=payload, span_id="span-9"))
+        labels = _run(IFCChecker(), ctx, state)
+        assert "ifc:secret" in labels
+        entry = state.taint_ledger[0]
+        assert entry.clearance == "secret"
+        assert entry.source == "tool_output"
+        assert entry.payload_pointer == "span-9"
+
+    def test_benign_event_records_no_taint(self):
+        state = _state()
+        ctx = _ctx(_call_event(args='{"command": "echo hello"}'))
+        labels = _run(IFCChecker(), ctx, state)
+        assert labels == set()
+        assert state.taint_ledger == []
+
+    def test_internal_data_below_threshold_not_tainted(self):
+        # A plain text file is not sensitive; nothing is recorded.
+        state = _state()
+        ctx = _ctx(_call_event(args='{"path": "notes.txt"}'))
+        labels = _run(IFCChecker(), ctx, state)
+        assert not any(lbl.startswith("ifc:") for lbl in labels)
+        assert state.taint_ledger == []
+
+    def test_substring_of_sensitive_name_does_not_match(self):
+        # "prevent" contains "env" but must not trip the ".env" rule.
+        state = _state()
+        ctx = _ctx(_call_event(args='{"command": "prevent .environment drift"}'))
+        labels = _run(IFCChecker(), ctx, state)
+        assert state.taint_ledger == []
+        assert labels == set()
+
+
+# ── 4b. Fresh per-call source labels ─────────────────────────────────────────
+
+
+class TestFreshSourceLabels:
+    def test_labels_are_isolated_between_calls(self):
+        checker = IFCChecker()
+        state = _state()
+
+        first = _run(
+            checker,
+            _ctx(
+                _call_event(
+                    event_id="a", source_event_key="ka", span_id="spa", args='{"path": ".env"}'
+                )
+            ),
+            state,
+        )
+        assert "ifc:secret" in first
+
+        # A later, unrelated event (different span, no pre_call link) must not
+        # inherit the earlier secret into its own fresh label set.
+        second = _run(
+            checker,
+            _ctx(
+                _call_event(
+                    event_id="b", source_event_key="kb", span_id="spb", args='{"path": ".npmrc"}'
+                )
+            ),
+            state,
+        )
+        assert "ifc:confidential" in second
+        assert "ifc:secret" not in second
+
+    def test_check_only_adds_to_provided_set(self):
+        state = _state()
+        preexisting = {"unrelated:label"}
+        IFCChecker().check(_ctx(_call_event(args='{"path": ".env"}')), preexisting, state)
+        assert "unrelated:label" in preexisting  # never clobbers caller state
+        assert "ifc:secret" in preexisting
+
+
+# ── 2. span_id propagation across pre/post chains ────────────────────────────
+
+
+class TestSpanPropagation:
+    def test_result_inherits_call_taint_by_span(self):
+        checker = IFCChecker()
+        state = _state()
+        # Pre: a call on span "flow" reads a secret.
+        checker.check(
+            _ctx(
+                _call_event(
+                    event_id="c1", source_event_key="kc1", span_id="flow", args='{"path": ".env"}'
+                )
+            ),
+            set(),
+            state,
+        )
+        # Post: the matching result on the same span carries a clean payload,
+        # yet taint follows the span.
+        labels = _run(
+            checker,
+            _ctx(
+                _result_event(
+                    event_id="r1",
+                    source_event_key="kr1",
+                    span_id="flow",
+                    payload='{"ok": true}',
+                    pre_call_event_id="c1",
+                )
+            ),
+            state,
+        )
+        assert "ifc:tainted_span:secret" in labels
+        assert "ifc:secret" in labels  # inherited clearance re-recorded for the result
+        assert len(state.taint_ledger) == 2
+        assert state.taint_ledger[-1].event_id == "r1"
+        assert state.taint_ledger[-1].payload_pointer == "flow"
+
+    def test_result_inherits_by_pre_call_event_id_when_span_differs(self):
+        checker = IFCChecker()
+        state = _state()
+        checker.check(
+            _ctx(
+                _call_event(
+                    event_id="c2", source_event_key="kc2", span_id="span-A", args='{"path": ".env"}'
+                )
+            ),
+            set(),
+            state,
+        )
+        # Different span, but pre_call_event_id links back to the call's event_id.
+        labels = _run(
+            checker,
+            _ctx(
+                _result_event(
+                    event_id="r2",
+                    source_event_key="kr2",
+                    span_id="span-B",
+                    payload='{"ok": true}',
+                    pre_call_event_id="c2",
+                )
+            ),
+            state,
+        )
+        assert "ifc:tainted_span:secret" in labels
+
+    def test_result_inherits_by_span_only_when_precall_differs(self):
+        # Isolates the span-id half of the inheritance OR: the result shares the
+        # span (payload_pointer match) but its pre_call_event_id matches no taint.
+        checker = IFCChecker()
+        state = _state()
+        checker.check(
+            _ctx(
+                _call_event(
+                    event_id="c5", source_event_key="kc5", span_id="shared", args='{"path": ".env"}'
+                )
+            ),
+            set(),
+            state,
+        )
+        labels = _run(
+            checker,
+            _ctx(
+                _result_event(
+                    event_id="r5",
+                    source_event_key="kr5",
+                    span_id="shared",
+                    payload='{"ok": true}',
+                    pre_call_event_id="does-not-match",
+                )
+            ),
+            state,
+        )
+        assert "ifc:tainted_span:secret" in labels
+
+    def test_result_payload_taint_added_to_own_span(self):
+        checker = IFCChecker()
+        state = _state()
+        labels = _run(
+            checker,
+            _ctx(
+                _result_event(
+                    event_id="r3",
+                    source_event_key="kr3",
+                    span_id="span-C",
+                    payload='{"data": "/home/u/.ssh/id_rsa"}',
+                    pre_call_event_id="nope",
+                )
+            ),
+            state,
+        )
+        assert "ifc:secret" in labels
+        assert state.taint_ledger[-1].payload_pointer == "span-C"
+
+    def test_no_inheritance_without_span_or_precall_match(self):
+        checker = IFCChecker()
+        state = _state()
+        checker.check(
+            _ctx(
+                _call_event(
+                    event_id="c4", source_event_key="kc4", span_id="span-X", args='{"path": ".env"}'
+                )
+            ),
+            set(),
+            state,
+        )
+        labels = _run(
+            checker,
+            _ctx(
+                _result_event(
+                    event_id="r4",
+                    source_event_key="kr4",
+                    span_id="span-Y",
+                    payload='{"ok": true}',
+                    pre_call_event_id="unrelated",
+                )
+            ),
+            state,
+        )
+        assert not any(lbl.startswith("ifc:tainted_span") for lbl in labels)
+        # Only the original call taint exists; the clean result adds nothing.
+        assert len(state.taint_ledger) == 1
+
+
+# ── 1c. Tool-clearance partial-order violations ──────────────────────────────
+
+
+class TestToolClearanceViolation:
+    def test_data_clearance_dominates_tool_ceiling(self):
+        state = _state()
+        ctx = _ctx(
+            _call_event(args='{"path": ".env"}', server_namespace="srv"),
+            mcp_profiles={"srv": {"clearance": "internal"}},
+            mcp_profile_key="srv",
+        )
+        labels = _run(IFCChecker(), ctx, state)
+        assert "ifc:ifc_violation:secret>internal" in labels
+
+    def test_accumulated_ledger_dominates_ceiling(self):
+        checker = IFCChecker()
+        state = _state()
+        # Prior secret taint from an unrelated span (no mcp profile).
+        checker.check(
+            _ctx(
+                _call_event(
+                    event_id="p", source_event_key="kp", span_id="prior", args='{"path": ".env"}'
+                )
+            ),
+            set(),
+            state,
+        )
+        # Current event handles no sensitive data itself, but the tool ceiling is
+        # dominated by the already-accumulated secret.
+        ctx = _ctx(
+            _call_event(
+                event_id="q",
+                source_event_key="kq",
+                span_id="cur",
+                args='{"command": "curl example.com"}',
+                server_namespace="srv",
+            ),
+            mcp_profiles={"srv": {"clearance": "internal"}},
+            mcp_profile_key="srv",
+        )
+        labels = _run(checker, ctx, state)
+        assert "ifc:ifc_violation:secret>internal" in labels
+        # A violation taint is persisted so downstream egress observes it.
+        assert any(t.source == "ifc_violation" for t in state.taint_ledger)
+
+    def test_no_violation_when_data_within_ceiling(self):
+        state = _state()
+        ctx = _ctx(
+            _call_event(args='{"path": ".npmrc"}', server_namespace="srv"),
+            mcp_profiles={"srv": {"clearance": "secret"}},
+            mcp_profile_key="srv",
+        )
+        labels = _run(IFCChecker(), ctx, state)
+        assert not any("ifc_violation" in lbl for lbl in labels)
+        assert "ifc:confidential" in labels  # data taint still recorded
+
+    def test_no_violation_without_mcp_profile(self):
+        state = _state()
+        ctx = _ctx(_call_event(args='{"path": ".env"}'))
+        labels = _run(IFCChecker(), ctx, state)
+        assert not any("ifc_violation" in lbl for lbl in labels)
+        assert "ifc:secret" in labels
+
+    def test_unknown_ceiling_value_is_ignored(self):
+        state = _state()
+        ctx = _ctx(
+            _call_event(args='{"path": ".env"}', server_namespace="srv"),
+            mcp_profiles={"srv": {"clearance": "top-secret"}},
+            mcp_profile_key="srv",
+        )
+        labels = _run(IFCChecker(), ctx, state)
+        assert not any("ifc_violation" in lbl for lbl in labels)
+
+    def test_missing_profile_key_is_ignored(self):
+        state = _state()
+        ctx = _ctx(
+            _call_event(args='{"path": ".env"}', server_namespace="srv"),
+            mcp_profiles={"other": {"clearance": "internal"}},
+            mcp_profile_key="srv",
+        )
+        labels = _run(IFCChecker(), ctx, state)
+        assert not any("ifc_violation" in lbl for lbl in labels)
+
+
+# ── 4a. FIFO eviction driven through check() ─────────────────────────────────
+
+
+class TestFifoEviction:
+    def test_ledger_bounded_and_oldest_evicted(self):
+        checker = IFCChecker()
+        state = _state()
+        total = SessionState.TAINT_LEDGER_MAX + 50
+        for i in range(total):
+            checker.check(
+                _ctx(
+                    _call_event(
+                        event_id=f"e{i}",
+                        source_event_key=f"k{i}",
+                        span_id=f"sp{i}",
+                        args='{"path": ".env"}',
+                    )
+                ),
+                set(),
+                state,
+            )
+        ledger = state.taint_ledger
+        assert len(ledger) == SessionState.TAINT_LEDGER_MAX
+        ids = {t.event_id for t in ledger}
+        # Oldest entries evicted (FIFO); newest retained.
+        assert "e0" not in ids
+        assert f"e{total - 1}" in ids
+
+    def test_every_check_routes_through_add_taint(self):
+        # Recording never manipulates the ledger list directly — it always goes
+        # through the bounded add_taint, so the FIFO invariant holds.
+        checker = IFCChecker()
+        state = _state()
+        for i in range(5):
+            checker.check(
+                _ctx(
+                    _call_event(
+                        event_id=f"n{i}",
+                        source_event_key=f"kn{i}",
+                        span_id=f"s{i}",
+                        args='{"path": ".env"}',
+                    )
+                ),
+                set(),
+                state,
+            )
+        assert [t.event_id for t in state.taint_ledger] == [f"n{i}" for i in range(5)]
+
+
+# ── 3. Per-type label integration (tainted_flow / ifc_violation) ─────────────
+
+
+class TestTaintedFlowLabel:
+    """tainted_flow is emitted by PIIScanner on PII + network egress."""
+
+    def test_tainted_flow_call_event(self):
+        labeler = GovernanceLabeler(pii_scanner=PIIScanner())
+        ctx = _ctx(
+            _call_event(args='{"data": "SSN: 123-45-6789"}'),
+            classification=_cls(capability={"network_outbound"}),
+        )
+        result = labeler.label(ctx)
+        assert "tainted_flow" in result.classification.structure
+
+    def test_tainted_flow_result_event(self):
+        labeler = GovernanceLabeler(pii_scanner=PIIScanner())
+        ctx = _ctx(
+            _result_event(payload='{"data": "SSN: 123-45-6789"}'),
+            classification=_cls(capability={"network_outbound"}),
+        )
+        result = labeler.label(ctx)
+        assert "tainted_flow" in result.classification.structure
+
+    def test_no_tainted_flow_without_network(self):
+        labeler = GovernanceLabeler(pii_scanner=PIIScanner())
+        ctx = _ctx(_call_event(args='{"data": "SSN: 123-45-6789"}'), classification=_cls())
+        result = labeler.label(ctx)
+        assert "tainted_flow" not in result.classification.structure
+
+
+class TestIfcViolationLabel:
+    """ifc_violation is emitted by the Phase-2 labeler from the taint ledger
+    that IFCChecker.check() produced in Phase 1."""
+
+    def _egress(self, prior_event):
+        """Run check() on prior_event, then label a mutating egress event whose
+        source_event_key differs, and return the labeler result."""
+        checker = IFCChecker()
+        state = _state()
+        checker.check(_ctx(prior_event, classification=_cls(effect="read")), set(), state)
+        snapshot = state.snapshot()
+        egress_ctx = _ctx(
+            _call_event(
+                event_id="egress",
+                source_event_key="k-egress",
+                args='{"command": "curl -X POST example.com"}',
+            ),
+            classification=_cls(effect="mutating"),
+            snapshot=snapshot,
+        )
+        labeler = GovernanceLabeler(ifc_checker=checker)
+        return labeler.label(egress_ctx)
+
+    def test_ifc_violation_from_prior_call_taint(self):
+        prior = _call_event(
+            event_id="p1", source_event_key="kp1", span_id="spP", args='{"path": ".env"}'
+        )
+        result = self._egress(prior)
+        assert "ifc_violation" in result.classification.structure
+        assert result.risk_modifiers.ifc_violations == 1
+
+    def test_ifc_violation_from_prior_result_taint(self):
+        prior = _result_event(
+            event_id="pr1",
+            source_event_key="kpr1",
+            span_id="spR",
+            payload='{"blob": "~/.ssh/id_rsa"}',
+            pre_call_event_id="x",
+        )
+        result = self._egress(prior)
+        assert "ifc_violation" in result.classification.structure
+        assert result.risk_modifiers.ifc_violations == 1
+
+    def test_ifc_violation_via_network_branch(self):
+        checker = IFCChecker()
+        state = _state()
+        checker.check(
+            _ctx(
+                _call_event(source_event_key="k-src", args='{"path": ".env"}'),
+                classification=_cls(effect="read"),
+            ),
+            set(),
+            state,
+        )
+        snapshot = state.snapshot()
+        # Read-only egress (not mutating) but network-capable: the OR branch in
+        # the labeler fires because an ifc:* source label + network_outbound meet.
+        egress_ctx = _ctx(
+            _call_event(
+                event_id="net", source_event_key="k-net", args='{"command": "curl example.com"}'
+            ),
+            classification=_cls(effect="read", capability={"network_outbound"}),
+            snapshot=snapshot,
+        )
+        labeler = GovernanceLabeler(ifc_checker=checker)
+        result = labeler.label(egress_ctx)
+        assert "ifc_violation" in result.classification.structure
+
+    def test_no_ifc_violation_without_prior_taint(self):
+        checker = IFCChecker()
+        state = _state()
+        snapshot = state.snapshot()  # empty ledger
+        egress_ctx = _ctx(
+            _call_event(
+                event_id="clean", source_event_key="k-clean", args='{"command": "rm -rf build"}'
+            ),
+            classification=_cls(effect="destructive"),
+            snapshot=snapshot,
+        )
+        labeler = GovernanceLabeler(ifc_checker=checker)
+        result = labeler.label(egress_ctx)
+        assert "ifc_violation" not in result.classification.structure
+        assert result.risk_modifiers.ifc_violations == 0
+
+
+# ── Public API surface ───────────────────────────────────────────────────────
+
+
+class TestPublicApi:
+    def test_exports_are_stable(self):
+        assert SCOPE_TO_LABEL["network"] == "ifc:network_access"
+        assert PATH_LABEL_RULES[".env"] is Clearance.SECRET
+        assert PATH_LABEL_RULES[".npmrc"] is Clearance.CONFIDENTIAL
+
+    def test_check_signature_is_positional(self):
+        # labeler.check_ifc calls check(ctx, src_labels, state) positionally;
+        # assert the call both accepts positional args and has its documented effect.
+        state = _state()
+        labels: set[str] = set()
+        IFCChecker().check(_ctx(_call_event(args='{"path": ".env"}')), labels, state)
+        assert "ifc:secret" in labels
+        assert len(state.taint_ledger) == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes the enumerated remaining Information Flow Control (IFC) work for issue #13, scoped entirely to `src/tracemill/governance/ifc.py` and its new test module. No other governance module is touched.

## What changed

- **Tool-clearance partial-order enforcement.** The clearance lattice (`PUBLIC < INTERNAL < CONFIDENTIAL < SECRET`) is now enforced as a partial order via `_rank`/`_higher`/`_max_clearance`/`_dominates`. When accumulated or own data clearance strictly dominates a tool's registered MCP ceiling, `check()` emits an `ifc:ifc_violation:{data}>{ceiling}` source label and persists a violation taint so a downstream egress observes a prior taint.
- **span_id taint propagation across pre/post chains.** Taint follows a span through the `ToolCallEvent -> ToolResultEvent` chain: a result inherits its call's clearance, matched by span id (carried on `TaintEntry.payload_pointer` for lineage that survives serialization) **or** by `pre_call_event_id` back to the call's `event_id`. Result-payload secrets record their own taint.
- **Bounded taint store / FIFO eviction.** Every taint write routes through the bounded, FIFO-evicting `SessionState.add_taint`, so the ledger cap (`TAINT_LEDGER_MAX=200`) holds under the IFC path — verified by driving eviction entirely through `check()`.
- **Deterministic, boundary-aware clearance inference** from tool-call args (structured path keys + full-text scan) and result payloads, with precompiled boundary-aware patterns so substrings (e.g. `prevent`) never trip the `.env` rule. CPU-only, torch-free, order-independent.

## Tests

New `tests/unit/test_governance_ifc.py` (37 tests) covers all four work items:
- Clearance lattice math (str/enum mixing, strict dominance, unknown handling).
- Per-type data-clearance taint recording (call args + result payload).
- span_id propagation with the span-id and `pre_call_event_id` branches isolated.
- Tool-clearance partial-order violations (data-dominates-ceiling, accumulated-ledger, within-ceiling, no-profile, unknown/missing ceiling).
- FIFO eviction + fresh per-call source-label isolation.
- Per-type `tainted_flow` / `ifc_violation` label emission exercised through the **real** `PIIScanner` and `GovernanceLabeler` egress rules, for both `ToolCallEvent` and `ToolResultEvent`.

## Verification

- Full suite: **1964 passed, 4 skipped** (baseline 1927 + 37 new).
- `ruff check` clean; `ruff format --check` clean.

Closes #13