### PR TITLE
Add shared E2E test harness, fake network backends, and markers (#79)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,15 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 # Vendored demo repos (tests/fixtures/demo_repos/) carry their own test suites and
 # third-party deps (fastapi, etc.) and must not be collected by traceforge's suite.
-addopts = "--ignore=tests/fixtures/demo_repos"
+# --strict-markers turns any unregistered marker into an error, so the marker list
+# below is the single source of truth (typos fail fast instead of silently no-op'ing).
+addopts = "--strict-markers --ignore=tests/fixtures/demo_repos"
+markers = [
+    "e2e: end-to-end test that drives real I/O (subprocess CLI, live sources/sinks, gate IPC).",
+    "slow: test that spawns a subprocess or otherwise runs longer than a unit test.",
+    "net: test that uses a local loopback fake network server (never an external host).",
+    "windows_only: test that only applies on Windows; auto-skipped elsewhere.",
+]
 
 [tool.ruff]
 target-version = "py311"
@@ -131,6 +139,9 @@ dev = [
     "datamodel-code-generator>=0.63.0",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.4.0",
+    "pytest-cov>=5.0",
+    "boto3>=1.28",
+    "moto[s3]>=5.0",
     "crewai>=0.80",
     "langchain-core>=0.3",
     "langgraph>=0.2",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,97 @@
+# TraceForge test suite
+
+Fast unit tests live directly under `tests/`. The **end-to-end (e2e) harness**
+lives under `tests/e2e/` and drives real I/O — subprocess CLI invocations, live
+source/sink classes, the gate IPC registry, and loopback fake network servers.
+
+## Running tests
+
+All commands use [`uv`](https://docs.astral.sh/uv/); the dev dependency group is
+installed with `uv sync --group dev`.
+
+```console
+# Everything (unit + e2e), the same set CI runs:
+uv run --no-progress python -m pytest -q -p no:cacheprovider
+
+# Only the e2e harness:
+uv run --no-progress python -m pytest -q -m e2e
+
+# Skip the slow subprocess-spawning tests:
+uv run --no-progress python -m pytest -q -m "not slow"
+
+# Just the loopback-network sink/source tests:
+uv run --no-progress python -m pytest -q -m net
+```
+
+`--strict-markers` is enabled, so every marker must be declared in
+`pyproject.toml` (`[tool.pytest.ini_options] markers`). A typo'd marker fails
+collection instead of silently doing nothing.
+
+### Markers
+
+| Marker         | Meaning                                                                              |
+| -------------- | ------------------------------------------------------------------------------------ |
+| `e2e`          | End-to-end test that drives real I/O (subprocess CLI, live sources/sinks, gate IPC). |
+| `slow`         | Spawns a `python -m traceforge` subprocess or otherwise runs longer than a unit test.|
+| `net`          | Uses a local **loopback** fake network server — never an external host.              |
+| `windows_only` | Only applies on Windows (e.g. the gate's TCP transport); auto-skipped elsewhere.     |
+
+`windows_only` tests are skipped automatically on non-Windows platforms (see the
+`pytest_collection_modifyitems` hook in `tests/conftest.py`), so the Linux CI
+matrix skips them by design.
+
+## Coverage
+
+`pytest-cov` is in the dev group, so coverage is runnable locally and in CI. There
+is intentionally **no `--cov-fail-under` gate** yet:
+
+```console
+uv run --no-progress python -m pytest -q --cov=traceforge --cov-report=term-missing
+```
+
+## The e2e harness (`tests/e2e/`)
+
+`tests/e2e/conftest.py` provides the shared fixtures; `tests/e2e/fakes/` provides
+the reusable fake network backends. `tests/e2e/test_harness_smoke.py` is the
+canary — one `@pytest.mark.e2e` test per fixture, each exercising the fixture
+through the **real** consumer class it exists to serve.
+
+### Fixtures (`tests/e2e/conftest.py`)
+
+| Fixture              | What it gives you                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `tmp_traceforge_home`| An isolated `$HOME`/`%USERPROFILE%` so anything reading `~/.traceforge` is sandboxed. Subprocesses inherit it.       |
+| `score_server_url`   | Spawns `traceforge score` on a free loopback port, polls `GET /health`, yields the base URL.                         |
+| `watch_daemon`       | Spawns `traceforge watch --frameworks claude --no-score` against an isolated home; waits for the `_default` gate session. Yields a `WatchDaemon` handle (`.home`, `.source_dir`, `.system_db`, `.output_db`, `.is_running()`, `.output`). |
+| `gate_socket_lookup` | Callable `(session_id) -> sock_path \| None` reading the `gate_endpoints` table in the sandboxed `system.db`.        |
+
+### Fake network backends (`tests/e2e/fakes/`)
+
+All bind `127.0.0.1:0` (an ephemeral loopback port) and run in a daemon thread —
+**loopback only, never an external host** (hence the `net` marker on tests that
+use them). Each is exposed both as a fixture and as an importable class.
+
+| Fixture           | Class / helper       | Serves                                                                                                  |
+| ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------ |
+| `http_poll_server`| `HttpPollServer`     | Mutable body behind an `ETag`; conditional GETs (`If-None-Match`) get `304`. For `HttpPollSource`.      |
+| `sse_server`      | `SSEServer`          | `text/event-stream` with `id`/`event`/`retry`; `close_current()` forces a `Last-Event-ID` reconnect. For `SSESource`. |
+| `otel_collector`  | `RecordingServer`    | Records OTLP/HTTP POSTs; `.endpoint` (`…/v1/traces`), `.spans()`. For `OtelExporterSink`.               |
+| `webhook_receiver`| `RecordingServer`    | Records POSTs; `.fail_next(n)`/`.set_status()` to exercise retries. For `WebhookSink`.                  |
+| `fake_s3`         | `fake_s3()` / `FakeS3`| A [moto](https://github.com/getmoto/moto)-backed in-memory S3 bucket; `.bucket`, `.region`, `.list_keys()`, `.read_all()`. For `S3Sink`. |
+
+Import the classes directly when you need finer control than the fixtures give:
+
+```python
+from tests.e2e.fakes import HttpPollServer, SSEServer, RecordingServer, fake_s3
+```
+
+### Isolation & platform notes
+
+* Everything computes `Path.home()` **inside** functions, so overriding `HOME`/
+  `USERPROFILE` (which `tmp_traceforge_home` does) fully redirects `~/.traceforge`
+  for both in-process code and spawned subprocesses.
+* The gate IPC transport is an `AF_UNIX` socket on POSIX and a loopback TCP address
+  (`tcp://127.0.0.1:<port>`) on Windows. Assertions specific to the Windows form
+  carry `@pytest.mark.windows_only`.
+* CI runs on Linux (Python 3.11/3.12/3.13); `windows_only` tests are developed and
+  run locally on Windows and skipped in CI.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timezone
 
 import pytest
@@ -93,3 +94,18 @@ class RecordingSink:
 @pytest.fixture
 def recording_sink() -> RecordingSink:
     return RecordingSink()
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-skip ``@pytest.mark.windows_only`` tests on non-Windows platforms.
+
+    The gate IPC transport differs by OS (AF_UNIX sockets on POSIX, loopback TCP
+    on Windows); tests asserting Windows-specific behavior carry this marker and
+    are skipped elsewhere — including the Linux CI matrix.
+    """
+    if sys.platform == "win32":
+        return
+    skip_windows = pytest.mark.skip(reason="windows_only: runs only on Windows")
+    for item in items:
+        if "windows_only" in item.keywords:
+            item.add_marker(skip_windows)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,340 @@
+"""Shared end-to-end test harness for TraceForge.
+
+This is the Wave-0 scaffolding imported by the downstream E2E stories (#81–#86).
+It provides:
+
+* **Isolation** — ``tmp_traceforge_home`` redirects ``$HOME``/``%USERPROFILE%`` to a
+  throwaway directory so anything that reads ``Path.home()/.traceforge`` (the Score
+  API, watch daemon, gate registry, default sinks) is fully sandboxed.
+* **Process fixtures** — ``score_server_url`` and ``watch_daemon`` spawn the real
+  ``python -m traceforge`` subprocesses and health-poll them before yielding.
+* **Registry access** — ``gate_socket_lookup`` reads the ``gate_endpoints`` table
+  in the sandboxed ``system.db``.
+* **Fake network backends** — ``http_poll_server``, ``sse_server``, ``fake_s3``,
+  ``otel_collector`` and ``webhook_receiver`` (loopback only; see
+  ``tests/e2e/fakes/``) so sink/source tests assert real I/O against the actual
+  classes.
+
+The unit-level factories (``make_event`` etc.) live in the repo-root
+``tests/conftest.py`` and remain available here.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from tests.e2e.fakes.http_poll import HttpPollServer
+from tests.e2e.fakes.recording import RecordingServer
+from tests.e2e.fakes.sse import SSEServer
+
+# ─── Isolation ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_traceforge_home(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """An isolated ``$HOME`` so ``~/.traceforge`` never touches the real one.
+
+    Overrides every variable ``os.path.expanduser`` consults (POSIX ``HOME``;
+    Windows ``USERPROFILE`` and ``HOMEDRIVE``/``HOMEPATH``) and scrubs the
+    framework-detection env vars, so auto-detection only sees what a test sets up.
+    Subprocesses spawned by the other fixtures inherit this patched environment.
+    """
+    home = tmp_path_factory.mktemp("tf-home")
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    drive, tail = os.path.splitdrive(str(home))
+    if drive:  # Windows: back up USERPROFILE with HOMEDRIVE/HOMEPATH
+        monkeypatch.setenv("HOMEDRIVE", drive)
+        monkeypatch.setenv("HOMEPATH", tail or "\\")
+
+    # Redirect app-data probes (cline/goose/amazonq detectors) into the sandbox
+    # and drop source-specific overrides so detection is deterministic.
+    monkeypatch.setenv("APPDATA", str(home / "AppData" / "Roaming"))
+    monkeypatch.setenv("LOCALAPPDATA", str(home / "AppData" / "Local"))
+    for var in ("CODEX_HOME", "CONTINUE_GLOBAL_DIR", "TRACEFORGE_CONFIG"):
+        monkeypatch.delenv(var, raising=False)
+
+    (home / ".traceforge").mkdir(parents=True, exist_ok=True)
+    return home
+
+
+# ─── Subprocess helpers ──────────────────────────────────────────────────────
+
+
+class BackgroundProcess:
+    """A spawned ``python -m traceforge`` process with drained stdout/stderr."""
+
+    def __init__(self, args: list[str]) -> None:
+        self.args = args
+        self.proc = subprocess.Popen(
+            args,
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        self._lines: list[str] = []
+        self._reader = threading.Thread(target=self._drain, daemon=True)
+        self._reader.start()
+
+    def _drain(self) -> None:
+        assert self.proc.stdout is not None
+        for line in self.proc.stdout:
+            self._lines.append(line)
+
+    @property
+    def output(self) -> str:
+        return "".join(self._lines)
+
+    def is_running(self) -> bool:
+        return self.proc.poll() is None
+
+    def terminate(self, timeout: float = 10.0) -> None:
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait(timeout=timeout)
+        self._reader.join(timeout=2.0)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _traceforge_cmd(*args: str) -> list[str]:
+    return [sys.executable, "-m", "traceforge", *args]
+
+
+def _wait_for_http_ok(url: str, proc: BackgroundProcess, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        if not proc.is_running():
+            raise RuntimeError(
+                f"process exited early (code {proc.proc.returncode}).\n--- output ---\n{proc.output}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.status == 200:
+                    resp.read()
+                    return
+        except Exception as exc:  # connection refused until the server binds
+            last_err = exc
+        time.sleep(0.2)
+    raise TimeoutError(
+        f"{url} not ready within {timeout}s (last error: {last_err!r}).\n--- output ---\n{proc.output}"
+    )
+
+
+def _query_gate_endpoint(system_db: Path, session_id: str) -> str | None:
+    if not system_db.exists():
+        return None
+    conn = sqlite3.connect(str(system_db))
+    try:
+        row = conn.execute(
+            "SELECT sock_path FROM gate_endpoints WHERE session_id = ?", (session_id,)
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None  # table not created yet
+    finally:
+        conn.close()
+    return row[0] if row else None
+
+
+def _wait_for_gate_session(
+    system_db: Path, session_id: str, proc: BackgroundProcess, timeout: float
+) -> str:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not proc.is_running():
+            raise RuntimeError(
+                f"watch exited early (code {proc.proc.returncode}).\n--- output ---\n{proc.output}"
+            )
+        value = _query_gate_endpoint(system_db, session_id)
+        if value is not None:
+            return value
+        time.sleep(0.25)
+    raise TimeoutError(
+        f"gate session {session_id!r} not registered within {timeout}s.\n--- output ---\n{proc.output}"
+    )
+
+
+# ─── Process fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def score_server_url(tmp_traceforge_home: Path) -> str:
+    """Spawn ``traceforge score`` on a free port and yield its base URL.
+
+    Blocks until ``GET /health`` returns 200. POST scoring requests to
+    ``f"{score_server_url}/score"``.
+    """
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}"
+    proc = BackgroundProcess(_traceforge_cmd("score", "--listen", f"127.0.0.1:{port}"))
+    try:
+        _wait_for_http_ok(f"{url}/health", proc, timeout=60.0)
+        yield url
+    finally:
+        proc.terminate()
+
+
+class WatchDaemon:
+    """Handle onto a running ``traceforge watch`` daemon.
+
+    Attributes:
+        home: the isolated ``$HOME``.
+        source_dir: ``~/.claude/projects`` — drop ``*.jsonl`` here to feed the daemon.
+        system_db / output_db: the sandboxed ``system.db`` and default sqlite sink.
+    """
+
+    def __init__(self, proc: BackgroundProcess, home: Path) -> None:
+        self._proc = proc
+        self.home = home
+        self.traceforge_dir = home / ".traceforge"
+        self.system_db = self.traceforge_dir / "system.db"
+        self.output_db = self.traceforge_dir / "traceforge.db"
+        self.source_dir = home / ".claude" / "projects"
+
+    @property
+    def process(self) -> subprocess.Popen:
+        return self._proc.proc
+
+    @property
+    def output(self) -> str:
+        return self._proc.output
+
+    def is_running(self) -> bool:
+        return self._proc.is_running()
+
+
+@pytest.fixture
+def watch_daemon(tmp_traceforge_home: Path) -> WatchDaemon:
+    """Spawn ``traceforge watch`` against an isolated home and health-poll it.
+
+    Seeds ``~/.claude/projects`` so the ``claude`` framework is detected (the
+    daemon exits if nothing is detected), spawns ``watch --frameworks claude
+    --no-score`` (``--no-score`` keeps the fixed 7331 port free — use
+    ``score_server_url`` for the Score API), then waits until the gate registry
+    has a live ``_default`` session before yielding.
+    """
+    home = tmp_traceforge_home
+    (home / ".claude" / "projects").mkdir(parents=True, exist_ok=True)
+
+    proc = BackgroundProcess(
+        _traceforge_cmd("watch", "--frameworks", "claude", "--no-score", "--log-level", "DEBUG")
+    )
+    daemon = WatchDaemon(proc, home)
+    try:
+        _wait_for_gate_session(daemon.system_db, "_default", proc, timeout=90.0)
+        yield daemon
+    finally:
+        proc.terminate()
+
+
+@pytest.fixture
+def gate_socket_lookup(tmp_traceforge_home: Path) -> Callable[[str], str | None]:
+    """Return ``lookup(session_id) -> sock_path | None`` over the sandboxed registry.
+
+    Reads the ``gate_endpoints`` table in ``~/.traceforge/system.db`` directly.
+    ``sock_path`` is a unix-socket path on POSIX or ``tcp://127.0.0.1:<port>`` on
+    Windows. Returns ``None`` if the db/table/row is absent.
+    """
+    system_db = tmp_traceforge_home / ".traceforge" / "system.db"
+
+    def lookup(session_id: str) -> str | None:
+        return _query_gate_endpoint(system_db, session_id)
+
+    return lookup
+
+
+# ─── Fake network backends ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def http_poll_server() -> HttpPollServer:
+    """A loopback HTTP endpoint with ETag/304 support (for ``HttpPollSource``)."""
+    server = HttpPollServer()
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture
+def sse_server() -> SSEServer:
+    """A loopback SSE endpoint with reconnect/resume support (for ``SSESource``)."""
+    server = SSEServer()
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture
+def otel_collector() -> RecordingServer:
+    """A fake OTLP/HTTP collector; POSTs land in ``.received`` / ``.spans()``.
+
+    ``.endpoint`` is the full ``/v1/traces`` URL to hand to ``OtelExporterSink``.
+    """
+    server = RecordingServer()
+    server.start()
+    server.endpoint = f"{server.url}/v1/traces"  # type: ignore[attr-defined]
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture
+def webhook_receiver() -> RecordingServer:
+    """A fake webhook endpoint; POST bodies land in ``.received``.
+
+    Use ``.fail_next(n)`` / ``.set_status(code)`` to exercise ``WebhookSink`` retries.
+    """
+    server = RecordingServer()
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture
+def fake_s3():
+    """A moto-backed in-memory S3 bucket (for ``S3Sink``); yields a ``FakeS3``.
+
+    Construct the sink inside the test as ``S3Sink(bucket=fake_s3.bucket,
+    region=fake_s3.region)`` — the mock intercepts boto3 at the wire level, so no
+    ``endpoint_url`` is needed. Skips if ``moto``/``boto3`` are unavailable.
+    """
+    pytest.importorskip("boto3")
+    pytest.importorskip("moto")
+    from tests.e2e.fakes.s3 import fake_s3 as _fake_s3
+
+    with _fake_s3() as handle:
+        yield handle

--- a/tests/e2e/fakes/__init__.py
+++ b/tests/e2e/fakes/__init__.py
@@ -1,0 +1,30 @@
+"""Reusable loopback fake network backends for TraceForge e2e tests.
+
+These helpers exist so downstream E2E stories (#81 sources, #82 network sources,
+#83 sinks, #85 CLI, #86 gate) can assert **real I/O** against the actual source
+and sink classes instead of mocks. Every server binds ``127.0.0.1`` on an
+ephemeral port — nothing here contacts an external host.
+
+Prefer the pytest fixtures in ``tests/e2e/conftest.py`` (``http_poll_server``,
+``sse_server``, ``fake_s3``, ``otel_collector``, ``webhook_receiver``); import
+these classes directly only when you need finer control.
+"""
+
+from __future__ import annotations
+
+from tests.e2e.fakes._http import ThreadedHTTPFake
+from tests.e2e.fakes.http_poll import HttpPollServer
+from tests.e2e.fakes.recording import RecordingServer
+from tests.e2e.fakes.s3 import DEFAULT_BUCKET, DEFAULT_REGION, FakeS3, fake_s3
+from tests.e2e.fakes.sse import SSEServer
+
+__all__ = [
+    "ThreadedHTTPFake",
+    "HttpPollServer",
+    "SSEServer",
+    "RecordingServer",
+    "FakeS3",
+    "fake_s3",
+    "DEFAULT_BUCKET",
+    "DEFAULT_REGION",
+]

--- a/tests/e2e/fakes/_http.py
+++ b/tests/e2e/fakes/_http.py
@@ -1,0 +1,91 @@
+"""Loopback HTTP fake-server base for e2e network tests.
+
+Every fake binds ``127.0.0.1:0`` (an ephemeral loopback port) and runs its
+serve loop in a daemon thread. Nothing here ever contacts an external host —
+tests that use these servers should carry ``@pytest.mark.net`` to document that
+they exercise a (local, fake) network boundary.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class SilentHandler(BaseHTTPRequestHandler):
+    """A request handler that reaches its owning fake via ``self.server.fake``.
+
+    Subclasses implement ``do_GET`` / ``do_POST``. Access the fake instance with
+    ``self.server.fake``. Logging is silenced so the fakes don't spam pytest's
+    captured output.
+    """
+
+    # HTTP/1.0 => the connection is closed when the handler returns. This is what
+    # lets the SSE fake model "stream ended, please reconnect" simply by returning
+    # from ``do_GET``.
+    protocol_version = "HTTP/1.0"
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass
+
+
+class _FakeHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, address, handler_class, fake: "ThreadedHTTPFake") -> None:
+        super().__init__(address, handler_class)
+        self.fake = fake
+
+
+class ThreadedHTTPFake:
+    """Base class for a loopback HTTP server running in a daemon thread.
+
+    Subclasses set ``handler_class`` to a :class:`SilentHandler` subclass. Use as
+    a context manager or call :meth:`start` / :meth:`stop` explicitly::
+
+        with MyFake() as fake:
+            httpx.get(fake.url)
+    """
+
+    handler_class: type[SilentHandler]
+
+    def __init__(self) -> None:
+        self._server = _FakeHTTPServer(("127.0.0.1", 0), self.handler_class, self)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name=type(self).__name__,
+            daemon=True,
+        )
+        self._started = False
+
+    @property
+    def port(self) -> int:
+        return self._server.server_address[1]
+
+    @property
+    def host(self) -> str:
+        return "127.0.0.1"
+
+    @property
+    def url(self) -> str:
+        """Base URL, e.g. ``http://127.0.0.1:53312`` (no trailing slash)."""
+        return f"http://{self.host}:{self.port}"
+
+    def start(self) -> "ThreadedHTTPFake":
+        if not self._started:
+            self._thread.start()
+            self._started = True
+        return self
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        if self._started:
+            self._thread.join(timeout=5.0)
+
+    def __enter__(self) -> "ThreadedHTTPFake":
+        return self.start()
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()

--- a/tests/e2e/fakes/http_poll.py
+++ b/tests/e2e/fakes/http_poll.py
@@ -1,0 +1,88 @@
+"""Fake HTTP-poll endpoint with ETag / conditional-request support.
+
+Targets :class:`traceforge.sources.http_poll.HttpPollSource`, which issues
+conditional GETs (``If-None-Match: <etag>``), treats ``304 Not Modified`` as
+"no new data", and reads ``ETag`` / ``Last-Modified`` (and an optional cursor
+header) off each response.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from tests.e2e.fakes._http import SilentHandler, ThreadedHTTPFake
+
+
+class _HttpPollHandler(SilentHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        fake: "HttpPollServer" = self.server.fake  # type: ignore[attr-defined]
+        with fake._lock:
+            fake.request_count += 1
+            fake.last_headers = {k.lower(): v for k, v in self.headers.items()}
+            body, etag, cursor = fake._body, fake._etag, fake._cursor_value
+
+        if_none_match = self.headers.get("If-None-Match")
+        if etag is not None and if_none_match == etag:
+            self.send_response(304)
+            self.end_headers()
+            return
+
+        payload = body.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", fake.content_type)
+        if etag is not None:
+            self.send_header("ETag", etag)
+        if fake.cursor_header and cursor is not None:
+            self.send_header(fake.cursor_header, cursor)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        try:
+            self.wfile.write(payload)
+        except (BrokenPipeError, ConnectionError):
+            pass
+
+
+class HttpPollServer(ThreadedHTTPFake):
+    """Serve a mutable body behind an ETag so conditional GETs return 304.
+
+    ``set_body`` installs new content and (unless an explicit ``etag`` is given)
+    bumps the ETag, so the next poll sees fresh data; polling an unchanged body
+    yields ``304``.
+    """
+
+    handler_class = _HttpPollHandler
+
+    def __init__(
+        self,
+        body: str = "",
+        *,
+        etag: str | None = None,
+        content_type: str = "application/json",
+        cursor_header: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self._version = 0
+        self._body = body
+        self._etag = etag if etag is not None else self._auto_etag()
+        self._cursor_value: str | None = None
+        self.content_type = content_type
+        self.cursor_header = cursor_header
+        self.request_count = 0
+        self.last_headers: dict[str, str] = {}
+
+    def _auto_etag(self) -> str:
+        return f'"v{self._version}"'
+
+    def set_body(self, body: str, *, etag: str | None = None, cursor: str | None = None) -> None:
+        """Replace the served body. A new ETag is generated unless one is given."""
+        with self._lock:
+            self._body = body
+            self._version += 1
+            self._etag = etag if etag is not None else self._auto_etag()
+            if cursor is not None:
+                self._cursor_value = cursor
+
+    @property
+    def etag(self) -> str | None:
+        return self._etag

--- a/tests/e2e/fakes/recording.py
+++ b/tests/e2e/fakes/recording.py
@@ -1,0 +1,93 @@
+"""Fake HTTP receiver that records POSTed JSON bodies.
+
+Backs both the fake OTel collector (``POST /v1/traces`` from
+:class:`traceforge.sinks.otel_exporter.OtelExporterSink`) and the fake webhook
+endpoint (:class:`traceforge.sinks.webhook.WebhookSink`). Both sinks POST JSON
+via stdlib ``urllib`` and retry on HTTP status >= 300, so the recorder can force
+failures via :meth:`fail_next` / :meth:`set_status` to exercise retry paths.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+from tests.e2e.fakes._http import SilentHandler, ThreadedHTTPFake
+
+
+class _RecordingHandler(SilentHandler):
+    def do_POST(self) -> None:  # noqa: N802
+        fake: "RecordingServer" = self.server.fake  # type: ignore[attr-defined]
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length > 0 else b""
+        fake._record(self.path, {k.lower(): v for k, v in self.headers.items()}, raw)
+
+        status = fake._next_status()
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+class RecordingServer(ThreadedHTTPFake):
+    """Record every POST; optionally return transient failures for retry tests."""
+
+    handler_class = _RecordingHandler
+
+    def __init__(self, default_status: int = 200) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self.default_status = default_status
+        self._fail_remaining = 0
+        #: One dict per request: ``{path, headers, body, json}``.
+        self.requests: list[dict[str, Any]] = []
+
+    def _record(self, path: str, headers: dict[str, str], raw: bytes) -> None:
+        try:
+            parsed: Any = json.loads(raw) if raw else None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            parsed = None
+        with self._lock:
+            self.requests.append({"path": path, "headers": headers, "body": raw, "json": parsed})
+
+    def _next_status(self) -> int:
+        with self._lock:
+            if self._fail_remaining > 0:
+                self._fail_remaining -= 1
+                return 503
+            return self.default_status
+
+    def set_status(self, code: int) -> None:
+        """Set the status returned to every subsequent request."""
+        with self._lock:
+            self.default_status = code
+
+    def fail_next(self, n: int) -> None:
+        """Return 503 for the next ``n`` requests, then the default status."""
+        with self._lock:
+            self._fail_remaining = n
+
+    @property
+    def request_count(self) -> int:
+        return len(self.requests)
+
+    @property
+    def received(self) -> list[Any]:
+        """Parsed JSON bodies (skipping any that failed to decode)."""
+        with self._lock:
+            return [r["json"] for r in self.requests if r["json"] is not None]
+
+    def spans(self) -> list[dict[str, Any]]:
+        """Flatten OTLP/HTTP JSON payloads into a list of span dicts.
+
+        Returns an empty list for non-OTLP bodies, so this is safe to call on a
+        plain webhook recorder too.
+        """
+        out: list[dict[str, Any]] = []
+        for payload in self.received:
+            if not isinstance(payload, dict):
+                continue
+            for resource_span in payload.get("resourceSpans", []):
+                for scope_span in resource_span.get("scopeSpans", []):
+                    out.extend(scope_span.get("spans", []))
+        return out

--- a/tests/e2e/fakes/s3.py
+++ b/tests/e2e/fakes/s3.py
@@ -1,0 +1,66 @@
+"""Fake S3 backend via `moto <https://github.com/getmoto/moto>`_.
+
+Targets :class:`traceforge.sinks.s3.S3Sink`, which uses a real ``boto3`` S3
+client (``put_object``). ``moto``'s ``mock_aws`` intercepts botocore at the wire
+level — including calls made from ``asyncio.to_thread`` worker threads — so the
+sink exercises its real serialization path against an in-memory bucket we can
+then read back.
+
+Requires the ``moto`` and ``boto3`` packages (both in the project's dev group).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import dataclass
+from typing import Any, Iterator
+from unittest import mock
+
+DEFAULT_REGION = "us-east-1"
+DEFAULT_BUCKET = "traceforge-e2e"
+
+_FAKE_CREDS = {
+    "AWS_ACCESS_KEY_ID": "testing",
+    "AWS_SECRET_ACCESS_KEY": "testing",
+    "AWS_SECURITY_TOKEN": "testing",
+    "AWS_SESSION_TOKEN": "testing",
+}
+
+
+@dataclass
+class FakeS3:
+    """Handle onto a mocked S3 bucket. ``client`` is a live boto3 S3 client."""
+
+    client: Any
+    bucket: str
+    region: str
+
+    def list_keys(self) -> list[str]:
+        resp = self.client.list_objects_v2(Bucket=self.bucket)
+        return sorted(obj["Key"] for obj in resp.get("Contents", []))
+
+    def read_object(self, key: str) -> str:
+        obj = self.client.get_object(Bucket=self.bucket, Key=key)
+        return obj["Body"].read().decode("utf-8")
+
+    def read_all(self) -> str:
+        """Concatenate every object body (handy for JSONL round-trip assertions)."""
+        return "".join(self.read_object(key) for key in self.list_keys())
+
+
+@contextlib.contextmanager
+def fake_s3(region: str = DEFAULT_REGION, bucket: str = DEFAULT_BUCKET) -> Iterator[FakeS3]:
+    """Context manager yielding a :class:`FakeS3` with one empty bucket created.
+
+    The mock stays active for the life of the ``with`` block, so any
+    ``boto3``/``S3Sink`` created inside it talks to the in-memory backend.
+    """
+    import boto3
+    from moto import mock_aws
+
+    creds = {**_FAKE_CREDS, "AWS_DEFAULT_REGION": region}
+    with mock.patch.dict(os.environ, creds), mock_aws():
+        client = boto3.client("s3", region_name=region)
+        client.create_bucket(Bucket=bucket)
+        yield FakeS3(client=client, bucket=bucket, region=region)

--- a/tests/e2e/fakes/sse.py
+++ b/tests/e2e/fakes/sse.py
@@ -1,0 +1,117 @@
+"""Fake Server-Sent Events endpoint with reconnect / resume support.
+
+Targets :class:`traceforge.sources.sse.SSESource`, which requires a
+``text/event-stream`` response, parses ``data`` / ``event`` / ``id`` / ``retry``
+fields, and replays ``Last-Event-ID`` when it reconnects after a stream ends.
+
+The server models a single long-lived stream: :meth:`enqueue` pushes an event to
+connected clients, and :meth:`close_current` ends the active connection so the
+source reconnects (carrying ``Last-Event-ID``).
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+
+from tests.e2e.fakes._http import SilentHandler, ThreadedHTTPFake
+
+
+class _SSEHandler(SilentHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        fake: "SSEServer" = self.server.fake  # type: ignore[attr-defined]
+        fake._on_connect(self.headers.get("Last-Event-ID", ""))
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+
+        fake._disconnect.clear()
+        try:
+            while not fake._disconnect.is_set():
+                try:
+                    block = fake._queue.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+                # A disconnect requested while we were blocked in ``get`` wins over
+                # a racing ``enqueue`` — don't deliver on a connection being torn
+                # down, so the item is served on the *next* (resumed) connection.
+                if fake._disconnect.is_set():
+                    fake._queue.put(block)
+                    return
+                try:
+                    self.wfile.write(block.encode("utf-8"))
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionError, OSError):
+                    return
+        finally:
+            fake._handler_done.set()
+
+
+class SSEServer(ThreadedHTTPFake):
+    """Stream SSE events to a single connection; force reconnects on demand."""
+
+    handler_class = _SSEHandler
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._queue: queue.Queue[str] = queue.Queue()
+        self._disconnect = threading.Event()
+        self._handler_done = threading.Event()
+        self._handler_done.set()  # no active handler yet
+        self._lock = threading.Lock()
+        #: ``Last-Event-ID`` header value seen on each connection, in order.
+        self.connections: list[str] = []
+
+    def _on_connect(self, last_event_id: str) -> None:
+        self._handler_done.clear()
+        with self._lock:
+            self.connections.append(last_event_id)
+
+    @property
+    def connection_count(self) -> int:
+        return len(self.connections)
+
+    @property
+    def received_last_event_id(self) -> str | None:
+        """The most recent ``Last-Event-ID`` the server was reconnected with."""
+        return self.connections[-1] if self.connections else None
+
+    def enqueue(
+        self,
+        data: str,
+        *,
+        id: str | None = None,  # noqa: A002
+        event: str | None = None,
+        retry: int | None = None,
+    ) -> None:
+        """Queue one SSE event for delivery to the active (or next) connection."""
+        lines: list[str] = []
+        if event is not None:
+            lines.append(f"event: {event}")
+        if id is not None:
+            lines.append(f"id: {id}")
+        if retry is not None:
+            lines.append(f"retry: {retry}")
+        for chunk in data.split("\n"):
+            lines.append(f"data: {chunk}")
+        self._queue.put("\n".join(lines) + "\n\n")
+
+    def close_current(self, timeout: float = 5.0) -> None:
+        """End the active connection and block until its handler has exited.
+
+        Returning only once the current connection is fully torn down makes the
+        reconnect deterministic: a subsequent :meth:`enqueue` is guaranteed to be
+        delivered on the *next* connection (which carries ``Last-Event-ID``),
+        never as a trailing write on the connection being closed.
+        """
+        self._disconnect.set()
+        self._handler_done.wait(timeout=timeout)
+
+    def stop(self) -> None:
+        # Wake any handler blocked in its send loop so it exits promptly instead
+        # of spinning as a leaked daemon thread after the server socket closes.
+        self._disconnect.set()
+        super().stop()

--- a/tests/e2e/test_harness_smoke.py
+++ b/tests/e2e/test_harness_smoke.py
@@ -1,0 +1,224 @@
+"""Smoke tests for the Wave-0 e2e harness (issue #79).
+
+Each test exercises one fixture from ``tests/e2e/conftest.py`` through the *real*
+consumer it exists to serve — a live ``traceforge`` subprocess, the gate registry,
+or an actual source/sink class — so a green run proves the fixture (and the fake it
+wraps) matches production expectations. Downstream stories (#81–#86) build on these
+same fixtures, so this file is their canary.
+
+Marker map:
+* ``e2e`` — every test here.
+* ``slow`` — spawns a ``python -m traceforge`` subprocess.
+* ``net`` — talks to a loopback fake network server.
+* ``windows_only`` — asserts Windows-specific gate transport (auto-skipped elsewhere).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import make_event
+from traceforge.types import TitleUpdate
+
+# ─── small HTTP helpers (stdlib only, loopback) ──────────────────────────────
+
+
+def _get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310 (loopback)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _post_json(url: str, payload: dict) -> tuple[int, object]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310 (loopback)
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            raw = resp.read().decode("utf-8")
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        status = exc.code
+    return status, (json.loads(raw) if raw else None)
+
+
+# ─── isolation ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_tmp_traceforge_home_is_isolated(tmp_traceforge_home: Path) -> None:
+    assert Path.home() == tmp_traceforge_home
+    assert (tmp_traceforge_home / ".traceforge").is_dir()
+
+    marker = Path.home() / ".traceforge" / "marker.txt"
+    marker.write_text("ok", encoding="utf-8")
+    assert marker.read_text(encoding="utf-8") == "ok"
+
+
+# ─── gate registry ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+def test_gate_socket_lookup_reads_registry(tmp_traceforge_home: Path, gate_socket_lookup) -> None:
+    from traceforge.gate import registry
+    from traceforge.governance.persistence import SystemStore
+
+    db = tmp_traceforge_home / ".traceforge" / "system.db"
+    store = SystemStore(db)  # runs migrations → creates the gate_endpoints table
+    try:
+        assert gate_socket_lookup("sess-A") is None  # empty table
+
+        registry.register_session("sess-A", "tcp://127.0.0.1:5555")
+        assert gate_socket_lookup("sess-A") == "tcp://127.0.0.1:5555"
+        assert gate_socket_lookup("does-not-exist") is None
+    finally:
+        store.close()
+
+
+# ─── score API subprocess ────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_score_server_health_and_score(score_server_url: str) -> None:
+    assert _get_json(f"{score_server_url}/health")["status"] == "ok"
+
+    status, body = _post_json(
+        f"{score_server_url}/score",
+        {"tool_name": "read_file", "arguments": {"path": "README.md"}, "session_id": "smoke"},
+    )
+    assert status == 200
+    assert isinstance(body, dict) and body
+
+
+# ─── watch daemon subprocess ─────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_watch_daemon_registers_default_gate(watch_daemon, gate_socket_lookup) -> None:
+    assert watch_daemon.is_running()
+    assert watch_daemon.system_db.exists()
+
+    sock = gate_socket_lookup("_default")
+    assert sock, f"_default not registered; daemon output:\n{watch_daemon.output}"
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.windows_only
+def test_gate_endpoint_is_tcp_on_windows(watch_daemon, gate_socket_lookup) -> None:
+    sock = gate_socket_lookup("_default")
+    assert sock is not None
+    assert sock.startswith("tcp://127.0.0.1:")
+
+
+# ─── HTTP-poll source + fake (ETag / 304) ────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_http_poll_source_etag_304(http_poll_server) -> None:
+    from traceforge.sources.http_poll import HttpPollSource
+
+    http_poll_server.set_body('{"n": 1}')
+    records = []
+    async with HttpPollSource(
+        http_poll_server.url, name="poll-smoke", interval=0.05, max_retries=0
+    ) as src:
+        stream = src.__aiter__()
+        records.append(await asyncio.wait_for(stream.__anext__(), timeout=10))
+        http_poll_server.set_body('{"n": 2}')
+        records.append(await asyncio.wait_for(stream.__anext__(), timeout=10))
+
+    assert [r.payload for r in records] == ['{"n": 1}', '{"n": 2}']
+    # The source only re-emits on change, so getting body #2 (not a repeat of #1)
+    # proves it honored the 304s in between; and it sent a conditional request.
+    assert http_poll_server.request_count >= 2
+    assert "if-none-match" in http_poll_server.last_headers
+
+
+# ─── SSE source + fake (reconnect / Last-Event-ID resume) ────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_source_reconnect_resume(sse_server) -> None:
+    from traceforge.sources.sse import SSESource
+
+    sse_server.enqueue("alpha", id="1")
+    sse_server.enqueue("beta", id="2")
+
+    got = []
+    async with SSESource(
+        sse_server.url, name="sse-smoke", reconnect_delay=0.05, max_reconnects=10
+    ) as src:
+        stream = src.__aiter__()
+        got.append(await asyncio.wait_for(stream.__anext__(), timeout=10))
+        got.append(await asyncio.wait_for(stream.__anext__(), timeout=10))
+
+        sse_server.close_current()  # force a reconnect
+        sse_server.enqueue("gamma", id="3")
+        got.append(await asyncio.wait_for(stream.__anext__(), timeout=10))
+
+    assert [r.payload for r in got] == ["alpha", "beta", "gamma"]
+    assert sse_server.connection_count >= 2  # reconnected at least once
+    assert sse_server.received_last_event_id == "2"  # resumed from the last dispatched id
+
+
+# ─── S3 sink + fake (round-trip via moto) ────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_s3_sink_round_trip(fake_s3) -> None:
+    from traceforge.sinks.s3 import S3Sink
+
+    sink = S3Sink(bucket=fake_s3.bucket, region=fake_s3.region)
+    await sink.on_event(make_event(session_id="s3-smoke"))
+    await sink.close()  # flushes the buffer
+
+    assert fake_s3.list_keys(), "no object written to the fake bucket"
+    assert "s3-smoke" in fake_s3.read_all()
+
+
+# ─── OTel exporter sink + fake collector ─────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_otel_exporter_reaches_collector(otel_collector) -> None:
+    from traceforge.sinks.otel_exporter import OtelExporterSink
+
+    sink = OtelExporterSink(endpoint=otel_collector.endpoint)
+    await sink.on_event(make_event(session_id="otel-smoke"))
+    await sink.flush()
+
+    spans = otel_collector.spans()
+    assert spans, "collector received no OTLP spans"
+    assert any(s.get("name", "").startswith("traceforge.") for s in spans)
+
+
+# ─── webhook sink + fake receiver (record + retry) ───────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_sink_records_and_retries(webhook_receiver) -> None:
+    from traceforge.sinks.webhook import WebhookSink
+
+    webhook_receiver.fail_next(1)  # first POST → 503, sink must retry
+    sink = WebhookSink(webhook_receiver.url, max_retries=3)
+    await sink.on_title_update(
+        TitleUpdate(session_id="wh", segment_id="wh", kind="session", title="Hello")
+    )
+
+    assert webhook_receiver.request_count >= 2  # one failed + one successful delivery
+    assert any(b.get("record") == "title_update" for b in webhook_receiver.received)

--- a/uv.lock
+++ b/uv.lock
@@ -685,6 +685,65 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/8b/adeb62ea8951f13c4c7fef2e7a85e1a06b499c8d8237ea589d496029e53f/coverage-7.15.0.tar.gz", hash = "sha256:9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f", size = 925362, upload-time = "2026-07-02T13:10:50.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/23/82e910835ef4b8391047025e1d53aa48d66029f444eb8b25373c849bf503/coverage-7.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:003fff99412ea848c0aaebcc78ed2b6ce7d8a1227ed17e68470672770b78a02a", size = 220662, upload-time = "2026-07-02T13:08:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0d/c7b213dde2f1579de5231062b386d8413f79c11667eb58c39319b25991da/coverage-7.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5cbd804bf2784ce7b45114516050f346ecd50f960c4bb630a7ee9e1d78fa2118", size = 221168, upload-time = "2026-07-02T13:08:40.471Z" },
+    { url = "https://files.pythonhosted.org/packages/33/77/d000aeedfac085088337b3c7becdad328474b1f8a9e4c9368a0c99605d68/coverage-7.15.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8773e15c23305b58882a4611fb9b2755977eae0dc2e515366a1b6c98866cc4c2", size = 251587, upload-time = "2026-07-02T13:08:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/e0/86787c56b9df17afd370d5e293515dd4d9a107a561d13054873eefad8ecc/coverage-7.15.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f50e40081494c1dc4239ebb202014cbcc3306ea96fb6302a34c8cc0967fc5ae8", size = 253497, upload-time = "2026-07-02T13:08:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/02/181bc917359299c07dead6270f94e411151c8b60cec905c33499da69afe6/coverage-7.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daf96f37f5fc3a7b6c6da862eb4aee61c426bd63da236ed4a73ef0e503b4bca5", size = 255607, upload-time = "2026-07-02T13:08:44.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/35/ca5e7427699913da6788c4f910e73ab16c5f4b59ec5d3a999dce2a45112f/coverage-7.15.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:51aa20f6ae2788fd197747766edf4cd8234fd9423309b934257fa6b21a592723", size = 257563, upload-time = "2026-07-02T13:08:46.334Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4d/b8220bacc2fc3c4e9078e27c32e99fb411479a4718a72bdd00036a9891c8/coverage-7.15.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03d1f922757662eb7af586e77834792274cff776bc7b1d1a0b66a49ea9d84735", size = 251726, upload-time = "2026-07-02T13:08:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e4/2e145da1991d72189b9c3cf7eca05c716ee7080d099aaea6757cfc7df008/coverage-7.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a6d6acc9a7666245e6133dd15144ca038a85a9cd5026bb06d6bbae9e77440dc9", size = 253301, upload-time = "2026-07-02T13:08:49.5Z" },
+    { url = "https://files.pythonhosted.org/packages/72/28/d2c841d698bf762e481f08bd4839d370246b6d9b61dab085a7b20b201a08/coverage-7.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1ac2c4c27c7df851dc9a017c2d7de00b69147e84ba3d96f37a530b0b6fb51035", size = 251361, upload-time = "2026-07-02T13:08:51.304Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ed/55d9ffde994fba3897c0c783f77a7d053b0c18787f6892ed5b0aed73f469/coverage-7.15.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b761a1d504fd4bd1f20f418753964dca9f5862a511fc854dac58296b3b223671", size = 255129, upload-time = "2026-07-02T13:08:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c0/ecbf33b8c460ea2718aeb813e2df8140d0370e5f67261c31524ceb0a2a8d/coverage-7.15.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e43b045e11c16e897895758ae90e4a90cf99e93d58549e2f90c0e2272e155695", size = 251081, upload-time = "2026-07-02T13:08:54.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/de/fb87b4261f54448dd2b9504ef19a58be42cef0d9520595fbfe1219b15234/coverage-7.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:589b54513e901739f4b4582c705ce96b80c96f57641b1464607e2367a270e540", size = 251988, upload-time = "2026-07-02T13:08:55.726Z" },
+    { url = "https://files.pythonhosted.org/packages/df/27/3494d5f291b9a4cb868f73c11221a8bd2d5bd761a8f9acea61ff57128dd1/coverage-7.15.0-cp311-cp311-win32.whl", hash = "sha256:106781b8482749162d0b47056937ba0933508e5d9447f65a5e7d5c422f0d6bb4", size = 222754, upload-time = "2026-07-02T13:08:57.091Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ee/cd4847ebc9be6a9c0123d763645a6f1f3be6b8c58c962706368b79cbac07/coverage-7.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:821e92b3631d762a339695824cadbbc73020354eba2a23a551a99ad34938fbe6", size = 223225, upload-time = "2026-07-02T13:08:58.594Z" },
+    { url = "https://files.pythonhosted.org/packages/57/37/5011581aa7f2be498b97dcc7c9902192442a42f4f9a748aeadb3d6506b42/coverage-7.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:309990eb5fb8014b9f67cb211f7fd41876ec8a88a88d3ae76de0ed1d611e3640", size = 222774, upload-time = "2026-07-02T13:09:00.074Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/74/fd4c0901137c4f8d81a76ada99e43c65163b4c94a02ece107a4ec0c6b615/coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b75ee5e8cb7575636ac598719b4307ac529ec8fcd79608a35c3cd4d4dada812d", size = 220838, upload-time = "2026-07-02T13:09:02.084Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2e/2347583467bd7f0402635101a916961915cc68fce652cd0db5f173ea04fc/coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffb31267816b93b075302248cc1737506081b4f163df4401e9df1a6424aafabe", size = 221197, upload-time = "2026-07-02T13:09:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/17/99fa688541ae1d6e84543a0e544f83de0c944815b63e9e7b1ed411d15036/coverage-7.15.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4d0bb73455bf97ab243a8f12c37c686ccf1c13bb614b7b85f1d062f06f42b2c", size = 252705, upload-time = "2026-07-02T13:09:05.059Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/02/6a95a5cd83b74839017ef9cf48d2d8c9ae60af919e17a3f336e6f9f1b7bd/coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4", size = 255441, upload-time = "2026-07-02T13:09:06.559Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f2/406f6c57d600f68185942422c4c00f1a3255d60aee6e5fd961425cd9987e/coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20c8a976c365c8cb12f0cbd099508772ea41fb5fa80657a8506df0e11bd278c5", size = 256556, upload-time = "2026-07-02T13:09:08.197Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/d3fa48489c15ecdec1ba48fd61f68798555dddd2f6716f9ad42adeb1a2a9/coverage-7.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f948fd5ba1b9cbca91f0ae08b4c1ce2b139509149a435e2585d056d57d70bf01", size = 258815, upload-time = "2026-07-02T13:09:09.691Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/2d40ddd110462c6a2769677cf7f1c119a52b45f568978fc6c98e4cc0dd0f/coverage-7.15.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f58185f06edf6ad68ec9fb155d63ef650c82f3fbd7e1770e2867751fb13158f4", size = 253117, upload-time = "2026-07-02T13:09:11.212Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c0/310782f0d7c3cb2b5ac05ba8d205fe91f24a36f6bf3256098f1782181c38/coverage-7.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02adc79a920c73c647c5d117f55747df7f2de94571884758ce8bc58e04f0a796", size = 254475, upload-time = "2026-07-02T13:09:13.029Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f7/702da6c275f8ae6ade423d2877243122932c9b27f5403003b9ef8c927d12/coverage-7.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6eb7c300fbed667fd6e3588eba71c1904cdb06110ca6fdf908c26bdd88b8e382", size = 252619, upload-time = "2026-07-02T13:09:14.699Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/84/c5b15a7e5ecba4e56218d772d99fe80a63e63f8d11f12783723a6005ab45/coverage-7.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b5fb23fa2de9dce1f5c36c09066d8fcda16cd96e8e26686caa2d7cb9b567d65c", size = 256689, upload-time = "2026-07-02T13:09:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2f/c8b07559b57701230c61b23a953858c052890c12ef568d81780c6c46e92e/coverage-7.15.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cec79341dbe6281484024979976d0c7f22beae08b4a254655decd25d42cbe766", size = 252189, upload-time = "2026-07-02T13:09:17.828Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/80/6d2f049dd3fd3dbfd60b62ba6b2162a04009e2c002ce70b24cf3878dec7a/coverage-7.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c664c5444b1d970b1b2a450e21fb19ee5c9cfdf151ded2dda37260031cca0da", size = 254059, upload-time = "2026-07-02T13:09:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/92/b0287a2c42031d25c628f815f89a3cd9f8268ee78bb1252c9356cda1c689/coverage-7.15.0-cp312-cp312-win32.whl", hash = "sha256:5f764a3fa339bde6b3aa97657f5a6a3a9451e4a5b4ea98a2892c773a43525f77", size = 222893, upload-time = "2026-07-02T13:09:20.812Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/69/e34c481915fecb499b3146975061dac528752e37706edc1804f32c822469/coverage-7.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:52f9a4d2c4c56c8848bc2f524916698354b0211488b38c49ad9ae54f6cafbff6", size = 223429, upload-time = "2026-07-02T13:09:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/98/6e878f0b571d32684ef3f38d7c03db241ca5b82a5da8a5391596a8f209c4/coverage-7.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:31e5c3e70c85307ea35a12964e2e40f56ca2ee4b1c8c721ccf4609d17071080b", size = 222810, upload-time = "2026-07-02T13:09:23.812Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/145a3748098bcc86b631a85408d2c3dc5c104e0bd86d605468239b25b6c4/coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782", size = 220863, upload-time = "2026-07-02T13:09:25.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/4ed55708fed2c64b63c9bc5715daef670872202101938869b7fe5d5fbb8f/coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430", size = 221230, upload-time = "2026-07-02T13:09:26.897Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/3a80b97d3b2a5c77a01ae359c6bed20c13738fe3d9380f08616d4fec0281/coverage-7.15.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bbcbb317c2e5ded5b21104af81c29f391be2af98d065693ffbe8d23949b948e5", size = 252227, upload-time = "2026-07-02T13:09:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/b70062750686bd7da454da27927622f48bbac6990ac7a4c4a4653e7b0036/coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970", size = 254823, upload-time = "2026-07-02T13:09:30.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/09/dad6a75a2e561b9dc5086a8c5257a7591d584246f67e23e70d2995b89ab6/coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c", size = 256059, upload-time = "2026-07-02T13:09:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e7/b5d2941fa9564573d44b693a871ff3156f0c42cbefe977a09fa7fdc59971/coverage-7.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5cf007add5ab4bb8fa9f4c77e3732127c9e6cad501d7db43355fbfafca0be84", size = 258190, upload-time = "2026-07-02T13:09:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1d/8e895bcde3c57ccd46d896dda5f2b3d5df761a1b0c6c9d450d175dedc632/coverage-7.15.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc78d9843bd576fbe2118248258d485e968dc535f95ed504a7b0867ba9b51389", size = 252456, upload-time = "2026-07-02T13:09:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4c/f6997da343ddeb959be82c3b05322793f92c071ad45f7cb8a96336e2dd5f/coverage-7.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a263060f1de0b4b74b4e089c2a70b8003b3781c733329a9c8fd54995328f9950", size = 254192, upload-time = "2026-07-02T13:09:37.445Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/a0bc09d032267b9da89d95a2d874cfbef2a5aebbf0e87cf7aba221d79a99/coverage-7.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c48decf16e0dfd5b049c7d5e82200c23c08126719142998d4f172444e3d0529e", size = 252153, upload-time = "2026-07-02T13:09:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c0/77fc233d9fba07b244c40948c53fe27308b8f21732fb3417f87fbd6fd992/coverage-7.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:08fb028000ed0aaa0a4cbdfbb98be7cb42f370db973fbbb469733505ab20e13e", size = 256310, upload-time = "2026-07-02T13:09:41.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/24/601cecfb5825becacb8d45219a018a3b55b9dbaec624efdb0ea249d08be2/coverage-7.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb7dc0c3b7d8a1077abea0b8546ebc5e26d6ef6ecefc2f0f5ad2b8a53bdad837", size = 251974, upload-time = "2026-07-02T13:09:42.733Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1e/6f45e5a5b3d5484318d368702af6716b5ab8913b0428bec981a562fcf296/coverage-7.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cb3602054ccbe9f0d8c2dc04bbeba90d5719236e2cd06e042ddd6d3fc7b6e37", size = 253745, upload-time = "2026-07-02T13:09:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4df027a77bd11d0e527f44c53557c76e54ad027413d0304252ea3a78d67e/coverage-7.15.0-cp313-cp313-win32.whl", hash = "sha256:0bf781da64326b677be344df505171435b6f58716108606621d5d27d964fff8b", size = 222902, upload-time = "2026-07-02T13:09:46.122Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/10/0355894d34e231f2c5449e71287e81a50793a325df2e2b027b7bcd9dfd19/coverage-7.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629", size = 223444, upload-time = "2026-07-02T13:09:47.687Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ef/bb725f263befaaff851203ab338e68af15e195d7f7b5f323162532d9b6a8/coverage-7.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3812c61afc6685c7999b39320779ab8f43b7a3081fdb0def39976e56fbdb9a21", size = 222839, upload-time = "2026-07-02T13:09:49.717Z" },
+    { url = "https://files.pythonhosted.org/packages/52/30/21b2ad45959cd50e909e02ebac1e30b4ceb7162e91c11d4c570223a458b7/coverage-7.15.0-py3-none-any.whl", hash = "sha256:56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19", size = 212632, upload-time = "2026-07-02T13:10:48.641Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "crewai"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1928,6 +1987,30 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/63/d944f387582cc53f53febbff2b3fa36a6d2ed7c1feef8990bf646cfa9cba/moto-5.2.2.tar.gz", hash = "sha256:aac8023a429e125e91c91f8f4730a67b54f518cda587352f7e67252fe3168f75", size = 8678761, upload-time = "2026-06-06T18:57:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/45/13cff46f4f617a6e97e1d497d75abd913e250bb4c823a4985668c6e593e4/moto-5.2.2-py3-none-any.whl", hash = "sha256:3817f1e39721ca833579b921e53e3b68547ace6a34d848c9486fbb5905808de9", size = 6698689, upload-time = "2026-06-06T18:57:51.435Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "msal"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2757,6 +2840,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3162,6 +3254,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3405,6 +3511,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
 ]
 
 [[package]]
@@ -3958,13 +4078,16 @@ s3 = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "boto3" },
     { name = "crewai" },
     { name = "datamodel-code-generator" },
     { name = "langchain-core" },
     { name = "langgraph" },
+    { name = "moto", extra = ["s3"] },
     { name = "openai-agents" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "semantic-kernel" },
     { name = "smolagents" },
 ]
@@ -4002,13 +4125,16 @@ provides-extras = ["dev", "s3"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "boto3", specifier = ">=1.28" },
     { name = "crewai", specifier = ">=0.80" },
     { name = "datamodel-code-generator", specifier = ">=0.63.0" },
     { name = "langchain-core", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=0.2" },
+    { name = "moto", extras = ["s3"], specifier = ">=5.0" },
     { name = "openai-agents", specifier = ">=0.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
     { name = "semantic-kernel", specifier = ">=1.20" },
     { name = "smolagents", specifier = ">=1.0" },
 ]
@@ -4492,6 +4618,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/af/d4502dc713b4ccea7175d764718d5183caf8d0867a4f0190d5d4a45cea49/werkzeug-3.1.1.tar.gz", hash = "sha256:8cd39dfbdfc1e051965f156163e2974e52c210f130810e9ad36858f0fd3edad4", size = 806453, upload-time = "2024-11-01T16:40:45.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/ea/c67e1dee1ba208ed22c06d1d547ae5e293374bfc43e0eb0ef5e262b68561/werkzeug-3.1.1-py3-none-any.whl", hash = "sha256:a71124d1ef06008baafa3d266c02f56e1836a5984afd6dd6c9230669d60d9fb5", size = 224371, upload-time = "2024-11-01T16:40:43.994Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #79

Wave-0 foundational scaffolding for the E2E Test Coverage Epic (#90), imported by downstream stories #81–#86. **Tests-only — no changes under `src/`.**

## What's here

**`tests/e2e/conftest.py`** — reusable fixtures:
- `tmp_traceforge_home` — isolated `$HOME`/`%USERPROFILE%` so anything reading `~/.traceforge` (Score API, watch daemon, gate registry, default sinks) is sandboxed; subprocesses inherit it.
- `score_server_url` — spawns `traceforge score` on a free loopback port, polls `GET /health`, yields the base URL.
- `watch_daemon` — spawns `traceforge watch --frameworks claude --no-score` against an isolated home, waits until the gate registry has a live `_default`, yields a `WatchDaemon` handle.
- `gate_socket_lookup` — `(session_id) -> sock_path | None` over the `gate_endpoints` table in the sandboxed `system.db`.
- Fixtures wrapping the fake backends: `http_poll_server`, `sse_server`, `otel_collector`, `webhook_receiver`, `fake_s3`.

**`tests/e2e/fakes/`** — reusable loopback fake servers (bind `127.0.0.1:0`, no external hosts):
- HTTP-poll server with `ETag` + `If-None-Match`/`304`.
- SSE server emitting `id`/`event`/`retry` with forced reconnect + `Last-Event-ID` resume.
- moto-backed in-memory S3.
- a POST-recording server backing both the fake OTel collector and webhook receiver (with `fail_next`/`set_status` for retry paths).

**`pyproject.toml`** — registers `e2e`, `slow`, `net`, `windows_only` markers and enables `--strict-markers`; adds `pytest-cov`, `boto3`, `moto[s3]` to the dev group so `--cov=traceforge` is runnable (no fail-under gate).

**`tests/conftest.py`** — `pytest_collection_modifyitems` hook auto-skips `windows_only` off Windows (so the Linux CI matrix skips them by design). Existing factories untouched.

**`tests/e2e/test_harness_smoke.py`** — one `@pytest.mark.e2e` smoke per fixture, each driving the **real** consumer (`HttpPollSource`, `SSESource`, `S3Sink`, `OtelExporterSink`, `WebhookSink`, the Score API subprocess, the watch daemon, the gate registry).

**`tests/README.md`** — how to run the e2e tests, the marker table, coverage command, and a fixture/fake reference.

## Validation
- Full suite (Windows): **2252 passed, 4 skipped** = baseline 2242 + 10 new smokes. On Linux CI the `windows_only` smoke skips (→ 2251 passed, 5 skipped).
- `ruff==0.15.20` `check` and `format --check` clean.
- `--cov=traceforge --cov-report=term-missing` runs and prints a number.
- No changes under `src/`.

## Notes
- **S3 uses moto `mock_aws`** (in-process, intercepts botocore across `asyncio.to_thread`) rather than a stub or server mode — real boto3 wire path, no flask/werkzeug, queryable bucket for #83.
- **One fake-server ergonomics fix while writing the SSE smoke:** `SSEServer.close_current()` is now synchronous (blocks until the closing connection's handler has exited, and won't deliver a racing enqueue on the dying connection), so reconnect/resume is deterministic for #82. No product code involved.
- **Optional CI coverage line deferred:** deliverable #4 only asks that `--cov=traceforge` be *runnable* (done via the dev group). Appending `--cov=traceforge --cov-report=term-missing` to `.github/workflows/ci-test.yml` would surface the % in CI but touches product CI, so I left it out to keep this story strictly tests-only — happy to add the one-liner if you want it.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>