### PR TITLE
Add e2e network-source I/O tests for HttpPoll and SSE (#82)

### DIFF
--- a/tests/e2e/test_http_poll_source_e2e.py
+++ b/tests/e2e/test_http_poll_source_e2e.py
@@ -1,0 +1,213 @@
+"""End-to-end I/O tests for :class:`traceforge.sources.http_poll.HttpPollSource` (issue #82).
+
+Every test drives the *real* source against a loopback HTTP fake (never an external host),
+so a green run proves the source's conditional-GET caching, cursor pagination, retry, and
+error handling against actual wire behavior. The ``http_poll_server`` fixture (see
+``tests/e2e/conftest.py``) supplies an ETag-aware server; the ``_FlakyPollServer`` below is a
+local variant that injects ``500``s to exercise the retry path.
+
+Bullets covered (issue #82, HttpPoll):
+* ``200`` + ETag → record
+* ``If-None-Match`` → ``304`` → no record
+* new ETag → record
+* cursor header propagated to the next request
+* ``500`` → retry (backoff) → succeed
+* bad URL logged, not crashed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections.abc import Callable
+
+import pytest
+
+from tests.e2e.fakes._http import SilentHandler, ThreadedHTTPFake
+from tests.e2e.fakes.http_poll import HttpPollServer
+from traceforge.sources.http_poll import HttpPollSource
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _anext(stream, timeout: float = 10.0):
+    """Pull the next record from an async source iterator, with a bounded wait."""
+    return await asyncio.wait_for(stream.__anext__(), timeout=timeout)
+
+
+async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0, poll: float = 0.01) -> None:
+    """Spin until ``pred()`` is true (yielding control), or fail after ``timeout``."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not pred():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError(f"condition not met within {timeout}s")
+        await asyncio.sleep(poll)
+
+
+class _FlakyPollHandler(SilentHandler):
+    """Serve ``500`` for the first ``fail_remaining`` GETs, then a normal ``200`` body."""
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib handler contract)
+        fake: _FlakyPollServer = self.server.fake  # type: ignore[attr-defined]
+        with fake._lock:
+            fake.request_count += 1
+            fail = fake.fail_remaining > 0
+            if fail:
+                fake.fail_remaining -= 1
+        if fail:
+            self.send_response(500)
+            self.end_headers()
+            return
+        payload = fake.body.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        try:
+            self.wfile.write(payload)
+        except (BrokenPipeError, ConnectionError):
+            pass
+
+
+class _FlakyPollServer(ThreadedHTTPFake):
+    """A loopback endpoint that returns N transient ``500``s before succeeding."""
+
+    handler_class = _FlakyPollHandler
+
+    def __init__(self, body: str, *, fail_times: int) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self.body = body
+        self.fail_remaining = fail_times
+        self.request_count = 0
+
+
+# ─── 200 + ETag → record ─────────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_http_poll_first_response_emits_record(http_poll_server: HttpPollServer) -> None:
+    http_poll_server.set_body('{"n": 1}')
+
+    async with HttpPollSource(
+        http_poll_server.url, name="poll-first", interval=0.02, max_retries=0
+    ) as src:
+        stream = src.__aiter__()
+        rec = await _anext(stream)
+
+    assert rec.payload == '{"n": 1}'
+    assert rec.source_name == "poll-first"
+    assert rec.mode == "poll"
+    assert rec.sequence == 0
+    # The very first request carries no cache validators (nothing learned yet).
+    assert http_poll_server.request_count == 1
+    assert "if-none-match" not in http_poll_server.last_headers
+    assert "if-modified-since" not in http_poll_server.last_headers
+
+
+# ─── If-None-Match → 304 → no record; then new ETag → record ─────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_http_poll_304_suppresses_then_new_etag_emits(
+    http_poll_server: HttpPollServer,
+) -> None:
+    http_poll_server.set_body('{"v": 1}')
+
+    async with HttpPollSource(
+        http_poll_server.url, name="poll-304", interval=0.01, max_retries=0
+    ) as src:
+        stream = src.__aiter__()
+        first = await _anext(stream)
+        assert first.payload == '{"v": 1}'
+
+        # Body unchanged → the source keeps polling conditionally and gets 304s, which
+        # must NOT surface a record. Drive that with an outstanding pull that stays pending.
+        pending = asyncio.ensure_future(stream.__anext__())
+        start = http_poll_server.request_count
+        await _wait_until(lambda: http_poll_server.request_count >= start + 2, timeout=5)
+        assert http_poll_server.last_headers.get("if-none-match") == http_poll_server.etag
+        assert not pending.done()  # every conditional poll returned 304 → still no record
+
+        # A fresh body (new ETag) unblocks exactly one new record.
+        http_poll_server.set_body('{"v": 2}')
+        second = await asyncio.wait_for(pending, timeout=10)
+
+    assert second.payload == '{"v": 2}'
+    assert second.sequence == first.sequence + 1
+
+
+# ─── cursor header propagated to the next request ────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_http_poll_propagates_cursor_header() -> None:
+    server = HttpPollServer(body='{"page": 1}', cursor_header="X-Cursor")
+    server.set_body('{"page": 1}', cursor="cursor-1")
+    server.start()
+    try:
+        async with HttpPollSource(
+            server.url,
+            name="poll-cursor",
+            interval=0.01,
+            cursor_header="X-Cursor",
+            max_retries=0,
+        ) as src:
+            stream = src.__aiter__()
+            first = await _anext(stream)
+            server.set_body('{"page": 2}', cursor="cursor-2")
+            second = await _anext(stream)
+    finally:
+        server.stop()
+
+    assert [first.payload, second.payload] == ['{"page": 1}', '{"page": 2}']
+    # The cursor advertised on response #1 must be echoed back as a header on request #2.
+    assert server.last_headers.get("x-cursor") == "cursor-1"
+
+
+# ─── 500 → retry (backoff) → succeed ─────────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_http_poll_retries_on_500_then_succeeds() -> None:
+    # NOTE: HttpPollSource's retry backoff is product-hardcoded (min(2**attempt, 30)); a single
+    # retry therefore costs ~1s of real sleep. One injected failure keeps this bounded and fast.
+    server = _FlakyPollServer('{"ok": true}', fail_times=1)
+    server.start()
+    try:
+        async with HttpPollSource(
+            server.url, name="poll-retry", interval=0.01, max_retries=3
+        ) as src:
+            stream = src.__aiter__()
+            rec = await asyncio.wait_for(stream.__anext__(), timeout=15)
+    finally:
+        server.stop()
+
+    assert rec.payload == '{"ok": true}'
+    assert server.request_count == 2  # one transient 500 (retried) + one 200
+
+
+# ─── bad URL logged, not crashed ─────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_http_poll_bad_url_logged_not_crash(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.ERROR, logger="traceforge.sources.http_poll")
+
+    async with HttpPollSource(
+        "not-a-valid-url", name="poll-bad", interval=0.02, max_retries=0
+    ) as src:
+        stream = src.__aiter__()
+        # A bad URL must never crash the iterator: it keeps polling (and logging), so the
+        # pull times out rather than raising the transport error out of the source.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(stream.__anext__(), timeout=1.0)
+
+    errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("poll-bad" in m and "poll failed" in m for m in errors), errors

--- a/tests/e2e/test_sse_source_e2e.py
+++ b/tests/e2e/test_sse_source_e2e.py
@@ -1,0 +1,278 @@
+"""End-to-end I/O tests for :class:`traceforge.sources.sse.SSESource` (issue #82).
+
+Every test drives the *real* source against a loopback SSE fake (never an external host).
+The ``sse_server`` fixture (see ``tests/e2e/conftest.py``) models a single long-lived stream
+whose ``close_current()`` is synchronous, so forced disconnect → reconnect is deterministic;
+``_ErroringSSEServer`` below is a local variant that always fails, to exercise the backoff and
+reconnect-budget paths.
+
+Bullets covered (issue #82, SSE):
+* events with ``id`` → the source tracks the id (and the record sequence advances)
+* server ``retry:`` respected
+* disconnect → reconnect sends ``Last-Event-ID``
+* duplicate ``id`` after reconnect NOT re-emitted (dedup) — currently xfail, see reason
+* backoff doubles on consecutive failures
+* ``max_reconnects`` → graceful close (disconnect path) + bounded retries (failure path)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+import time
+from collections.abc import Callable
+
+import pytest
+
+from tests.e2e.fakes._http import SilentHandler, ThreadedHTTPFake
+from tests.e2e.fakes.sse import SSEServer
+from traceforge.sources.sse import SSESource
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _anext(stream, timeout: float = 10.0):
+    """Pull the next record from an async source iterator, with a bounded wait."""
+    return await asyncio.wait_for(stream.__anext__(), timeout=timeout)
+
+
+async def _drain(stream, *, max_events: int, per_timeout: float = 0.3) -> list:
+    """Collect up to ``max_events`` records, stopping early on timeout/exhaustion.
+
+    Used to observe how many events actually reach the consumer without hanging when the
+    source (correctly) emits fewer than requested.
+    """
+    out: list = []
+    for _ in range(max_events):
+        try:
+            out.append(await asyncio.wait_for(stream.__anext__(), timeout=per_timeout))
+        except (asyncio.TimeoutError, StopAsyncIteration):
+            break
+    return out
+
+
+async def _wait_until(pred: Callable[[], bool], timeout: float = 6.0, poll: float = 0.01) -> None:
+    """Spin until ``pred()`` is true (yielding control), or fail after ``timeout``."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not pred():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError(f"condition not met within {timeout}s")
+        await asyncio.sleep(poll)
+
+
+class _ErroringSSEHandler(SilentHandler):
+    """Always answer with an error status, recording each connection attempt + timestamp."""
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib handler contract)
+        fake: _ErroringSSEServer = self.server.fake  # type: ignore[attr-defined]
+        with fake._lock:
+            fake.attempts += 1
+            fake.timestamps.append(time.monotonic())
+            status = fake.status
+        self.send_response(status)
+        self.end_headers()
+
+
+class _ErroringSSEServer(ThreadedHTTPFake):
+    """A loopback endpoint whose every connection fails (for backoff / budget tests)."""
+
+    handler_class = _ErroringSSEHandler
+
+    def __init__(self, status: int = 503) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self.status = status
+        self.attempts = 0
+        self.timestamps: list[float] = []
+
+
+# ─── events with id → id tracked, sequence advances ──────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_event_ids_tracked_in_sequence(sse_server: SSEServer) -> None:
+    sse_server.enqueue("alpha", id="1")
+    sse_server.enqueue("beta", id="2")
+    sse_server.enqueue("gamma", id="3")
+
+    got = []
+    async with SSESource(
+        sse_server.url, name="sse-ids", reconnect_delay=0.02, max_reconnects=5
+    ) as src:
+        stream = src.__aiter__()
+        for _ in range(3):
+            got.append(await _anext(stream))
+        # The source advances its last-seen id as events with ids are dispatched.
+        assert src._last_event_id == "3"
+
+    assert [r.payload for r in got] == ["alpha", "beta", "gamma"]
+    assert [r.sequence for r in got] == [0, 1, 2]  # monotonic record sequence
+
+
+# ─── server retry: respected ─────────────────────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_server_retry_directive_respected(sse_server: SSEServer) -> None:
+    # A ``retry: 40`` (ms) directive must reset the source's reconnect delay to 0.04s.
+    sse_server.enqueue("hello", id="1", retry=40)
+
+    async with SSESource(
+        sse_server.url, name="sse-retry", reconnect_delay=1.0, max_reconnects=5
+    ) as src:
+        stream = src.__aiter__()
+        rec = await _anext(stream)
+        assert rec.payload == "hello"
+        assert src.reconnect_delay == pytest.approx(0.04)
+
+
+# ─── disconnect → reconnect sends Last-Event-ID ──────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_reconnect_sends_last_event_id(sse_server: SSEServer) -> None:
+    sse_server.enqueue("alpha", id="1")
+    sse_server.enqueue("beta", id="2")
+
+    got = []
+    async with SSESource(
+        sse_server.url, name="sse-resume", reconnect_delay=0.02, max_reconnects=10
+    ) as src:
+        stream = src.__aiter__()
+        got.append(await _anext(stream))
+        got.append(await _anext(stream))
+
+        sse_server.close_current()  # deterministic disconnect
+        sse_server.enqueue("gamma", id="3")
+        got.append(await _anext(stream))
+
+    assert [r.payload for r in got] == ["alpha", "beta", "gamma"]
+    assert sse_server.connection_count >= 2  # reconnected at least once
+    assert sse_server.received_last_event_id == "2"  # resumed from the last dispatched id
+
+
+# ─── duplicate id after reconnect NOT re-emitted (dedup) ─────────────────────
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "bug: SSESource performs no client-side dedup. When a server redelivers an "
+        "already-seen id after reconnect (at-least-once delivery), the source re-emits it: "
+        "sources/sse.py _iter_records/_stream_once yield every parsed event and _last_event_id "
+        "is only sent on reconnect, never used to filter ids <= the last seen."
+    ),
+)
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_duplicate_id_after_reconnect_not_reemitted(sse_server: SSEServer) -> None:
+    sse_server.enqueue("alpha", id="1")
+    sse_server.enqueue("beta", id="2")
+
+    got = []
+    async with SSESource(
+        sse_server.url, name="sse-dedup", reconnect_delay=0.02, max_reconnects=10
+    ) as src:
+        stream = src.__aiter__()
+        got.append(await _anext(stream))
+        got.append(await _anext(stream))
+
+        sse_server.close_current()
+        sse_server.enqueue("beta", id="2")  # duplicate id redelivered after reconnect
+        sse_server.enqueue("gamma", id="3")
+        got += await _drain(stream, max_events=3)
+
+    payloads = [r.payload for r in got]
+    # A dedup-correct source drops the redelivered id=2 and yields only the new gamma.
+    assert payloads == ["alpha", "beta", "gamma"], f"duplicate re-emitted: {payloads}"
+
+
+# ─── backoff doubles on consecutive failures ─────────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_backoff_doubles_on_consecutive_failures() -> None:
+    server = _ErroringSSEServer(status=503)
+    server.start()
+    try:
+        async with SSESource(
+            server.url, name="sse-backoff", reconnect_delay=0.1, max_reconnects=None
+        ) as src:
+            stream = src.__aiter__()
+            # This pull never yields (every connect fails); it just keeps reconnecting.
+            pull = asyncio.ensure_future(stream.__anext__())
+            await _wait_until(lambda: server.attempts >= 4, timeout=6)
+            pull.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await pull
+    finally:
+        server.stop()
+
+    ts = server.timestamps[:4]
+    gaps = [ts[i + 1] - ts[i] for i in range(3)]
+    # Delays follow reconnect_delay * 2**(n-1) ≈ 0.1, 0.2, 0.4 → each gap ~2× the previous.
+    assert 1.5 <= gaps[1] / gaps[0] <= 3.0, gaps
+    assert 1.5 <= gaps[2] / gaps[1] <= 3.0, gaps
+
+
+# ─── max_reconnects → graceful close (disconnect path) ───────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_max_reconnects_graceful_close_on_disconnect(sse_server: SSEServer) -> None:
+    sse_server.enqueue("alpha", id="1")
+
+    got = []
+    async with SSESource(
+        sse_server.url, name="sse-max0", reconnect_delay=0.02, max_reconnects=0
+    ) as src:
+        stream = src.__aiter__()
+        got.append(await _anext(stream))  # consume alpha (handler now in its serve loop)
+
+        sse_server.close_current()  # deterministic disconnect exhausts the (zero) budget
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(stream.__anext__(), timeout=10)
+
+    assert [r.payload for r in got] == ["alpha"]
+    assert sse_server.connection_count == 1  # budget=0 → no reconnect after the disconnect
+
+
+# ─── max_reconnects bounds persistent failures ───────────────────────────────
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_sse_max_reconnects_bounds_persistent_failures() -> None:
+    server = _ErroringSSEServer(status=503)
+    server.start()
+    max_reconnects = 2
+    outcome = "hang"
+    try:
+        async with SSESource(
+            server.url, name="sse-bound", reconnect_delay=0.02, max_reconnects=max_reconnects
+        ) as src:
+            stream = src.__aiter__()
+            try:
+                await asyncio.wait_for(stream.__anext__(), timeout=10)
+                outcome = "stopped"
+            except StopAsyncIteration:
+                outcome = "stopped"
+            except asyncio.TimeoutError:
+                outcome = "hang"
+            except Exception:  # noqa: BLE001 — any transport error still counts as "terminated"
+                outcome = "raised"
+    finally:
+        server.stop()
+
+    # The reliability-critical guarantee: persistent failure is BOUNDED by max_reconnects —
+    # the source neither hangs nor retries forever (exactly max_reconnects + 1 attempts).
+    # NOTE (reported): the source currently surfaces the transport error here rather than
+    # closing gracefully (StopAsyncIteration); this test stays agnostic to that open question.
+    assert outcome in {"raised", "stopped"}
+    assert server.attempts == max_reconnects + 1


### PR DESCRIPTION
## What

Wave 2 (🔴 network ingestion edge) e2e coverage for the two network sources, both previously at
**0% real-I/O coverage**. Every test drives the *real* `HttpPollSource` / `SSESource` against the
Wave-0 loopback fakes (`http_poll_server`, `sse_server`, plus small always-fail / flaky variants
built on `ThreadedHTTPFake`). Marked `net` + `e2e`; deterministic and time-budgeted.

`Closes #82`

## Files added

- `tests/e2e/test_http_poll_source_e2e.py` — 5 tests
- `tests/e2e/test_sse_source_e2e.py` — 7 tests (1 strict `xfail`)

## Coverage vs acceptance criteria

**HttpPoll:** `200`+ETag → record (first request sends no validators) · `If-None-Match` → `304` →
no record · new ETag → new record (sequence advances) · cursor header echoed on the next request ·
`500` → retry (backoff) → succeed · bad URL logged, iterator not crashed.

**SSE:** events with `id` → source tracks the id + record sequence advances · server `retry:`
directive resets the reconnect delay · disconnect → reconnect sends `Last-Event-ID` (resume) ·
backoff doubles on consecutive failures (~0.1→0.2→0.4s) · `max_reconnects` → graceful
`StopAsyncIteration` on the disconnect path · `max_reconnects` bounds persistent failures to
exactly `N+1` attempts.

## Product bug surfaced (xfail, strict) — no product code changed

**SSE has no client-side dedup.** `test_sse_duplicate_id_after_reconnect_not_reemitted` is pinned
`@pytest.mark.xfail(strict=True)`. When a server redelivers an already-seen `id` after reconnect
(at-least-once delivery), the source **re-emits it** — observed sequence `[alpha, beta, beta,
gamma]`. `src/traceforge/sources/sse.py` `_iter_records`/`_stream_once` yield every parsed event;
`_last_event_id` is only *sent* on reconnect, never used to filter ids `<=` the last seen. Issue
#82 calls deduplication "reliability-critical," so this is pinned + reported rather than fixed
(precedent #84 → #92).

## Observation (not pinned as a bug) — for your call

On **persistent connection failure**, once `max_reconnects` is exhausted the source **re-raises the
transport error** (e.g. `httpx.HTTPStatusError`) out of the iterator rather than closing gracefully
with `StopAsyncIteration` (`src/traceforge/sources/sse.py:87-88`, the `except Exception: ... raise`
branch). The disconnect/normal-end path *does* close gracefully (`:92-94`). `#82` says
"`max_reconnects` → graceful close," which the disconnect path satisfies; the failure-path re-raise
is a defensible fail-loud choice, so the failure-path test asserts only the retry **bound**
(`attempts == N+1`, no hang) and stays agnostic. Flagging for your judgment.

## Verification

- New files: `11 passed, 1 xfailed`.
- Full suite (Windows): `2572 passed, 4 skipped, 5 xfailed` — baseline was `2561 / 4 / 4`, i.e.
  **+11 passed, +1 xfailed, only added**.
- Lint: `ruff check` clean, `ruff format --check` clean (ruff==0.15.20).
- No changes under `src/`, `pyproject.toml`, `.github/workflows/`, or `uv.lock`; no new deps.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
