### PR TITLE
ci: surface traceforge coverage in the CI test job (#79)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --group dev
-      - run: uv run pytest --tb=short -q
+      - run: uv run pytest --tb=short -q --cov=traceforge --cov-report=term-missing
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #94 (which merged the #79 harness before this line was added).

Single strictly-additive change: append `--cov=traceforge --cov-report=term-missing` to the existing pytest invocation in the **test** job of `.github/workflows/ci-test.yml`, so the coverage number is visible in the CI summary. This completes item 4 of #79 ("coverage visible in CI").

- No `--cov-fail-under` gate.
- `pytest-cov` is already in the dev group (added in #94), so `uv sync --group dev` already covers it.
- Matrix, the `build` job, and everything else are untouched.

Verified locally with the exact CI command:

```
uv run pytest --tb=short -q --cov=traceforge --cov-report=term-missing
→ 2252 passed, 4 skipped; TOTAL coverage 81%
```

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
