### PR TITLE
test(e2e): file & local source I/O coverage (#81)

### DIFF
--- a/tests/e2e/test_auto_detect_e2e.py
+++ b/tests/e2e/test_auto_detect_e2e.py
@@ -1,0 +1,161 @@
+"""End-to-end tests for framework auto-detection (issue #81, Wave 2).
+
+``detect_frameworks`` scans OS-specific home / app-data locations and honored
+environment variables to discover installed agent frameworks. These tests build
+fake install trees under the sandboxed ``$HOME`` provided by
+``tmp_traceforge_home`` (which also scrubs ``CODEX_HOME`` /
+``CONTINUE_GLOBAL_DIR`` and redirects ``APPDATA`` / ``LOCALAPPDATA``), then
+assert each framework is discovered with the correct path, adapter, and
+ingestion mode — plus the env-var overrides, the framework filter, and the
+none-installed empty case.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from pathlib import Path
+
+import pytest
+
+from traceforge.sources.auto_detect import detect_frameworks
+
+pytestmark = pytest.mark.e2e
+
+
+def _framework_layout(home: Path) -> dict[str, tuple[Path, bool, str, str]]:
+    """Map framework name → (path_to_create, is_file, adapter, ingestion_mode).
+
+    Mirrors the OS-specific lookups in ``auto_detect`` so the fake install tree
+    lands exactly where the detector looks on the running platform. The app-data
+    roots resolve under ``home`` because ``tmp_traceforge_home`` points
+    ``APPDATA``/``LOCALAPPDATA`` there on Windows and ``$HOME`` there on POSIX.
+    """
+    system = platform.system()
+    if system == "Darwin":
+        app_support = home / "Library" / "Application Support"
+        global_storage = app_support / "Code" / "User" / "globalStorage"
+        goose_dir = app_support / "Block" / "goose"
+        amazonq_dir = app_support / "amazon-q"
+    elif system == "Windows":
+        appdata = Path(os.environ["APPDATA"])
+        localappdata = Path(os.environ["LOCALAPPDATA"])
+        global_storage = appdata / "Code" / "User" / "globalStorage"
+        goose_dir = localappdata / "Block" / "goose"
+        amazonq_dir = localappdata / "amazon-q"
+    else:  # Linux / other POSIX
+        global_storage = home / ".config" / "Code" / "User" / "globalStorage"
+        goose_dir = home / ".local" / "share" / "goose"
+        amazonq_dir = home / ".local" / "share" / "amazon-q"
+
+    return {
+        "claude": (home / ".claude" / "projects", False, "claude", "file_watch"),
+        "codex": (home / ".codex" / "sessions", False, "codex", "file_watch"),
+        "continue": (home / ".continue" / "sessions", False, "continue", "file_watch"),
+        "cline": (
+            global_storage / "saoudrizwan.claude-dev" / "tasks",
+            False,
+            "cline",
+            "file_watch",
+        ),
+        "goose": (goose_dir / "sessions", False, "goose", "poll"),
+        "amazonq": (amazonq_dir / "data.sqlite3", True, "amazonq", "sqlite"),
+    }
+
+
+def _install(path: Path, is_file: bool) -> None:
+    if is_file:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"")
+    else:
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def _same_path(a: Path, b: Path) -> bool:
+    return os.path.normcase(str(a)) == os.path.normcase(str(b))
+
+
+def test_none_installed_returns_empty(
+    tmp_traceforge_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Detection also probes the CWD for aider; run from a clean empty dir so a
+    # stray .aider.chat.history.md in the repo can't leak into the result.
+    monkeypatch.chdir(tmp_path)
+    assert detect_frameworks() == []
+
+
+def test_each_framework_detected_with_path_adapter_mode(
+    tmp_traceforge_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)  # keep aider (CWD-based) out of this home-based scan
+    layout = _framework_layout(tmp_traceforge_home)
+    for path, is_file, _adapter, _mode in layout.values():
+        _install(path, is_file)
+
+    detected = {d.name: d for d in detect_frameworks()}
+
+    assert set(detected) == set(layout)
+    for name, (path, _is_file, adapter, mode) in layout.items():
+        found = detected[name]
+        assert _same_path(found.path, path), f"{name}: {found.path} != {path}"
+        assert found.adapter == adapter
+        assert found.ingestion_mode == mode
+
+
+def test_codex_home_env_var_is_honored(
+    tmp_traceforge_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    custom = tmp_traceforge_home / "xdg-codex"
+    (custom / "sessions").mkdir(parents=True)
+    monkeypatch.setenv("CODEX_HOME", str(custom))
+
+    detected = detect_frameworks(["codex"])
+    assert len(detected) == 1
+    assert _same_path(detected[0].path, custom / "sessions")
+
+
+def test_continue_global_dir_env_var_is_honored(
+    tmp_traceforge_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    custom = tmp_traceforge_home / "xdg-continue"
+    (custom / "sessions").mkdir(parents=True)
+    monkeypatch.setenv("CONTINUE_GLOBAL_DIR", str(custom))
+
+    detected = detect_frameworks(["continue"])
+    assert len(detected) == 1
+    assert _same_path(detected[0].path, custom / "sessions")
+
+
+def test_framework_filter_limits_detection(tmp_traceforge_home: Path) -> None:
+    layout = _framework_layout(tmp_traceforge_home)
+    for path, is_file, _adapter, _mode in layout.values():
+        _install(path, is_file)
+
+    detected = detect_frameworks(["claude", "goose"])
+    assert sorted(d.name for d in detected) == ["claude", "goose"]
+
+
+def test_unknown_framework_in_filter_is_ignored(tmp_traceforge_home: Path) -> None:
+    layout = _framework_layout(tmp_traceforge_home)
+    path, is_file, _adapter, _mode = layout["claude"]
+    _install(path, is_file)
+
+    detected = detect_frameworks(["claude", "does-not-exist"])
+    assert [d.name for d in detected] == ["claude"]
+
+
+def test_aider_detected_from_cwd(
+    tmp_traceforge_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    history = project / ".aider.chat.history.md"
+    history.write_text("# aider chat history\n", encoding="utf-8")
+    monkeypatch.chdir(project)
+
+    detected = detect_frameworks(["aider"])
+    assert len(detected) == 1
+    assert detected[0].name == "aider"
+    assert detected[0].adapter == "aider_markdown"
+    assert detected[0].ingestion_mode == "file_watch"
+    assert _same_path(detected[0].path, history)

--- a/tests/e2e/test_file_poll_source_e2e.py
+++ b/tests/e2e/test_file_poll_source_e2e.py
@@ -1,0 +1,160 @@
+"""End-to-end tests for FilePollSource (issue #81, Wave 2 file/local edge).
+
+``FilePollSource`` is the interval-poll fallback for files that OS-native
+watching can't cover (NFS/SMB mounts): it reopens/reads on a fixed cadence and
+detects rotation/truncation via inode identity and size. These tests exercise
+the *real* polling loop against *real* files with a short interval so they stay
+fast and deterministic while still crossing the actual disk I/O boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from traceforge.sources.base import RawRecord
+from traceforge.sources.file_poll import FilePollSource
+
+pytestmark = pytest.mark.e2e
+
+_TIMEOUT = 8.0
+_INTERVAL = 0.02
+
+
+def _append(path: Path, text: str) -> None:
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        handle.write(text)
+        handle.flush()
+
+
+async def _next(stream: AsyncIterator[RawRecord], timeout: float = _TIMEOUT) -> RawRecord:
+    return await asyncio.wait_for(stream.__anext__(), timeout=timeout)
+
+
+def _atomic_replace(src: Path, dst: Path, attempts: int = 100) -> None:
+    """Rename ``src`` over ``dst`` (guaranteeing a distinct inode), retrying the
+    brief Windows window in which a poll may hold the target open for reading."""
+    for _ in range(attempts):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            time.sleep(0.01)
+    os.replace(src, dst)
+
+
+async def test_new_lines_detected_on_next_interval(tmp_path: Path) -> None:
+    log = tmp_path / "poll.log"
+    log.write_text("existing\n", encoding="utf-8")
+
+    async with FilePollSource(log, name="fp", interval=_INTERVAL) as source:
+        stream = source.__aiter__()
+        r0 = await _next(stream)
+        assert r0.payload == "existing"
+        assert r0.mode == "poll"
+        assert r0.source_name == "fp"
+
+        _append(log, "fresh-1\nfresh-2\n")
+        r1 = await _next(stream)
+        r2 = await _next(stream)
+
+    assert [r1.payload, r2.payload] == ["fresh-1", "fresh-2"]
+    assert [r0.sequence, r1.sequence, r2.sequence] == [0, 1, 2]
+
+
+async def test_truncation_resets_offset(tmp_path: Path) -> None:
+    log = tmp_path / "poll.log"
+    log.write_text("aaaaaaaaaa\nbbbbbbbbbb\n", encoding="utf-8")
+
+    async with FilePollSource(log, name="fp", interval=_INTERVAL) as source:
+        stream = source.__aiter__()
+        assert (await _next(stream)).payload == "aaaaaaaaaa"
+        assert (await _next(stream)).payload == "bbbbbbbbbb"
+
+        # Shrink far below the current offset: detected as truncation → re-read
+        # from the start of the new (shorter) content.
+        log.write_text("c\n", encoding="utf-8")
+        rotated = await _next(stream)
+
+    assert rotated.payload == "c"
+
+
+async def test_inode_change_is_treated_as_rotation(tmp_path: Path) -> None:
+    log = tmp_path / "poll.log"
+    log.write_text("v1\n", encoding="utf-8")
+
+    async with FilePollSource(log, name="fp", interval=_INTERVAL) as source:
+        stream = source.__aiter__()
+        assert (await _next(stream)).payload == "v1"
+
+        # Replace the file with a *distinct inode* whose content is longer than
+        # the current offset, so only the inode change (not a size drop) can
+        # trigger the reset. Renaming a sibling guarantees a new inode even on
+        # Linux, where a plain unlink+recreate frequently reuses the number.
+        replacement = tmp_path / "poll.log.rotated"
+        replacement.write_text("rotated-content-line\n", encoding="utf-8")
+        _atomic_replace(replacement, log)
+
+        record = await _next(stream)
+
+    assert record.payload == "rotated-content-line"
+
+
+async def test_missing_error_raises_on_enter(tmp_path: Path) -> None:
+    source = FilePollSource(tmp_path / "nope.log", name="fp", missing="error")
+    with pytest.raises(FileNotFoundError):
+        async with source:
+            pass
+
+
+async def test_missing_wait_tolerates_absent_then_created_file(tmp_path: Path) -> None:
+    log = tmp_path / "late.log"  # does not exist at enter time
+
+    async with FilePollSource(log, name="fp", interval=_INTERVAL, missing="wait") as source:
+        stream = source.__aiter__()
+        # The source polls a missing file without raising until it appears.
+        await asyncio.sleep(_INTERVAL * 3)
+        log.write_text("arrived\n", encoding="utf-8")
+        record = await _next(stream)
+
+    assert record.payload == "arrived"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "bug: FilePollSource crashes on invalid UTF-8 instead of logging and "
+        "continuing. _read_from_offset (src/traceforge/sources/file_poll.py:113-118) "
+        "opens with the default errors='strict', while _poll_once (lines 92-98) "
+        "only catches (FileNotFoundError, OSError); a UnicodeDecodeError therefore "
+        "propagates out of the async iterator and kills the poll loop."
+    ),
+)
+async def test_invalid_utf8_is_logged_not_crashed(tmp_path: Path) -> None:
+    log = tmp_path / "poll.log"
+    log.write_bytes(b"valid\n")
+
+    seen: list[str] = []
+    async with FilePollSource(log, name="fp", interval=_INTERVAL) as source:
+        stream = source.__aiter__()
+        seen.append((await _next(stream)).payload)  # "valid"
+
+        with log.open("ab") as handle:
+            handle.write(b"\xff\xfe not utf-8\nafter\n")
+
+        # Desired behavior: the decode failure is logged and the source keeps
+        # polling, eventually surfacing the later valid line. Stop on the first
+        # idle poll so the assertion works whether a fix skips or replaces the
+        # bad bytes.
+        for _ in range(3):
+            try:
+                seen.append((await _next(stream, timeout=2.0)).payload)
+            except (asyncio.TimeoutError, StopAsyncIteration):
+                break
+
+    assert "after" in seen

--- a/tests/e2e/test_file_watch_source_e2e.py
+++ b/tests/e2e/test_file_watch_source_e2e.py
@@ -1,0 +1,138 @@
+"""End-to-end tests for FileWatchSource (issue #81, Wave 2 file/local edge).
+
+``FileWatchSource`` is the PRIMARY live path for CLI agents: it tails a file via
+watchdog's OS-native filesystem events (inotify / ReadDirectoryChangesW /
+FSEvents) and emits one ``RawRecord`` per appended line. These tests drive the
+*real* observer against *real* files on the local disk — no watchdog mocking — so
+a green run proves the append→record path, the rotation/truncation reopen, and
+clean observer teardown against actual OS semantics.
+
+Determinism: every record is awaited with a bounded ``asyncio.wait_for`` timeout,
+and truncation is forced by shrinking the file far below its previous size so the
+size drop is unambiguous regardless of how the OS coalesces change events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from traceforge.sources.base import RawRecord
+from traceforge.sources.file_watch import FileWatchSource
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+_TIMEOUT = 10.0
+
+
+def _append(path: Path, text: str) -> None:
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        handle.write(text)
+        handle.flush()
+
+
+async def _next(stream: AsyncIterator[RawRecord], timeout: float = _TIMEOUT) -> RawRecord:
+    return await asyncio.wait_for(stream.__anext__(), timeout=timeout)
+
+
+async def test_append_emits_records_with_monotonic_sequence(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_text("preexisting\n", encoding="utf-8")
+
+    async with FileWatchSource(log, name="fw", start_at="end") as source:
+        stream = source.__aiter__()
+
+        _append(log, "first\n")
+        r0 = await _next(stream)
+
+        _append(log, "second\nthird\n")
+        r1 = await _next(stream)
+        r2 = await _next(stream)
+
+    records = (r0, r1, r2)
+    assert [r.payload for r in records] == ["first", "second", "third"]
+    assert all(r.mode == "file_watch" for r in records)
+    assert all(r.source_name == "fw" for r in records)
+    assert [r.sequence for r in records] == [0, 1, 2]
+    # start_at="end" must not replay content that predated the observer.
+    assert "preexisting" not in [r.payload for r in records]
+
+
+async def test_truncation_reopens_from_beginning(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_text("seed-line-one\nseed-line-two\n", encoding="utf-8")
+
+    async with FileWatchSource(log, name="fw", start_at="end") as source:
+        stream = source.__aiter__()
+
+        _append(log, "before-rotate\n")
+        before = await _next(stream)
+        assert before.payload == "before-rotate"
+
+        # Rewrite with far less content: the size drop is detected as a
+        # truncation and the source reopens from offset 0.
+        log.write_text("after\n", encoding="utf-8")
+        after = await _next(stream)
+
+    assert after.payload == "after"
+    assert after.mode == "file_watch"
+    # The sequence stays monotonic across the reopen (it does not reset).
+    assert after.sequence == before.sequence + 1
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "Windows denies unlink/replace of a file held open for reading by the "
+        "watch source (WinError 32); delete+recreate rotation is POSIX file "
+        "semantics. Windows rotation handling is covered by "
+        "test_truncation_reopens_from_beginning."
+    ),
+)
+async def test_delete_and_recreate_rotation(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_text("seed\n", encoding="utf-8")
+
+    async with FileWatchSource(log, name="fw", start_at="end") as source:
+        stream = source.__aiter__()
+
+        _append(log, "pre-rotation\n")
+        before = await _next(stream)
+        assert before.payload == "pre-rotation"
+
+        # Replace the inode entirely, the way an external log rotation would.
+        log.unlink()
+        log.write_text("post-rotation\n", encoding="utf-8")
+        _append(log, "post-rotation-more\n")
+
+        after = await _next(stream)
+
+    assert after.payload == "post-rotation"
+    assert after.mode == "file_watch"
+    assert after.sequence == before.sequence + 1
+
+
+async def test_teardown_stops_observer_without_leaking_threads(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_text("", encoding="utf-8")
+
+    await asyncio.sleep(0)  # let any pending callbacks settle before counting
+    threads_before = threading.active_count()
+
+    source = FileWatchSource(log, name="fw", start_at="end")
+    async with source:
+        stream = source.__aiter__()
+        _append(log, "line\n")
+        record = await _next(stream)
+        assert record.payload == "line"
+        assert source._observer is not None  # observer thread running while entered
+
+    await asyncio.sleep(0.2)  # observer.join runs in __aexit__; allow it to settle
+    assert source._observer is None
+    # The observer thread created on entry must be gone after teardown.
+    assert threading.active_count() <= threads_before

--- a/tests/e2e/test_sqlite_source_e2e.py
+++ b/tests/e2e/test_sqlite_source_e2e.py
@@ -1,0 +1,176 @@
+"""End-to-end tests for SqliteSource advanced query features (issue #81).
+
+The basic read/poll behavior of ``SqliteSource`` is covered by
+``tests/test_sqlite_source.py``; this file exercises the advanced knobs the
+Copilot CLI ``session-store.db`` integration depends on, against a *real*
+on-disk SQLite database: ``session_filter``, a raw ``where`` clause, explicit
+``columns`` selection, a timestamp ``order_column`` cursor, and a 1000+ row
+batch read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from traceforge.sources.base import RawRecord
+from traceforge.sources.sqlite import SqliteSource
+
+pytestmark = pytest.mark.e2e
+
+_TIMEOUT = 15.0
+
+
+async def _collect(source: SqliteSource, count: int, timeout: float = _TIMEOUT) -> list[RawRecord]:
+    out: list[RawRecord] = []
+    stream = source.__aiter__()
+    for _ in range(count):
+        out.append(await asyncio.wait_for(stream.__anext__(), timeout=timeout))
+    return out
+
+
+@pytest.fixture
+def events_db(tmp_path: Path) -> Path:
+    """A small ``turns`` table spanning two sessions, roles, and timestamps."""
+    db = tmp_path / "session-store.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE turns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO turns (session_id, role, content, created_at) VALUES (?, ?, ?, ?)",
+        [
+            ("sess-a", "user", "hello a", "2026-01-01T00:00:01Z"),
+            ("sess-b", "user", "hello b", "2026-01-01T00:00:02Z"),
+            ("sess-a", "assistant", "reply a", "2026-01-01T00:00:03Z"),
+            ("sess-b", "assistant", "reply b", "2026-01-01T00:00:04Z"),
+            ("sess-a", "user", "second a", "2026-01-01T00:00:05Z"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+async def test_session_filter_only_yields_matching_session(events_db: Path) -> None:
+    source = SqliteSource(
+        events_db, name="sql", table="turns", start_at="beginning", session_filter="sess-a"
+    )
+    async with source:
+        records = await _collect(source, 3)
+
+    payloads = [json.loads(r.payload) for r in records]
+    assert {p["session_id"] for p in payloads} == {"sess-a"}
+    assert [p["content"] for p in payloads] == ["hello a", "reply a", "second a"]
+    assert all(r.mode == "sqlite" for r in records)
+
+
+async def test_where_clause_filters_rows(events_db: Path) -> None:
+    source = SqliteSource(
+        events_db, name="sql", table="turns", start_at="beginning", where="role = 'assistant'"
+    )
+    async with source:
+        records = await _collect(source, 2)
+
+    payloads = [json.loads(r.payload) for r in records]
+    assert [p["role"] for p in payloads] == ["assistant", "assistant"]
+    assert [p["content"] for p in payloads] == ["reply a", "reply b"]
+
+
+async def test_column_selection_limits_payload_keys(events_db: Path) -> None:
+    source = SqliteSource(
+        events_db,
+        name="sql",
+        table="turns",
+        start_at="beginning",
+        columns=["id", "session_id", "content"],
+    )
+    async with source:
+        records = await _collect(source, 1)
+
+    payload = json.loads(records[0].payload)
+    assert set(payload) == {"id", "session_id", "content"}
+    assert "created_at" not in payload
+    assert "role" not in payload
+
+
+async def test_where_columns_and_session_filter_combine(events_db: Path) -> None:
+    source = SqliteSource(
+        events_db,
+        name="sql",
+        table="turns",
+        start_at="beginning",
+        columns=["session_id", "role", "content"],
+        where="role = 'user'",
+        session_filter="sess-a",
+    )
+    async with source:
+        records = await _collect(source, 2)
+
+    payloads = [json.loads(r.payload) for r in records]
+    assert all(set(p) == {"session_id", "role", "content"} for p in payloads)
+    assert all(p["session_id"] == "sess-a" and p["role"] == "user" for p in payloads)
+    assert [p["content"] for p in payloads] == ["hello a", "second a"]
+
+
+async def test_timestamp_order_column_tracks_new_rows(events_db: Path) -> None:
+    # start_at="end" seeds the cursor from MAX(created_at); only a row with a
+    # strictly later timestamp should surface.
+    source = SqliteSource(
+        events_db,
+        name="sql",
+        table="turns",
+        order_column="created_at",
+        start_at="end",
+        interval=0.02,
+    )
+    async with source:
+        stream = source.__aiter__()
+        conn = sqlite3.connect(str(events_db))
+        conn.execute(
+            "INSERT INTO turns (session_id, role, content, created_at) "
+            "VALUES ('sess-c', 'user', 'newest', '2026-06-01T00:00:00Z')"
+        )
+        conn.commit()
+        conn.close()
+        record = await asyncio.wait_for(stream.__anext__(), timeout=_TIMEOUT)
+
+    payload = json.loads(record.payload)
+    assert payload["content"] == "newest"
+    assert payload["created_at"] == "2026-06-01T00:00:00Z"
+
+
+async def test_large_batch_reads_all_rows_in_order(tmp_path: Path) -> None:
+    db = tmp_path / "big.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE turns (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, content TEXT)"
+    )
+    total = 1500
+    conn.executemany(
+        "INSERT INTO turns (session_id, content) VALUES (?, ?)",
+        [("sess", f"msg-{i}") for i in range(total)],
+    )
+    conn.commit()
+    conn.close()
+
+    source = SqliteSource(db, name="sql", table="turns", start_at="beginning", interval=0.02)
+    async with source:
+        records = await _collect(source, total)
+
+    assert len(records) == total
+    assert [r.sequence for r in records] == list(range(total))
+    assert json.loads(records[0].payload)["content"] == "msg-0"
+    assert json.loads(records[-1].payload)["content"] == f"msg-{total - 1}"


### PR DESCRIPTION
Closes #81

Wave 2 of the E2E Test Coverage Epic (#90) — the 🔴 file/local ingestion edge. Adds real-I/O end-to-end tests for the four file/local source surfaces. **Tests only; no changes under `src/`, `pyproject.toml`, or workflows.** Built on the already-merged Wave-0 harness (`tests/e2e/conftest.py`); deterministic (short intervals, bounded `asyncio.wait_for` waits) and network-free.

## New files (all marked `e2e`)
- `tests/e2e/test_file_watch_source_e2e.py` — `FileWatchSource` (real watchdog observer)
  - append → `RawRecord` (`mode="file_watch"`, monotonic sequence)
  - truncation → reopen from beginning (sequence stays monotonic)
  - delete + recreate rotation (new inode)
  - teardown stops the observer cleanly (no leaked threads)
- `tests/e2e/test_file_poll_source_e2e.py` — `FilePollSource`
  - new lines detected on next interval; truncation resets offset
  - inode change = rotation (via `os.replace` of a sibling → guaranteed distinct inode, robust to Linux inode reuse)
  - `missing="error"` raises on enter vs `missing="wait"` tolerates absent-then-created
  - **`xfail(strict=True)`** pinning an invalid-UTF-8 crash (see bug below)
- `tests/e2e/test_sqlite_source_e2e.py` — `SqliteSource` advanced: `session_filter`, `where`, `columns` selection, timestamp `order_column` cursor, 1000+ row batch
- `tests/e2e/test_auto_detect_e2e.py` — `detect_frameworks`: sandboxed-home discovery of every framework with correct path/adapter/mode, `$CODEX_HOME`/`$CONTINUE_GLOBAL_DIR` overrides, framework filter, none-installed → empty, aider CWD detection

## Suite delta (Windows local)
`2561 → 2582 passed`, `4 → 5 skipped`, `4 → 5 xfailed` — **+21 passed, +1 skipped, +1 xfailed**. Pure addition; the 4 pre-existing `#92` xfails are untouched. `ruff check` + `ruff format --check` clean (0.15.20).

## Product bug found (reported, not fixed)
`FilePollSource` **crashes on invalid UTF-8** instead of logging and continuing (issue #81 requires "logged not crashed"). `_read_from_offset` (`src/traceforge/sources/file_poll.py:113-118`) opens with the default `errors="strict"`, and `_poll_once` (`src/traceforge/sources/file_poll.py:92-98`) only catches `(FileNotFoundError, OSError)`, so a `UnicodeDecodeError` propagates out of the async iterator and kills the poll loop. Pinned via `xfail(strict=True)` in `test_invalid_utf8_is_logged_not_crashed`.

## Deviation
`test_delete_and_recreate_rotation` (FileWatch) is `skipif(win32)`: Windows forbids `unlink`/`replace` of a file held open for reading by the source (WinError 32), so true delete+recreate is POSIX file semantics. Windows rotation handling is still covered by the truncation-reopen test. This test runs on CI (ubuntu 3.11/3.12/3.13).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>