### PR TITLE
Remove three phantom-legacy compat shims

### DIFF
--- a/src/tracemill/gate/registry.py
+++ b/src/tracemill/gate/registry.py
@@ -1,6 +1,6 @@
 """Gate endpoint registry — maps session_id → socket path in system.db.
 
-The gate_endpoints table is now managed by Alembic as part of the unified
+The gate_endpoints table is managed by Alembic as part of the unified
 system schema. This module provides convenience functions that operate
 on a standalone connection for lightweight lookups (the gate client doesn't
 always have access to a full SystemStore instance).
@@ -24,26 +24,12 @@ def _system_db_path() -> str:
     return str(Path.home() / ".tracemill" / "system.db")
 
 
-def _ensure_table(conn: sqlite3.Connection) -> None:
-    """Ensure gate_endpoints table exists (backward compat for pre-migration DBs)."""
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS gate_endpoints (
-            session_id TEXT PRIMARY KEY,
-            sock_path TEXT NOT NULL,
-            pid INTEGER NOT NULL,
-            registered_at TEXT NOT NULL DEFAULT (datetime('now'))
-        )
-    """)
-    conn.commit()
-
-
 def register_session(session_id: str, sock_path: str, *, db_path: str | None = None) -> None:
     """Register a session_id → sock_path mapping."""
     db = db_path or _system_db_path()
     Path(db).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db)
     try:
-        _ensure_table(conn)
         conn.execute(
             "INSERT OR REPLACE INTO gate_endpoints (session_id, sock_path, pid) VALUES (?, ?, ?)",
             (session_id, sock_path, os.getpid()),
@@ -60,7 +46,6 @@ def lookup_session(session_id: str, *, db_path: str | None = None) -> str | None
         return None
     conn = sqlite3.connect(db)
     try:
-        _ensure_table(conn)
         row = conn.execute(
             "SELECT sock_path, pid FROM gate_endpoints WHERE session_id = ?",
             (session_id,),
@@ -85,7 +70,6 @@ def unregister_session(session_id: str, *, db_path: str | None = None) -> None:
         return
     conn = sqlite3.connect(db)
     try:
-        _ensure_table(conn)
         conn.execute("DELETE FROM gate_endpoints WHERE session_id = ?", (session_id,))
         conn.commit()
     finally:
@@ -99,7 +83,6 @@ def unregister_pid(*, db_path: str | None = None) -> None:
         return
     conn = sqlite3.connect(db)
     try:
-        _ensure_table(conn)
         conn.execute("DELETE FROM gate_endpoints WHERE pid = ?", (os.getpid(),))
         conn.commit()
     finally:

--- a/src/tracemill/governance/codec.py
+++ b/src/tracemill/governance/codec.py
@@ -374,26 +374,20 @@ class MetaCodec:
         from tracemill.governance.mcp_drift import MCPIntegrityAlert
 
         mcp_alerts_raw = data.get("mcp_alerts", ())
-        mcp_alerts: tuple = ()
-        if mcp_alerts_raw:
-            alerts_list = []
-            for a in mcp_alerts_raw:
-                if isinstance(a, dict):
-                    alerts_list.append(
-                        MCPIntegrityAlert(
-                            tool_name=a.get("tool_name", ""),
-                            server=a.get("server", ""),
-                            alert_type=a.get("alert_type", "schema_change"),
-                            previous=a.get("previous", ""),
-                            current=a.get("current", ""),
-                            severity=a.get("severity", "info"),
-                            timestamp=datetime.fromisoformat(a["timestamp"])
-                            if a.get("timestamp")
-                            else datetime.now(timezone.utc),
-                        )
-                    )
-                # Legacy string alerts: skip (can't reconstruct typed object)
-            mcp_alerts = tuple(alerts_list)
+        mcp_alerts: tuple = tuple(
+            MCPIntegrityAlert(
+                tool_name=a.get("tool_name", ""),
+                server=a.get("server", ""),
+                alert_type=a.get("alert_type", "schema_change"),
+                previous=a.get("previous", ""),
+                current=a.get("current", ""),
+                severity=a.get("severity", "info"),
+                timestamp=datetime.fromisoformat(a["timestamp"])
+                if a.get("timestamp")
+                else datetime.now(timezone.utc),
+            )
+            for a in mcp_alerts_raw
+        )
 
         return SessionMeta(
             classification=cls,

--- a/src/tracemill/governance/pii.py
+++ b/src/tracemill/governance/pii.py
@@ -234,10 +234,6 @@ _DETECTORS: tuple[_Detector, ...] = (
     ),
 )
 
-# Backward-compatible views derived from the detector table.
-_CREDENTIAL_CATEGORIES = frozenset(d.category for d in _DETECTORS if d.is_credential)
-PII_PATTERNS: dict[PIICategory, re.Pattern[str]] = {d.category: d.pattern for d in _DETECTORS}
-
 
 class PIIScanner:
     """Stateless PII/credential scanner. Adds capability labels."""

--- a/tests/unit/test_gate_registry.py
+++ b/tests/unit/test_gate_registry.py
@@ -1,0 +1,70 @@
+"""Gate endpoint registry round-trips against an Alembic-migrated system.db.
+
+The ``gate_endpoints`` table is owned solely by the Alembic migration
+(``0001_initial``); the registry no longer creates it ad-hoc. These tests
+prove register -> lookup -> unregister works against a properly-migrated
+database, and that a lookup against a not-yet-created db returns ``None``
+without materialising an unmigrated file (the gate client is never the first
+toucher of the db).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tracemill.gate.registry import (
+    lookup_session,
+    register_session,
+    unregister_pid,
+    unregister_session,
+)
+from tracemill.governance.persistence import SystemStore
+
+
+def _migrated_db(tmp_path: Path) -> str:
+    """Create a system.db and bring it to HEAD via SystemStore (Alembic)."""
+    db = str(tmp_path / "system.db")
+    SystemStore(db).close()
+    return db
+
+
+def test_migration_owns_gate_endpoints_table(tmp_path):
+    db = _migrated_db(tmp_path)
+    conn = sqlite3.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='gate_endpoints'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+
+
+def test_register_lookup_unregister_round_trip(tmp_path):
+    db = _migrated_db(tmp_path)
+
+    register_session("sess-1", "/tmp/sess-1.sock", db_path=db)
+    assert lookup_session("sess-1", db_path=db) == "/tmp/sess-1.sock"
+
+    unregister_session("sess-1", db_path=db)
+    assert lookup_session("sess-1", db_path=db) is None
+
+
+def test_unregister_pid_clears_current_process_entries(tmp_path):
+    db = _migrated_db(tmp_path)
+
+    register_session("sess-a", "/tmp/a.sock", db_path=db)
+    register_session("sess-b", "/tmp/b.sock", db_path=db)
+
+    unregister_pid(db_path=db)
+
+    assert lookup_session("sess-a", db_path=db) is None
+    assert lookup_session("sess-b", db_path=db) is None
+
+
+def test_lookup_missing_db_returns_none_without_creating_it(tmp_path):
+    db = str(tmp_path / "nonexistent.db")
+
+    assert lookup_session("sess-x", db_path=db) is None
+    assert not Path(db).exists()

--- a/tests/unit/test_governance_codec.py
+++ b/tests/unit/test_governance_codec.py
@@ -1,0 +1,73 @@
+"""MetaCodec round-trips SessionMeta through its JSON-able dict form.
+
+The serializer emits MCP alerts only as dicts, so the deserializer treats
+every alert element as a dict. These tests guard that typed
+``MCPIntegrityAlert`` objects survive an encode -> decode round trip with all
+fields intact — there is no bare-string alert format to reconstruct.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from tracemill.governance.codec import MetaCodec
+from tracemill.governance.mcp_drift import MCPIntegrityAlert
+from tracemill.governance.results import SessionMeta
+
+
+def test_single_mcp_alert_survives_round_trip():
+    alert = MCPIntegrityAlert(
+        tool_name="db.query",
+        server="analytics",
+        alert_type="effect_escalation",
+        previous="read_only",
+        current="destructive",
+        severity="critical",
+        timestamp=datetime(2026, 7, 6, 12, 30, 0, tzinfo=timezone.utc),
+    )
+    meta = SessionMeta(classification=None, risk_assessment=None, mcp_alerts=(alert,))
+
+    codec = MetaCodec()
+    restored = codec.deserialize_meta(codec.serialize_meta(meta))
+
+    assert len(restored.mcp_alerts) == 1
+    got = restored.mcp_alerts[0]
+    assert got.tool_name == alert.tool_name
+    assert got.server == alert.server
+    assert got.alert_type == alert.alert_type
+    assert got.previous == alert.previous
+    assert got.current == alert.current
+    assert got.severity == alert.severity
+    assert got.timestamp == alert.timestamp
+
+
+def test_multiple_mcp_alerts_all_survive_round_trip():
+    alerts = tuple(
+        MCPIntegrityAlert(
+            tool_name=f"tool-{i}",
+            server=f"srv-{i}",
+            alert_type="schema_change",
+            previous="a",
+            current="b",
+            severity="warning",
+            timestamp=datetime(2026, 7, 6, 12, 0, i, tzinfo=timezone.utc),
+        )
+        for i in range(3)
+    )
+    meta = SessionMeta(classification=None, risk_assessment=None, mcp_alerts=alerts)
+
+    codec = MetaCodec()
+    restored = codec.deserialize_meta(codec.serialize_meta(meta))
+
+    assert len(restored.mcp_alerts) == 3
+    assert [a.tool_name for a in restored.mcp_alerts] == ["tool-0", "tool-1", "tool-2"]
+    assert [a.timestamp for a in restored.mcp_alerts] == [a.timestamp for a in alerts]
+
+
+def test_no_mcp_alerts_round_trips_to_empty_tuple():
+    meta = SessionMeta(classification=None, risk_assessment=None, mcp_alerts=())
+
+    codec = MetaCodec()
+    restored = codec.deserialize_meta(codec.serialize_meta(meta))
+
+    assert restored.mcp_alerts == ()


### PR DESCRIPTION
## Why

tracemill has **never been released** — no alpha, no PyPI publish, zero deployed databases, zero external importers. Any backward-compatibility / legacy / migration-adoption / dual-write machinery therefore models a constraint that does not exist. This PR removes three such self-created "phantom-legacy" shims so every schema and serialization format has **one source of truth**.

## The three purges

### 1. `governance/pii.py` — delete dead compat views
Removed the `PII_PATTERNS` and `_CREDENTIAL_CATEGORIES` "backward-compatible views derived from the detector table" (plus the comment). `git grep` confirms **zero importers/users** in `src/` or `tests/` — they were pure dead code. `_DETECTORS` remains the single source of truth.

### 2. `governance/codec.py` — remove the impossible "legacy string alerts" branch
In `deserialize_meta`, the `mcp_alerts` loop guarded each element with `isinstance(a, dict)` and silently skipped a non-dict "legacy string" case. The serializer in the same file (`serialize_meta`) **only ever emits dicts**, so a bare-string alert can never exist. Simplified to construct `MCPIntegrityAlert` directly for each (guaranteed-dict) element; the real dict-path behavior is byte-for-byte identical.

### 3. `gate/registry.py` — kill the "pre-migration DBs" shim
`_ensure_table(conn)` ran an ad-hoc `CREATE TABLE IF NOT EXISTS gate_endpoints (...)` (docstring: "backward compat for pre-migration DBs") at the top of register/lookup/unregister/cleanup. But `gate_endpoints` is **already owned by the Alembic migration `0001_initial`**. Bootstrap trace: the only path that creates or registers endpoints is `tracemill watch`, which constructs `SystemStore` (running migrations to HEAD, creating `gate_endpoints`) **before** the gate server registers anything; the read/delete paths (`lookup_session`/`unregister_session`/`unregister_pid`) all early-return when the db file is absent, so the registry is **never the first toucher of an unmigrated db**. Deleted `_ensure_table` and its 4 call sites; Alembic is the sole schema authority.

## Tests
- `tests/unit/test_governance_codec.py` — `MetaCodec` round-trip proving a typed `MCPIntegrityAlert` (and multiple alerts, and the empty case) survive encode → decode with all fields intact.
- `tests/unit/test_gate_registry.py` — register → lookup → unregister round-trip against an Alembic-migrated `system.db`, plus a guard that a lookup against a missing db returns `None` without materialising an unmigrated file.

## Verification
- Full suite: **2177 passed, 4 skipped**, 0 failures/errors.
- `ruff check` — all checks passed; `ruff format --check` — all files formatted (pinned `ruff==0.15.20`).
- `git diff --name-only origin/main` = exactly these 5 files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>