### PR TITLE
ci: add unified PyPI release workflow (trusted publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+# Build and publish TraceForge's two distributable packages to PyPI using PyPI
+# Trusted Publishing (OIDC) -- no long-lived API token is stored in repo secrets.
+#
+#   * traceforge              -- the root library (src/traceforge)
+#   * traceforge-title-model  -- the pretrained int8 ONNX titler weights
+#                                (packages/traceforge-title-model)
+#
+# The research package (traceforge_research) is intentionally NOT a PyPI artifact
+# and is never published here.
+#
+# A single `v*` tag (e.g. v1.2.3) releases BOTH packages via the matrix below.
+# Their versions bump independently, so `skip-existing: true` lets a tag
+# re-publish only the package whose version actually changed and tolerates the
+# unchanged one already being on PyPI.
+#
+# Reviewer note: this repo currently also ships publish.yml (traceforge on `v*`)
+# and publish-title-model.yml (title-model on `title-model-v*`). release.yml is
+# the unified single-tag alternative -- see the PR description for the overlap
+# decision that needs to be made before this is merged.
+
+on:
+  push:
+    tags: ["v*"]        # release tag, e.g. v1.2.3
+  workflow_dispatch: {} # manual run (targets production PyPI)
+
+jobs:
+  release:
+    name: Build & publish ${{ matrix.package.name }}
+    runs-on: ubuntu-latest
+
+    # One matrix leg per distributable package. fail-fast is off so a failure
+    # (or a skip) on one package never cancels the other -- they carry separate
+    # versions and release independently.
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: traceforge
+            dir: "."
+            # The model2vec potion-base-8M embedder weights ride in the root wheel.
+            weight_suffix: ".safetensors"
+          - name: traceforge-title-model
+            dir: "packages/traceforge-title-model"
+            # The int8 ONNX encoder/decoder titler weights ship in this package.
+            weight_suffix: ".onnx"
+
+    # Trusted Publishing mints a short-lived OIDC token instead of using a stored
+    # API token. The `pypi` environment is the trust anchor registered on both
+    # PyPI projects (and can double as a manual release-approval gate).
+    environment: pypi
+    permissions:
+      id-token: write   # required: mint the OIDC token PyPI verifies (no secret)
+      contents: read    # required: checkout only
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Model weights (*.onnx, *.safetensors) are tracked via Git LFS. Without
+          # lfs: true the working tree holds ~133-byte pointer files and the build
+          # would silently ship broken packages. The verify step below is the
+          # backstop that fails loudly if a pointer ever sneaks through.
+          lfs: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Build ${{ matrix.package.name }} (sdist + wheel)
+        run: uv build "${{ matrix.package.dir }}" --out-dir dist
+
+      - name: Verify weights are real binaries (not Git LFS pointers)
+        run: python scripts/verify_no_lfs_pointers.py dist --require ${{ matrix.package.weight_suffix }}
+
+      - name: Publish ${{ matrix.package.name }} to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          # A `v*` tag triggers both matrix legs, but usually only one package's
+          # version changed. skip-existing lets the unchanged package's already
+          # published version be skipped instead of failing the run.
+          skip-existing: true


### PR DESCRIPTION
## What this adds

A single new workflow, `.github/workflows/release.yml`, that builds and publishes **both** distributable packages to PyPI using **Trusted Publishing (OIDC)** — no long-lived API token in secrets.

| Package | Location | Ships |
|---|---|---|
| `traceforge` | repo root (`src/traceforge`) | phase/boundary `.joblib` heads + `potion-base-8M/model.safetensors` embedder |
| `traceforge-title-model` | `packages/traceforge-title-model` | int8 ONNX titler weights (`encoder.onnx`, `decoder.onnx`, `tokenizer.json`) |

The `research/` package (`traceforge_research`) is **not** published.

### Design
- **Triggers:** push tags matching `v*` (e.g. `v1.2.3`) **and** `workflow_dispatch` (manual, production PyPI).
- **Matrix over the two packages** (`fail-fast: false`) — each leg checks out (with `lfs: true`), sets up Python 3.13 + uv, runs `uv build <dir> --out-dir dist`, then publishes.
- **Publish:** `pypa/gh-action-pypi-publish@release/v1` with Trusted Publishing (no password/token), `packages-dir: dist`, and **`skip-existing: true`** so one `v*` tag releases both packages and tolerates the unchanged one already on PyPI.
- **Per job:** `permissions: { id-token: write, contents: read }` and `environment: pypi`.
- **LFS guard:** reuses the repo's `scripts/verify_no_lfs_pointers.py` (`--require .safetensors` for root, `--require .onnx` for the title model) so a checkout that ever drops `lfs: true` fails loudly instead of shipping ~133-byte pointer files.
- Action pins match the existing workflows: `actions/checkout@v6`, `actions/setup-python@v6`, `astral-sh/setup-uv@v7`, `pypa/gh-action-pypi-publish@release/v1`.

TestPyPI toggle was intentionally omitted (production PyPI is the requirement; keeps the workflow clean).

---

## ⚠️ Overlap with existing workflows — decision needed before merge

This repo **already** contains two publish workflows that this branch does **not** modify:

- **`publish.yml`** — publishes `traceforge` on `v*` tags (trusted publishing, no `skip-existing`).
- **`publish-title-model.yml`** — publishes `traceforge-title-model` on `title-model-v*` tags (trusted publishing + GitHub-release wheel mirror).

Those implement a **decoupled two-tag** strategy; `release.yml` implements a **unified single-`v*`-tag** strategy. They collide on the `v*` trigger: a `v*` push would fire **both** `publish.yml` and `release.yml` for `traceforge`, and since `publish.yml` has no `skip-existing`, one of the two runs can fail on a re-publish/race.

**Recommendation:** if you adopt `release.yml`, delete `publish.yml` and `publish-title-model.yml` (I left them untouched per task scope). If you prefer the existing decoupled workflows, this PR can simply be closed. Flagging so the choice is explicit — the task brief did not mention these pre-existing files.

---

## Local build verification (Definition of Done)

`uv build` run locally for both packages — real weights confirmed bundled (not LFS pointers); `verify_no_lfs_pointers.py` passes for each:

**`traceforge` 0.1.0**
- `traceforge-0.1.0-py3-none-any.whl` (28.8 MB), `traceforge-0.1.0.tar.gz` (28.7 MB)
- bundles `phase/data/phase-model.joblib`, `boundary/data/boundary-model.joblib`, `phase/data/potion-base-8M/model.safetensors` (30,236,760 B, real) + classify YAMLs

**`traceforge-title-model` 0.2.0**
- `traceforge_title_model-0.2.0-py3-none-any.whl` (68.5 MB), `traceforge_title_model-0.2.0.tar.gz` (68.5 MB)
- bundles `data/span/encoder.onnx` (35,628,332 B), `data/span/decoder.onnx` (58,627,575 B), `data/span/tokenizer.json` — all real binaries

> **Note / correction to the brief:** the title-model ships **`.onnx`** weights, not `.joblib`. The `.joblib` files (phase + boundary heads) live in the **root `traceforge`** package. The workflow's LFS guard is set accordingly (`.onnx` for the title model, `.safetensors` for root).

`actionlint` (v1.7.12) passes clean on the new file. No changes to `src/`, `tests/`, versions, or existing workflows — only `release.yml` is added.

---

## Manual setup to do before the first release

1. **PyPI Trusted Publishers** — add one for **both** projects `traceforge` and `traceforge-title-model` (use PyPI's *pending publisher* flow for a project that doesn't exist yet): Owner `dfinson`, Repository `traceforge`, Workflow name `release.yml`, Environment name `pypi`.
2. **GitHub Environment** — create an environment named `pypi` in repo Settings → Environments (optionally add required reviewers as a release gate).
3. **Names** — ensure the PyPI project names `traceforge` and `traceforge-title-model` are available/owned by you.
4. **Cut a release** — bump the version(s) in the relevant `pyproject.toml`, commit, then `git tag vX.Y.Z && git push origin vX.Y.Z`. The workflow builds and publishes both packages; `skip-existing` skips whichever version is already on PyPI.

Leaving this **unmerged** for review (branch protection requires an approving review).