### PR TITLE
Add escalation context + evidence construction detail (#24, #25)

### DIFF
--- a/src/tracemill/governance/assessor.py
+++ b/src/tracemill/governance/assessor.py
@@ -194,11 +194,16 @@ class DefaultAssessor:
                 risk_score=risk.score,
                 risk_factors=risk.factors,
                 mitre_techniques=risk.mitre,
+                rule_id=rule_match.rule_id,
+                matched_predicates=self._serialize_predicates(rule_match.matched_predicates),
                 pointers=(
                     EvidencePointer(
                         event_id=ctx.event.event_id,
                         rule_id=rule_match.rule_id,
                         detector="rule_engine",
+                        payload_pointer=self._serialize_triggering_values(
+                            result.classification, risk, rule_match.matched_predicates
+                        ),
                     ),
                 ),
                 escalation=escalation,
@@ -327,6 +332,11 @@ class DefaultAssessor:
             tool_args_summary=tool_args_summary,
             session_id=ctx.event.session_id,
             timestamp=ctx.event.timestamp,
+            event_id=ctx.event.event_id,
+            classification_summary=self._summarize_classification(result.classification),
+            risk_factors=risk.factors,
+            session_event_count=snapshot.event_count if snapshot else 0,
+            recent_phase_window=snapshot.phase_window if snapshot else (),
         )
 
     def _sanitize_args(self, raw_args: str, max_len: int = 500) -> str:
@@ -350,3 +360,82 @@ class DefaultAssessor:
         if len(sanitized) > max_len:
             sanitized = sanitized[:max_len] + "..."
         return sanitized
+
+    # ── #24 / #25 serialization helpers ──
+
+    @staticmethod
+    def _summarize_classification(classification) -> str:
+        """Concise, deterministic human-readable summary of a classification.
+
+        Renders ``mechanism[/effect]`` followed by the salient set dimensions
+        (capability, action, scope) sorted for stability. Empty dimensions are
+        omitted; a ``None`` classification yields an empty string.
+        """
+        if classification is None:
+            return ""
+        head = classification.mechanism or "unknown"
+        if classification.effect:
+            head = f"{head}/{classification.effect}"
+        parts: list[str] = []
+        if classification.capability:
+            parts.append("caps=" + ",".join(sorted(classification.capability)))
+        if classification.action:
+            parts.append("actions=" + ",".join(sorted(classification.action)))
+        if classification.scope:
+            parts.append("scope=" + ",".join(sorted(classification.scope)))
+        return f"{head} ({'; '.join(parts)})" if parts else head
+
+    @staticmethod
+    def _format_predicate(pred) -> str:
+        """Render one matched rule predicate as a compact, deterministic string."""
+        if pred.dim == "risk_score":
+            threshold = pred.threshold if pred.threshold is not None else 0
+            return f"risk_score {pred.operator} {threshold}"
+        if pred.operator == "exact":
+            return f"{pred.dim} == {pred.target}"
+        return f"{pred.dim} {pred.operator} [{','.join(sorted(pred.targets))}]"
+
+    def _serialize_predicates(self, predicates) -> tuple[str, ...]:
+        """Serialize the rule predicates that matched this event (rule requirements)."""
+        return tuple(self._format_predicate(p) for p in predicates)
+
+    @staticmethod
+    def _classification_dim_value(classification, dim: str) -> str | None:
+        """Concrete value of ``dim`` on ``classification`` (None when absent/empty)."""
+        if classification is None:
+            return None
+        if dim == "mechanism":
+            return classification.mechanism or None
+        if dim == "effect":
+            return classification.effect
+        set_value = {
+            "scope": classification.scope,
+            "role": classification.role,
+            "action": classification.action,
+            "capability": classification.capability,
+            "structure": classification.structure,
+        }.get(dim)
+        if set_value:
+            return "[" + ",".join(sorted(set_value)) + "]"
+        return None
+
+    def _serialize_triggering_values(self, classification, risk, predicates) -> str:
+        """Compact, sanitized serialization of the values that triggered the match.
+
+        For each matched predicate we record the *actual* value the rule engine
+        evaluated — the classification dimension value, or the concrete risk score
+        for ``risk_score`` predicates. Keys are sorted for determinism and the
+        rendered string is passed through :meth:`_sanitize_args` so the same
+        secret-redaction discipline applies, even though classification labels are
+        derived tokens rather than raw event payloads.
+        """
+        values: dict[str, str] = {}
+        for pred in predicates:
+            if pred.dim == "risk_score":
+                values["risk_score"] = str(risk.score)
+                continue
+            actual = self._classification_dim_value(classification, pred.dim)
+            if actual is not None:
+                values[pred.dim] = actual
+        rendered = "; ".join(f"{dim}={values[dim]}" for dim in sorted(values))
+        return self._sanitize_args(rendered)

--- a/src/tracemill/governance/codec.py
+++ b/src/tracemill/governance/codec.py
@@ -149,6 +149,11 @@ class MetaCodec:
             timestamp=datetime.fromisoformat(data["timestamp"])
             if data.get("timestamp")
             else datetime.now(timezone.utc),
+            event_id=data.get("event_id", ""),
+            classification_summary=data.get("classification_summary", ""),
+            risk_factors=tuple(data.get("risk_factors", ())),
+            session_event_count=data.get("session_event_count", 0),
+            recent_phase_window=tuple(data.get("recent_phase_window", ())),
         )
 
     def serialize_meta(self, meta: SessionMeta) -> dict:
@@ -227,6 +232,8 @@ class MetaCodec:
                 "risk_score": meta.evidence.risk_score,
                 "risk_factors": list(meta.evidence.risk_factors),
                 "mitre_techniques": list(meta.evidence.mitre_techniques),
+                "rule_id": meta.evidence.rule_id,
+                "matched_predicates": list(meta.evidence.matched_predicates),
                 "pointers": pointers_data,
             }
             if meta.evidence.escalation:
@@ -243,6 +250,11 @@ class MetaCodec:
                     "tool_args_summary": esc.tool_args_summary,
                     "session_id": esc.session_id,
                     "timestamp": esc.timestamp.isoformat(),
+                    "event_id": esc.event_id,
+                    "classification_summary": esc.classification_summary,
+                    "risk_factors": list(esc.risk_factors),
+                    "session_event_count": esc.session_event_count,
+                    "recent_phase_window": list(esc.recent_phase_window),
                 }
         mcp_alerts_data = []
         if meta.mcp_alerts:
@@ -369,6 +381,8 @@ class MetaCodec:
                 mitre_techniques=tuple(evidence_data.get("mitre_techniques", ())),
                 pointers=pointers,
                 escalation=self.deserialize_escalation(evidence_data.get("escalation")),
+                rule_id=evidence_data.get("rule_id", ""),
+                matched_predicates=tuple(evidence_data.get("matched_predicates", ())),
             )
 
         from tracemill.governance.mcp_drift import MCPIntegrityAlert

--- a/src/tracemill/governance/results.py
+++ b/src/tracemill/governance/results.py
@@ -94,6 +94,12 @@ class EscalationContext:
     tool_args_summary: str  # Sanitized — no secrets
     session_id: str
     timestamp: datetime
+    # --- #24: richer escalation context ---
+    event_id: str = ""  # Triggering event's id (ctx.event.event_id)
+    classification_summary: str = ""  # Concise deterministic human-readable summary
+    risk_factors: tuple[str, ...] = ()  # risk.factors that drove the score
+    session_event_count: int = 0  # snapshot.event_count at escalation time
+    recent_phase_window: tuple[str, ...] = ()  # snapshot.phase_window (recent phases)
 
 
 @dataclass(frozen=True)
@@ -127,6 +133,9 @@ class Evidence:
     mitre_techniques: tuple[str, ...]
     pointers: tuple[EvidencePointer, ...]
     escalation: EscalationContext | None = None
+    # --- #25: promote rule provenance + matched-predicate detail to the top level ---
+    rule_id: str = ""  # Matching rule id (also carried on each EvidencePointer)
+    matched_predicates: tuple[str, ...] = ()  # Serialized rule predicates that matched
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_governance_codec.py
+++ b/tests/unit/test_governance_codec.py
@@ -10,9 +10,16 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from tracemill.classify.core import Classification
 from tracemill.governance.codec import MetaCodec
 from tracemill.governance.mcp_drift import MCPIntegrityAlert
-from tracemill.governance.results import SessionMeta
+from tracemill.governance.results import (
+    Evidence,
+    EvidencePointer,
+    EscalationContext,
+    RecommendedAction,
+    SessionMeta,
+)
 
 
 def test_single_mcp_alert_survives_round_trip():
@@ -71,3 +78,103 @@ def test_no_mcp_alerts_round_trips_to_empty_tuple():
     restored = codec.deserialize_meta(codec.serialize_meta(meta))
 
     assert restored.mcp_alerts == ()
+
+
+def _fully_populated_evidence() -> Evidence:
+    """Evidence carrying every #24/#25 field set to a distinctive non-default value."""
+    cls = Classification(
+        mechanism="shell.execute",
+        effect="destructive",
+        scope=frozenset({"host.filesystem"}),
+        action=frozenset({"file.delete"}),
+        capability=frozenset({"credential_exposure"}),
+    )
+    escalation = EscalationContext(
+        canonical_id="sha256:esc",
+        classification=cls,
+        recommended_action=RecommendedAction.DENY,
+        reason_code="cred_destruction",
+        mitre_techniques=("T1059", "T1486"),
+        drift=None,
+        budget_snapshot=None,
+        pii_taint=True,
+        ifc_violations=2,
+        tool_name="bash",
+        tool_args_summary="rm -rf /",
+        session_id="sess-7",
+        timestamp=datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc),
+        # --- #24 new fields ---
+        event_id="evt-42",
+        classification_summary="shell.execute/destructive (caps=credential_exposure)",
+        risk_factors=("destructive_command", "ifc_violations:2"),
+        session_event_count=9,
+        recent_phase_window=("explore", "edit", "exploit"),
+    )
+    return Evidence(
+        canonical_id="sha256:esc",
+        timestamp=datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc),
+        session_id="sess-7",
+        mechanism="shell.execute",
+        effect="destructive",
+        scope=("host.filesystem",),
+        role=(),
+        action=("file.delete",),
+        capability=("credential_exposure",),
+        structure=(),
+        source_labels=(),
+        recommended_action=RecommendedAction.DENY,
+        risk_score=92,
+        risk_factors=("destructive_command", "ifc_violations:2"),
+        mitre_techniques=("T1059", "T1486"),
+        pointers=(
+            EvidencePointer(
+                event_id="evt-42",
+                rule_id="deny-cred-destruction",
+                detector="rule_engine",
+                payload_pointer="capability=[credential_exposure]; mechanism=shell.execute; risk_score=92",
+            ),
+        ),
+        escalation=escalation,
+        # --- #25 new fields ---
+        rule_id="deny-cred-destruction",
+        matched_predicates=(
+            "mechanism == shell.execute",
+            "capability any_of [credential_exposure]",
+            "risk_score >= 70",
+        ),
+    )
+
+
+def test_evidence_and_escalation_new_fields_survive_round_trip():
+    """#24 + #25: every new Evidence / EscalationContext field is lossless."""
+    meta = SessionMeta(
+        classification=None,
+        risk_assessment=None,
+        evidence=_fully_populated_evidence(),
+    )
+
+    codec = MetaCodec()
+    restored = codec.deserialize_meta(codec.serialize_meta(meta))
+
+    ev = restored.evidence
+    assert ev is not None
+    # #25 — promoted Evidence provenance
+    assert ev.rule_id == "deny-cred-destruction"
+    assert ev.matched_predicates == (
+        "mechanism == shell.execute",
+        "capability any_of [credential_exposure]",
+        "risk_score >= 70",
+    )
+    # #25 — EvidencePointer.payload_pointer (serialized triggering values)
+    assert ev.pointers[0].payload_pointer == (
+        "capability=[credential_exposure]; mechanism=shell.execute; risk_score=92"
+    )
+
+    esc = ev.escalation
+    assert esc is not None
+    # #24 — richer escalation context
+    assert esc.event_id == "evt-42"
+    assert esc.classification_summary == ("shell.execute/destructive (caps=credential_exposure)")
+    assert esc.risk_factors == ("destructive_command", "ifc_violations:2")
+    assert esc.session_event_count == 9
+    assert esc.recent_phase_window == ("explore", "edit", "exploit")

--- a/tests/unit/test_governance_escalation_evidence.py
+++ b/tests/unit/test_governance_escalation_evidence.py
@@ -1,0 +1,206 @@
+"""#24 escalation context + #25 evidence construction — assessor build sites.
+
+Drives :meth:`DefaultAssessor._phase3` directly with a fabricated ``GovernanceResult``
+and a controlled ``SessionStateSnapshot`` so the new ``EscalationContext`` fields (#24),
+the promoted ``Evidence.rule_id`` / ``Evidence.matched_predicates`` (#25), and the newly
+populated ``EvidencePointer.payload_pointer`` are exercised against the *real* production
+build sites rather than re-implemented in the test. A real ``ClassificationEngine`` is
+supplied because ``_phase3`` computes risk through it; the labeler is unused there.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tracemill.classify.config import ClassificationEngine, ClassifyConfig
+from tracemill.classify.core import Classification
+from tracemill.governance.assessor import DefaultAssessor
+from tracemill.governance.labeler import GovernanceResult
+from tracemill.governance.risk_wrapper import RiskModifiers
+from tracemill.governance.rules import Predicate
+from tracemill.governance.rules import RecommendedAction as RuleAction
+from tracemill.governance.rules import Rule
+from tracemill.governance.state import BudgetSnapshot, SessionStateSnapshot
+from tracemill.governance.types import EnrichmentContext, ToolCallEvent
+
+_MECHANISM = "shell.execute"
+_SUMMARY = (
+    "shell.execute/destructive "
+    "(caps=credential_exposure; actions=file.delete; scope=host.filesystem)"
+)
+
+
+def _event() -> ToolCallEvent:
+    return ToolCallEvent(
+        event_id="evt-42",
+        session_id="sess-7",
+        timestamp=datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc),
+        source_event_key="key-42",
+        span_id="span-42",
+        tool_name="bash",
+        server_namespace=None,
+        tool_args_json='{"command": "rm -rf /", "password": "hunter2"}',
+        source_event_id=None,
+    )
+
+
+def _classification() -> Classification:
+    return Classification(
+        mechanism=_MECHANISM,
+        effect="destructive",
+        scope=frozenset({"host.filesystem"}),
+        action=frozenset({"file.delete"}),
+        capability=frozenset({"credential_exposure"}),
+    )
+
+
+def _ctx(classification: Classification) -> EnrichmentContext:
+    return EnrichmentContext(
+        event=_event(),
+        base_classification=classification,
+        command_analysis=None,
+        session_state=None,
+        mcp_profiles=None,
+        project_root=None,
+        engine="shell",
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+def _result(classification: Classification) -> GovernanceResult:
+    return GovernanceResult(
+        classification=classification,
+        risk_modifiers=RiskModifiers(ifc_violations=2),
+        drift_result=None,
+    )
+
+
+def _snapshot() -> SessionStateSnapshot:
+    return SessionStateSnapshot(
+        budget=BudgetSnapshot(),
+        phase_window=("explore", "edit", "exploit"),
+        event_count=9,
+    )
+
+
+def _rule(action: RuleAction) -> Rule:
+    return Rule(
+        id="deny-cred-destruction",
+        index=0,
+        when=(
+            Predicate(dim="mechanism", operator="exact", target=_MECHANISM),
+            Predicate(dim="capability", operator="any_of", targets=("credential_exposure",)),
+            # threshold 0 so the rule matches regardless of the concrete score.
+            Predicate(dim="risk_score", operator=">=", threshold=0),
+        ),
+        recommend=action,
+        reason="cred_destruction",
+    )
+
+
+def _assessor(action: RuleAction) -> DefaultAssessor:
+    # labeler is unused by _phase3; a real engine is required for risk scoring.
+    return DefaultAssessor(None, [_rule(action)], ClassificationEngine(ClassifyConfig()))
+
+
+def _phase3(action: RuleAction, snapshot: SessionStateSnapshot | None = _snapshot()):
+    cls = _classification()
+    return _assessor(action)._phase3(_ctx(cls), _result(cls), snapshot)
+
+
+class TestEscalationContextFields:
+    """#24 — the five new EscalationContext fields populate from ctx/risk/snapshot."""
+
+    def test_deny_populates_new_escalation_fields(self):
+        phase3 = _phase3(RuleAction.DENY)
+        esc = phase3.recommendation_result.evidence.escalation
+        assert esc is not None
+        assert esc.event_id == "evt-42"
+        assert esc.classification_summary == _SUMMARY
+        assert esc.risk_factors == phase3.risk_assessment.factors
+        assert "ifc_violations:2" in esc.risk_factors
+        assert esc.session_event_count == 9
+        assert esc.recent_phase_window == ("explore", "edit", "exploit")
+
+    def test_escalate_guards_missing_snapshot(self):
+        # Mirrors the existing `snapshot.budget if snapshot else None` defensiveness:
+        # snapshot-derived fields fall back to their empties, event-derived ones stay.
+        phase3 = _phase3(RuleAction.ESCALATE, snapshot=None)
+        esc = phase3.recommendation_result.evidence.escalation
+        assert esc is not None
+        assert esc.session_event_count == 0
+        assert esc.recent_phase_window == ()
+        assert esc.event_id == "evt-42"
+        assert esc.classification_summary == _SUMMARY
+
+
+class TestNoEscalationForNonEscalateActions:
+    """#24 — EscalationContext is only ever built for ESCALATE / DENY."""
+
+    @pytest.mark.parametrize("action", [RuleAction.ALLOW, RuleAction.WARN, RuleAction.TRANSFORM])
+    def test_no_escalation_context(self, action):
+        rr = _phase3(action).recommendation_result
+        esc = rr.evidence.escalation if rr.evidence else None
+        assert esc is None
+
+    def test_warn_builds_evidence_but_no_escalation(self):
+        ev = _phase3(RuleAction.WARN).recommendation_result.evidence
+        assert ev is not None  # evidence IS emitted for WARN …
+        assert ev.escalation is None  # … but carries no escalation context
+
+    @pytest.mark.parametrize("action", [RuleAction.ALLOW, RuleAction.TRANSFORM])
+    def test_allow_and_transform_emit_no_evidence(self, action):
+        assert _phase3(action).recommendation_result.evidence is None
+
+
+class TestEvidenceConstruction:
+    """#25 — rule_id / matched_predicates promoted; payload_pointer populated."""
+
+    def test_rule_id_promoted_to_top_level(self):
+        ev = _phase3(RuleAction.DENY).recommendation_result.evidence
+        assert ev.rule_id == "deny-cred-destruction"
+        assert ev.pointers[0].rule_id == "deny-cred-destruction"
+
+    def test_matched_predicates_serialized(self):
+        ev = _phase3(RuleAction.DENY).recommendation_result.evidence
+        assert ev.matched_predicates == (
+            "mechanism == shell.execute",
+            "capability any_of [credential_exposure]",
+            "risk_score >= 0",
+        )
+
+    def test_payload_pointer_holds_triggering_values(self):
+        phase3 = _phase3(RuleAction.DENY)
+        pointer = phase3.recommendation_result.evidence.pointers[0].payload_pointer
+        assert pointer is not None
+        assert "capability=[credential_exposure]" in pointer
+        assert "mechanism=shell.execute" in pointer
+        assert f"risk_score={phase3.risk_assessment.score}" in pointer
+
+    def test_payload_pointer_applies_secret_sanitization(self):
+        # A classification label shaped like a secret assignment must be redacted,
+        # proving the pointer runs through the _sanitize_args discipline (non-vacuous).
+        cls = Classification(
+            mechanism=_MECHANISM,
+            effect="destructive",
+            capability=frozenset({"credential_exposure"}),
+            action=frozenset({"token=abcdef123"}),
+        )
+        rule = Rule(
+            id="r",
+            index=0,
+            when=(
+                Predicate(dim="action", operator="any_of", targets=("token=abcdef123",)),
+                Predicate(dim="capability", operator="any_of", targets=("credential_exposure",)),
+            ),
+            recommend=RuleAction.DENY,
+            reason="x",
+        )
+        assessor = DefaultAssessor(None, [rule], ClassificationEngine(ClassifyConfig()))
+        phase3 = assessor._phase3(_ctx(cls), _result(cls), _snapshot())
+        pointer = phase3.recommendation_result.evidence.pointers[0].payload_pointer
+        assert "abcdef123" not in pointer
+        assert "REDACTED" in pointer


### PR DESCRIPTION
Closes #24
Closes #25

Two tightly-coupled governance issues shipped together: they build in the same
assessor region and both round-trip through `governance/codec.py`.

## What the diff actually does

### #24 — EscalationContext enrichment
`results.py`: `EscalationContext` gains five fields (all with defaults, since it's a
frozen dataclass and this project has no released serialization to preserve):
`event_id`, `classification_summary`, `risk_factors`, `session_event_count`,
`recent_phase_window`.

`assessor.py` `_build_escalation` populates them:
- `event_id` ← `ctx.event.event_id`
- `classification_summary` ← `_summarize_classification(result.classification)` — a
  short deterministic string `mechanism[/effect] (caps=[..]; actions=[..]; scope=[..])`,
  dims sorted and empty dims omitted.
- `risk_factors` ← `risk.factors`
- `session_event_count` ← `snapshot.event_count if snapshot else 0`
- `recent_phase_window` ← `snapshot.phase_window if snapshot else ()`

The two snapshot-derived fields mirror the existing `snapshot.budget if snapshot else None`
defensiveness so a missing snapshot can't crash escalation building. `_build_escalation`
is still only reached for ESCALATE/DENY (guard unchanged).

### #25 — Evidence construction detail
`results.py`: `Evidence` gains `rule_id` and `matched_predicates` (both defaulted).

`assessor.py` evidence build (WARN/ESCALATE/DENY only):
- `rule_id` ← `rule_match.rule_id` (promoted to the top level; it was previously only on
  the `EvidencePointer`).
- `matched_predicates` ← `_serialize_predicates(rule_match.matched_predicates)`.
- `EvidencePointer.payload_pointer` (was defaulted `None`) ← `_serialize_triggering_values(...)`.

### codec.py
Every new field is added to **both** the serialize and deserialize sides
(`serialize_meta` evidence + escalation dicts; `deserialize_meta` / `deserialize_escalation`)
so `SessionMeta` → encode → decode is lossless. (`payload_pointer` already round-tripped;
its value is now non-`None`.)

## `matched_predicates` — source & justification
Source is `rules.RuleMatch.matched_predicates`. A `RuleMatch` is produced by
`evaluate_rules` only when **every** predicate in `rule.when` evaluates true against the
event's classification/risk, so `matched_predicates` is exactly the set of rule
requirements that fired for this event — the honest answer to "which predicates matched".
Each `Predicate` is rendered deterministically by `_format_predicate`:
`risk_score` → `"risk_score >= 92"`; equality → `"mechanism == shell.execute"`; set ops →
`"capability any_of [credential_exposure]"` (targets sorted). Serialized as a `tuple[str,...]`.

## `payload_pointer` — serialization design & justification
Compact, deterministic `dim=value; ...` string (keys sorted) built by
`_serialize_triggering_values`, then passed through the same `_sanitize_args`
secret-redaction discipline used elsewhere in the assessor.

The rule engine matches on **classification dimensions + risk score**, not on raw event
args, so "the actual data that caused the match" is the concrete classification value each
matched predicate evaluated (e.g. `mechanism=shell.execute`, `capability=[credential_exposure]`)
plus the concrete score for any `risk_score` predicate (e.g. `risk_score=92`). Set-valued
dims render as sorted `[a,b]`. Those tokens are inherently safe classification labels;
running them through `_sanitize_args` is defense-in-depth (e.g. a hypothetical
`token=...` label would be redacted). This keeps the pointer small, stable across runs,
and free of unsanitized payload data.

## Tests
- `tests/unit/test_governance_escalation_evidence.py` (new): drives
  `DefaultAssessor._phase3` directly — DENY populates all five escalation fields; escalate
  path guards a missing snapshot; ALLOW/WARN/TRANSFORM build **no** EscalationContext
  (WARN still builds Evidence with `escalation=None`; ALLOW/TRANSFORM build no Evidence);
  `rule_id` promotion, `matched_predicates` serialization, `payload_pointer` triggering
  values, and `payload_pointer` sanitization.
- `tests/unit/test_governance_codec.py`: a fully-populated `Evidence`+`EscalationContext`
  round-trips and every new field survives encode → decode intact.

## Validation
- Full suite: **2221 passed, 4 skipped** (baseline on this main was 2208 passed / 4 skipped;
  +13 new tests, zero regressions).
- Lint: `ruff check` clean; `ruff format --check` — all files already formatted (ruff 0.15.20).
- Non-vacuity proven per field: temporarily breaking each field's population or its codec
  serialize line makes the specific guarding test FAIL; restoring makes it PASS. Verified for
  all five #24 fields, both #25 Evidence fields, `payload_pointer`, and each field's codec
  round-trip (16 breakage checks, all non-vacuous).

Left **unmerged** for coordinator verify + merge.