### PR TITLE
Route lifecycle events through idempotency store; wire Phase 1 motivation (#10)

### DIFF
--- a/src/tracemill/governance/monitor.py
+++ b/src/tracemill/governance/monitor.py
@@ -112,18 +112,62 @@ class SessionMonitor:
         return self._registry.get_or_create(session_id)
 
     def process_lifecycle(self, session_id: str, event_kind: str) -> SessionMeta:
-        """Handle session_start/end — Phase 1 only, skip Phase 2/3."""
+        """Handle session_start/end — Phase 1 only, skip Phase 2/3.
 
-        state = self.get_or_create_state(session_id)
+        Lifecycle deliveries are idempotent. Each ``(session_id, event_kind)`` is
+        recorded in the ``processed_events`` store under its lifecycle idempotency
+        key, and a re-delivery short-circuits to a true no-op that never touches
+        session state. This closes the session_end resurrection bug: without the
+        dedup guard a duplicate session_end would call ``get_or_create_state``,
+        rehydrating the just-evicted session back into the durable registry, and
+        re-run finalization against that rehydrated state. For session_end the
+        summary write and the idempotency record commit inside a single
+        ``write_transaction`` so they are atomic — the event is marked processed
+        only if its summary durably landed.
+        """
+        from tracemill.governance.state import BudgetSnapshot
+        from tracemill.governance.types import compute_source_event_key
 
-        if event_kind == "session_start":
-            # Initialize state (idempotent — load_from_db handles fresh sessions)
-            pass
-        elif event_kind == "session_end":
-            # Finalize: write session summary
+        # Reuse the canonical lifecycle key so retries with different adapter
+        # timestamps map to the same start/end event.
+        lifecycle_key = compute_source_event_key(session_id=session_id, event_kind=event_kind)
+
+        # A re-delivered lifecycle event is a true no-op: return without touching
+        # state, so an ended session is never resurrected into the registry.
+        if self._store.is_duplicate(lifecycle_key) is not None:
+            return self._lifecycle_meta(BudgetSnapshot())
+
+        marker_json = json.dumps({"lifecycle": event_kind})
+        now = datetime.now(timezone.utc).isoformat()
+
+        if event_kind == "session_end":
+            state = self.get_or_create_state(session_id)
             snapshot = state.snapshot()
-            self._write_session_summary(session_id, snapshot)
-            # Evict session state to prevent unbounded memory growth. Both
+            try:
+                # Summary write + idempotency record commit atomically: the event is
+                # marked processed only if its finalized summary durably landed.
+                with self._store.write_transaction():
+                    self._write_session_summary_no_commit(session_id, snapshot, now)
+                    self._store.execute_in_transaction(
+                        "INSERT OR IGNORE INTO processed_events "
+                        "(source_event_key, session_id, session_meta_json, processed_at) "
+                        "VALUES (?, ?, ?, ?)",
+                        (lifecycle_key, session_id, marker_json, now),
+                    )
+                self._store.cache_processed(lifecycle_key, marker_json)
+            except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "Failed to finalize session_end for %s: %s — will retry on next delivery",
+                    session_id,
+                    e,
+                )
+                # Rolled back and NOT marked processed: leave the state resident so a
+                # re-delivery re-runs finalization.
+                return self._lifecycle_meta(snapshot.budget)
+
+            # Evict only after the summary + idempotency record durably commit. Both
             # residencies (durable + gate) are dropped on session end.
             self._registry.evict(session_id)
             self._registry.evict_gate(session_id)
@@ -131,13 +175,40 @@ class SessionMonitor:
             # Clean up any lingering phase23 attempts for this session's events
             for key in self._phase23_session_keys.pop(session_id, set()):
                 self._phase23_attempts.pop(key, None)
+            return self._lifecycle_meta(snapshot.budget)
 
+        # session_start (and any other non-end lifecycle kind): no finalization side
+        # effects today, but record the delivery so the idempotency contract is
+        # uniform and a duplicate is recognized as a no-op without resurrecting state.
+        state = self.get_or_create_state(session_id)
         snapshot = state.snapshot()
+        try:
+            with self._store.write_transaction():
+                self._store.execute_in_transaction(
+                    "INSERT OR IGNORE INTO processed_events "
+                    "(source_event_key, session_id, session_meta_json, processed_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (lifecycle_key, session_id, marker_json, now),
+                )
+            self._store.cache_processed(lifecycle_key, marker_json)
+        except (sqlite3.OperationalError, sqlite3.IntegrityError) as e:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Failed to record %s for %s: %s — will retry on next delivery",
+                event_kind,
+                session_id,
+                e,
+            )
+        return self._lifecycle_meta(snapshot.budget)
+
+    def _lifecycle_meta(self, budget: "BudgetSnapshot") -> SessionMeta:
+        """Build the minimal Phase-1-only SessionMeta returned for lifecycle events."""
         return SessionMeta(
             classification=None,
             risk_assessment=None,
             recommendation=None,
-            budget_snapshot=snapshot.budget,
+            budget_snapshot=budget,
             drift=None,
             mcp_alerts=(),
             evidence=None,
@@ -430,12 +501,19 @@ class SessionMonitor:
                 write.timestamp,
             )
 
-    def _write_session_summary(self, session_id: str, snapshot: "SessionStateSnapshot") -> None:
-        """Write session summary to session_summaries table (idempotent — won't overwrite existing)."""
-        import json as json_mod
-        import logging
+    def _write_session_summary_no_commit(
+        self, session_id: str, snapshot: "SessionStateSnapshot", now: str
+    ) -> None:
+        """Write the session summary row on the caller's OPEN transaction (no commit).
 
-        now = datetime.now(timezone.utc).isoformat()
+        ``INSERT OR IGNORE`` keeps the first delivery authoritative: the started/
+        ended timestamps, event counts, and budget snapshot are recorded once, and a
+        duplicate delivery is a no-op at the SQL level. The caller owns the
+        surrounding ``write_transaction`` so the summary commits atomically with the
+        lifecycle idempotency record.
+        """
+        import json as json_mod
+
         budget_snapshot_json = json_mod.dumps(
             {
                 "total_tool_calls": snapshot.budget.total_tool_calls,
@@ -443,26 +521,19 @@ class SessionMonitor:
                 "pressure": snapshot.budget.pressure,
             }
         )
-        try:
-            # INSERT OR IGNORE: first delivery records started_at/ended_at; duplicates are no-ops.
-            # Routed through write_transaction so the commit is serialized on the
-            # shared connection (single writer) rather than racing another writer's
-            # open transaction with a bare connection.commit().
-            with self._store.write_transaction():
-                self._store.execute_in_transaction(
-                    """INSERT OR IGNORE INTO session_summaries
-                       (session_id, started_at, ended_at, total_events, dropped_events, budget_snapshot_json)
-                       VALUES (?, ?, ?, ?, ?, ?)""",
-                    (
-                        session_id,
-                        now,
-                        now,
-                        snapshot.event_count,
-                        snapshot.dropped_events,
-                        budget_snapshot_json,
-                    ),
-                )
-        except sqlite3.OperationalError as e:
-            logging.getLogger(__name__).warning(
-                "Failed to write session summary for %s: %s", session_id, e
-            )
+        # INSERT OR IGNORE: first delivery records started_at/ended_at; duplicates
+        # are no-ops. The caller's write_transaction serializes the commit on the
+        # shared connection (single writer).
+        self._store.execute_in_transaction(
+            """INSERT OR IGNORE INTO session_summaries
+               (session_id, started_at, ended_at, total_events, dropped_events, budget_snapshot_json)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                now,
+                now,
+                snapshot.event_count,
+                snapshot.dropped_events,
+                budget_snapshot_json,
+            ),
+        )

--- a/src/tracemill/governance/phase1.py
+++ b/src/tracemill/governance/phase1.py
@@ -67,3 +67,11 @@ class Phase1:
             self._labeler.check_ifc(ctx, ifc_src_labels, state)
         state.record_event(None)
         self._budget.check_pressure(state)
+        # Motivation tracking (#10): record the id of the last assistant-authored
+        # governed event. Every event that reaches Phase 1 is an assistant-initiated
+        # tool call — session lifecycle is handled by process_lifecycle, and user/
+        # assistant *messages* are ungoverned at the observe choke point and never
+        # reach here — so the tool call's own event id is the assistant motivation
+        # pointer. There is no user-authored event in the tool-call observation path,
+        # so the user pointer is intentionally left unset (no phantom id).
+        state.set_last_assistant(ctx.event.event_id)

--- a/tests/unit/test_governance_phase1_pipeline.py
+++ b/tests/unit/test_governance_phase1_pipeline.py
@@ -1,0 +1,252 @@
+"""Tests for issue #10 — governance Phase 1 pipeline.
+
+Covers the four #10 checklist behaviours:
+  1. lifecycle events are routed through the processed_events idempotency store so
+     a duplicate delivery (notably session_end) is a true no-op;
+  2. Phase 1 populates the last-assistant motivation pointer, which persists and
+     recovers;
+  3. MCP ``last_seen`` is committed only after pipeline finalization, never eagerly;
+  4. a state snapshot is an immutable point-in-time view unaffected by later
+     mutations.
+"""
+
+import hashlib
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+from tracemill.classify.config import ClassificationEngine, ClassifyConfig
+from tracemill.classify.core import Classification
+from tracemill.governance.budget import BudgetThresholds, BudgetTracker
+from tracemill.governance.labeler import GovernanceLabeler
+from tracemill.governance.mcp_drift import MCPIntegrityScanner
+from tracemill.governance.persistence import SystemStore
+from tracemill.governance.pipeline import GovernancePipeline
+from tracemill.governance.state import SessionState
+from tracemill.governance.types import EnrichmentContext, ToolCallEvent
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = SystemStore(tmp_path / "phase1.db")
+    yield s
+    s.close()
+
+
+def _make_pipeline(store, *, mcp=False):
+    engine = ClassificationEngine(ClassifyConfig())
+    mcp_scanner = MCPIntegrityScanner(store) if mcp else None
+    labeler = GovernanceLabeler(mcp_scanner=mcp_scanner)
+    tracker = BudgetTracker(BudgetThresholds())
+    return GovernancePipeline(
+        store=store, labeler=labeler, budget_tracker=tracker, rules=[], engine=engine
+    )
+
+
+def _tool_ctx(session_id="s1", event_id="evt-1", source_event_key="key-1", tool_name="bash"):
+    event = ToolCallEvent(
+        event_id=event_id,
+        session_id=session_id,
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        source_event_key=source_event_key,
+        span_id="span-1",
+        tool_name=tool_name,
+        server_namespace=None,
+        tool_args_json='{"command": "ls"}',
+        source_event_id=None,
+    )
+    classification = Classification(mechanism="shell.execute", effect="read_only")
+    return EnrichmentContext(
+        event=event,
+        base_classification=classification,
+        command_analysis=None,
+        session_state=None,
+        mcp_profiles=None,
+        project_root=None,
+        engine="shell",
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+def _mcp_ctx(
+    session_id="s1",
+    event_id="e1",
+    source_event_key="k1",
+    server="mcp-fs",
+    tool_name="read_file",
+    desc="Read a file",
+    schema="{}",
+):
+    event = ToolCallEvent(
+        event_id=event_id,
+        session_id=session_id,
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        source_event_key=source_event_key,
+        span_id="sp1",
+        tool_name=tool_name,
+        server_namespace=server,
+        tool_args_json="{}",
+        source_event_id=None,
+        mcp_server_name=server,
+        tool_description=desc,
+        tool_schema_json=schema,
+    )
+    return EnrichmentContext(
+        event=event,
+        base_classification=Classification(mechanism="mcp.tool_call"),
+        command_analysis=None,
+        session_state=None,
+        mcp_profiles=None,
+        project_root=None,
+        engine="mcp",
+        drift_baseline=None,
+        mcp_profile_key=f"{server}:{tool_name}",
+    )
+
+
+# ─── Item 1 + 4a: lifecycle idempotency ───
+
+
+class TestLifecycleIdempotency:
+    def test_session_end_records_lifecycle_key(self, store):
+        pipeline = _make_pipeline(store)
+        pipeline.process_event(_tool_ctx())
+        pipeline.process_lifecycle("s1", "session_end")
+        # The lifecycle delivery is durably recorded under its canonical key.
+        assert store.is_duplicate("lifecycle:s1:session_end") is not None
+
+    def test_duplicate_session_end_is_true_noop(self, store):
+        pipeline = _make_pipeline(store)
+        pipeline.process_event(_tool_ctx())  # build non-empty, persisted state
+        monitor = pipeline._monitor
+        with mock.patch.object(
+            monitor,
+            "_write_session_summary_no_commit",
+            wraps=monitor._write_session_summary_no_commit,
+        ) as spy:
+            pipeline.process_lifecycle("s1", "session_end")  # finalizes once
+            pipeline.process_lifecycle("s1", "session_end")  # duplicate → short-circuits
+        # Without the dedup guard the second delivery would rehydrate the evicted
+        # state and re-run finalization; with it, finalization runs exactly once.
+        assert spy.call_count == 1
+
+    def test_duplicate_session_end_does_not_overwrite_summary(self, store):
+        pipeline = _make_pipeline(store)
+        pipeline.process_event(_tool_ctx())
+        pipeline.process_lifecycle("s1", "session_end")
+        before = store.connection.execute(
+            "SELECT total_events, budget_snapshot_json FROM session_summaries "
+            "WHERE session_id = 's1'"
+        ).fetchone()
+
+        pipeline.process_lifecycle("s1", "session_end")  # duplicate delivery
+        count = store.connection.execute(
+            "SELECT COUNT(*) FROM session_summaries WHERE session_id = 's1'"
+        ).fetchone()[0]
+        after = store.connection.execute(
+            "SELECT total_events, budget_snapshot_json FROM session_summaries "
+            "WHERE session_id = 's1'"
+        ).fetchone()
+
+        assert count == 1
+        assert before == after  # the good summary is never overwritten
+
+    def test_duplicate_session_start_is_noop(self, store):
+        pipeline = _make_pipeline(store)
+        pipeline.process_lifecycle("s1", "session_start")
+        assert store.is_duplicate("lifecycle:s1:session_start") is not None
+        # A re-delivered session_start is a harmless no-op.
+        meta = pipeline.process_lifecycle("s1", "session_start")
+        assert meta.classification is None
+
+
+# ─── Item 2: motivation tracking (last assistant/user event ids) ───
+
+
+class TestMotivationTracking:
+    def test_phase1_populates_last_assistant_on_writer_path(self, store):
+        pipeline = _make_pipeline(store)
+        pipeline.process_event(_tool_ctx(event_id="evt-abc"))
+        snap = pipeline.get_or_create_state("s1").snapshot()
+        assert snap.last_assistant_event_id == "evt-abc"
+        # No user-authored event reaches Phase 1, so the user pointer stays unset.
+        assert snap.last_user_event_id is None
+
+    def test_last_assistant_persists_and_recovers(self, tmp_path):
+        db = tmp_path / "recover.db"
+        store = SystemStore(db)
+        pipeline = _make_pipeline(store)
+        pipeline.process_event(_tool_ctx(event_id="evt-persist"))
+        store.close()
+
+        # A fresh store over the same file rehydrates state from SQLite.
+        store2 = SystemStore(db)
+        try:
+            pipeline2 = _make_pipeline(store2)
+            recovered = pipeline2.get_or_create_state("s1").snapshot()
+            assert recovered.last_assistant_event_id == "evt-persist"
+        finally:
+            store2.close()
+
+
+# ─── Item 3: MCP last_seen finalization timing (code already exists) ───
+
+
+class TestMCPLastSeenFinalization:
+    def test_last_seen_committed_only_after_finalization(self, store):
+        pipeline = _make_pipeline(store, mcp=True)
+        desc, schema = "Read a file", "{}"
+        old = "2000-01-01T00:00:00+00:00"
+        # Seed an EXISTING profile (matching fingerprints, clearly-old last_seen) so
+        # a scan yields a `last_seen` deferred write, not a first-seen registration.
+        store.upsert_mcp_profile(
+            "mcp-fs",
+            "read_file",
+            {
+                "description_hash": hashlib.sha256(desc.encode()).hexdigest(),
+                "schema_hash": hashlib.sha256(schema.encode()).hexdigest(),
+                "registered_effect": None,
+                "clearance": None,
+                "first_seen": old,
+                "last_seen": old,
+                "role": [],
+                "capability": [],
+                "scope": [],
+            },
+        )
+        ctx = _mcp_ctx(source_event_key="k-mcp-1", desc=desc, schema=schema)
+
+        # Not eager: assess() returns a last_seen deferred write but writes nothing.
+        assessment = pipeline._assessor.assess(ctx, SessionState(session_id="s1").snapshot())
+        assert "last_seen" in [w.kind for w in assessment.mcp_deferred_writes]
+        assert store.get_mcp_profile("mcp-fs", "read_file")["last_seen"] == old
+
+        # Committed at finalization: process_event flushes the deferred write.
+        pipeline.process_event(ctx)
+        assert store.get_mcp_profile("mcp-fs", "read_file")["last_seen"] != old
+
+
+# ─── Item 4b: snapshot immutability ───
+
+
+class TestSnapshotImmutability:
+    def test_snapshot_unaffected_by_later_mutations(self):
+        state = SessionState(session_id="s1")
+        state.set_last_assistant("evt-early")
+        state.record_event(None)
+        snap = state.snapshot()
+
+        # Mutate the state AFTER the snapshot was taken.
+        state.set_last_assistant("evt-late")
+        state.set_last_user("user-late")
+        state.record_event(None)
+
+        # The earlier snapshot is a frozen point-in-time view — unchanged.
+        assert snap.last_assistant_event_id == "evt-early"
+        assert snap.last_user_event_id is None
+        assert snap.event_count == 1
+        # The live state, meanwhile, has advanced.
+        assert state.snapshot().event_count == 2
+        assert state.snapshot().last_assistant_event_id == "evt-late"


### PR DESCRIPTION
Closes #10

Phase 1 pipeline hardening for issue #10. Three source-touching files: `governance/monitor.py`, `governance/phase1.py`, and one new test module. Rebased onto current `main` (on top of #71); the diff is disjoint from that PR's files.

## Item 1 — lifecycle events routed through the idempotency store (`monitor.py`)
`process_lifecycle` previously never touched `processed_events`, so a re-delivered `session_end` called `get_or_create_state` (rehydrating the just-evicted session back into the durable registry) and re-ran finalization.

- Dedup key: I reuse the canonical `compute_source_event_key(session_id=…, event_kind=…)` → `lifecycle:<sid>:<kind>` rather than inventing a new `__lifecycle__:` string. That helper already exists as the single source of truth for lifecycle keys, and lifecycle keys are owned exclusively by `process_lifecycle` (lifecycle events never reach `process_event`), so there's no collision risk.
- A re-delivered lifecycle event now short-circuits at the top via `is_duplicate(...)` and returns a minimal `SessionMeta` (empty `BudgetSnapshot`) **without touching state** — a true no-op, no resurrection.
- For `session_end`, the summary write and the `processed_events` record now commit inside **one** `write_transaction` (atomic: the event is marked processed only if its summary durably landed). Eviction happens only after that commit; on rollback the state stays resident so a re-delivery re-runs finalization.
- `_write_session_summary` is refactored into `_write_session_summary_no_commit(session_id, snapshot, now)` so it shares the finalization transaction (its only caller was `process_lifecycle`).
- **`session_start` decision:** I *did* dedup it (record its lifecycle key) for a uniform idempotency contract, even though `session_start` is otherwise a no-op today. It's cheap and defensive; if start ever gains side effects the contract already holds.

**Honest finding:** the summary SQL was already `INSERT OR IGNORE`, so a duplicate `session_end` never actually *overwrote* the good summary (the "overwrite" framing in the issue doesn't manifest with `INSERT OR IGNORE`). The real value of the fix is making the duplicate a **true no-op** — no state resurrection, no redundant finalization. The teeth test asserts finalization runs exactly once, not merely that the row is unchanged.

## Item 2 — Phase 1 motivation tracking (`phase1.py`)
`state.set_last_assistant` / `set_last_user` existed with full persist/recover but had **zero callers**. `Phase1.apply` now calls `state.set_last_assistant(ctx.event.event_id)`.

- Every event that reaches Phase 1 is an assistant-initiated tool call (lifecycle goes through `process_lifecycle`; user/assistant *messages* are ungoverned at the observe choke point and never reach Phase 1), so the tool call's own id is the assistant pointer.
- The **user pointer is intentionally left unset** in this path — there is no user-authored event in the tool-call observation flow, and fabricating one would be phantom data. Documented inline.
- `Phase1.apply` runs on both the real writer state and the scorer's transient clone; setting on the transient is harmless (discarded). The test asserts on the real writer path.

## Item 3 — MCP `last_seen` finalization timing (test only)
The deferred-write path already existed (`mcp_drift` emits a `last_seen` `_DeferredWrite`; the monitor commits it via `write_mcp_last_seen_no_commit` inside the finalization `write_transaction`). **No code change.** Added a test proving `assess()` returns the deferred write but does **not** mutate the stored profile, and only `process_event` finalization commits the new `last_seen`.

## Item 4 — tests (`tests/unit/test_governance_phase1_pipeline.py`, 8 tests)
- lifecycle key recorded on `session_end`; duplicate `session_end` is a true no-op (finalization runs once); summary not overwritten; duplicate `session_start` no-op;
- motivation populate on the writer path (+ user pointer stays `None`) and persist→recover across a fresh store;
- MCP `last_seen` committed only at finalization;
- snapshot immutability (mutate state after `snapshot()`; earlier snapshot object unchanged).

## Validation
- Full suite: **2216 passed, 4 skipped** on the rebased base (adds 8 tests, zero regressions).
- Lint: `ruff check` clean; `ruff format --check` clean.
- **Non-vacuity proofs:** removing the lifecycle dedup guard → `test_duplicate_session_end_is_true_noop` fails (`call_count == 2`); removing the `set_last_assistant` call → both motivation tests fail (`None != 'evt-…'`). Both restored → green.

Leaving this **unmerged** for coordinator verification.