### PR TITLE
test(e2e): sink I/O + failure/retry coverage across all 9 sinks (#83)

### DIFF
--- a/tests/e2e/_sink_governance.py
+++ b/tests/e2e/_sink_governance.py
@@ -1,0 +1,71 @@
+"""Governance-stamped event factory for the sink e2e suite (issue #83).
+
+Several sinks (:class:`~traceforge.sinks.console.ConsoleSink`,
+:class:`~traceforge.sinks.webhook.WebhookSink`,
+:class:`~traceforge.sinks.otel_exporter.OtelExporterSink`) only emit — or only
+emit *richly* — for events that carry a governance ``recommendation`` (and, for
+the console, a ``classification``). This helper builds such an event the same way
+the enrichment pipeline stamps one, so the e2e tests drive the real filter/serialize
+paths instead of hand-rolling metadata in every module.
+
+The leading underscore keeps pytest from collecting this as a test module.
+"""
+
+from __future__ import annotations
+
+from tests.conftest import make_event
+from traceforge.classify.core import Classification
+from traceforge.classify.risk import RiskAssessment
+from traceforge.governance.results import (
+    RecommendedAction,
+    RiskRecommendation,
+    SessionMeta,
+)
+from traceforge.types import EventKind, EventMetadata, SessionEvent
+
+
+def governed_event(
+    action: str = "deny",
+    *,
+    session_id: str = "gov-session",
+    tool_name: str = "rm",
+    arguments: str = "-rf /tmp/x",
+    score: int = 90,
+    level: str = "critical",
+    confidence: str = "high",
+    reason_code: str = "rule.block",
+    kind: str = EventKind.TOOL_CALL_STARTED,
+) -> SessionEvent:
+    """A tool-call event stamped with a governance ``recommendation`` of ``action``.
+
+    ``action`` is one of the :class:`RecommendedAction` values ("allow", "warn",
+    "escalate", "deny", "transform"). The event also carries a ``classification``
+    so the console sink (which gates on it) emits.
+    """
+    classification = Classification(mechanism="shell.execute", effect="destructive")
+    risk = RiskAssessment(
+        score=score,
+        level=level,
+        confidence=confidence,
+        factors=("shell_execute",),
+        mitre=("T1059",),
+        version="risk-v2",
+    )
+    recommendation = RiskRecommendation(
+        recommended_action=RecommendedAction(action),
+        assessment=risk,
+        reason_code=reason_code,
+        canonical_id="cid-test",
+    )
+    governance = SessionMeta(
+        classification=classification,
+        risk_assessment=risk,
+        recommendation=recommendation,
+    )
+    metadata = EventMetadata(classification=classification, governance=governance)
+    return make_event(
+        kind=kind,
+        session_id=session_id,
+        payload={"tool_name": tool_name, "arguments": arguments},
+        metadata=metadata,
+    )

--- a/tests/e2e/test_sink_base_e2e.py
+++ b/tests/e2e/test_sink_base_e2e.py
@@ -1,0 +1,101 @@
+"""End-to-end tests for :class:`traceforge.sinks.base.StorageSink` defaults (issue #83).
+
+Exercises the base envelope-emission contract that every sink inherits: a live
+``SessionEvent`` wrapped in an ``EnrichedEvent`` is forwarded to ``on_event``
+byte-for-byte, while a synthetic non-event payload (a ``ContextGapEvent``) it
+cannot express is *dropped with a one-time warning* rather than silently — the
+defined behavior for an audit-gap marker. Also confirms the ``on_span`` /
+``on_usage`` / ``flush`` / ``close`` no-ops and the one-time title-drop warning.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.conftest import make_event, make_span, make_usage
+from traceforge.governance.envelope import ContextGapEvent, EnrichedEvent
+from traceforge.governance.results import SessionMeta
+from traceforge.sinks.base import StorageSink
+from traceforge.types import TitleUpdate
+
+
+def _empty_meta() -> SessionMeta:
+    """A lifecycle-style governance stamp with no phase-2/3 fields set."""
+    return SessionMeta(classification=None, risk_assessment=None)
+
+
+class _RecordingBaseSink(StorageSink):
+    """Minimal concrete sink: records forwarded events, inherits every default."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    async def on_event(self, event) -> None:
+        self.events.append(event)
+
+
+def _forget(cls_name: str) -> None:
+    """Reset the base's one-time warn state for a class (test isolation)."""
+    StorageSink._title_drop_warned.discard(cls_name)
+    StorageSink._enriched_drop_warned.discard(cls_name)
+
+
+@pytest.mark.e2e
+async def test_base_on_enriched_forwards_live_event_to_on_event() -> None:
+    sink = _RecordingBaseSink()
+    live = make_event(session_id="fwd")
+    await sink.on_enriched_event(EnrichedEvent(event=live, governance=_empty_meta()))
+    assert sink.events == [live]
+    assert sink.events[0] is live  # forwarded unchanged
+
+
+@pytest.mark.e2e
+async def test_base_on_enriched_drops_non_event_payload_with_one_time_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _forget("_RecordingBaseSink")
+    sink = _RecordingBaseSink()
+    gap = ContextGapEvent(
+        id="gap-1",
+        session_id="s",
+        timestamp=datetime.now(timezone.utc),
+        source_event_key="gap:s:1:2",
+    )
+    enriched = EnrichedEvent(event=gap, governance=_empty_meta())
+
+    with caplog.at_level(logging.WARNING, logger="traceforge.sinks.base"):
+        await sink.on_enriched_event(enriched)
+        await sink.on_enriched_event(enriched)  # second call: no new warning
+
+    assert sink.events == []  # the gap marker is dropped, not forwarded
+    warnings = [r for r in caplog.records if "_RecordingBaseSink" in r.getMessage()]
+    assert len(warnings) == 1  # warned exactly once per class
+
+
+@pytest.mark.e2e
+async def test_base_on_title_update_warns_once(caplog: pytest.LogCaptureFixture) -> None:
+    _forget("_RecordingBaseSink")
+    sink = _RecordingBaseSink()
+    with caplog.at_level(logging.WARNING, logger="traceforge.sinks.base"):
+        await sink.on_title_update(
+            TitleUpdate(session_id="s", segment_id="a", kind="activity", title="One")
+        )
+        await sink.on_title_update(
+            TitleUpdate(session_id="s", segment_id="b", kind="activity", title="Two")
+        )
+
+    warnings = [r for r in caplog.records if "title updates" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+@pytest.mark.e2e
+async def test_base_span_usage_flush_close_are_noops() -> None:
+    sink = _RecordingBaseSink()
+    await sink.on_span(make_span(session_id="noop"))
+    await sink.on_usage(make_usage(session_id="noop"))
+    await sink.flush()
+    await sink.close()
+    assert sink.events == []  # none of these touch event state

--- a/tests/e2e/test_sink_callback_e2e.py
+++ b/tests/e2e/test_sink_callback_e2e.py
@@ -1,0 +1,126 @@
+"""End-to-end tests for :class:`traceforge.sinks.callback.CallbackSink` and the
+``as_async_event_callback`` adapter (issue #83).
+
+The "artifact" for a callback sink is the invocation itself: each record type is
+delivered to its handler as the *same object* (identity preserved), a missing
+handler is a silent no-op, and the adapter behind ``pipeline.subscribe`` turns a
+plain sync-or-async callable into the ``async on_event`` shape while honoring its
+kind filter and running blocking callbacks off the loop on request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import make_event, make_span, make_usage
+from traceforge import EventKind
+from traceforge.sinks.callback import CallbackSink, as_async_event_callback
+from traceforge.types import TitleUpdate
+
+
+@pytest.mark.e2e
+async def test_callback_dispatches_each_record_with_identity() -> None:
+    events: list = []
+    spans: list = []
+    usages: list = []
+    titles: list = []
+
+    async def on_event(e):
+        events.append(e)
+
+    async def on_span(s):
+        spans.append(s)
+
+    async def on_usage(u):
+        usages.append(u)
+
+    async def on_title(t):
+        titles.append(t)
+
+    sink = CallbackSink(
+        on_event=on_event, on_span=on_span, on_usage=on_usage, on_title_update=on_title
+    )
+    ev = make_event(session_id="cb")
+    sp = make_span(session_id="cb")
+    us = make_usage(session_id="cb")
+    tu = TitleUpdate(session_id="cb", segment_id="s", kind="session", title="T")
+    await sink.on_event(ev)
+    await sink.on_span(sp)
+    await sink.on_usage(us)
+    await sink.on_title_update(tu)
+
+    assert events == [ev] and events[0] is ev
+    assert spans == [sp] and spans[0] is sp
+    assert usages == [us] and usages[0] is us
+    assert titles == [tu] and titles[0] is tu
+
+
+@pytest.mark.e2e
+async def test_callback_missing_handlers_are_noops() -> None:
+    sink = CallbackSink()  # all handlers None
+    await sink.on_event(make_event(session_id="none"))
+    await sink.on_span(make_span(session_id="none"))
+    await sink.on_usage(make_usage(session_id="none"))
+    await sink.on_title_update(
+        TitleUpdate(session_id="none", segment_id="s", kind="session", title="T")
+    )
+
+
+@pytest.mark.e2e
+async def test_adapter_wraps_sync_and_async_callables() -> None:
+    seen_sync: list = []
+    seen_async: list = []
+
+    def sync_cb(e):
+        seen_sync.append(e)
+
+    async def async_cb(e):
+        seen_async.append(e)
+
+    ev = make_event(session_id="adapt")
+    await as_async_event_callback(sync_cb)(ev)
+    await as_async_event_callback(async_cb)(ev)
+    assert seen_sync == [ev]
+    assert seen_async == [ev]
+
+
+@pytest.mark.e2e
+async def test_adapter_applies_kind_filter_before_dispatch() -> None:
+    seen: list = []
+    wrapped = as_async_event_callback(seen.append, kind="tool.*")
+
+    tool_event = make_event(kind=EventKind.TOOL_CALL_STARTED, session_id="f")
+    other_event = make_event(kind=EventKind.SESSION_ENDED, session_id="f")
+    await wrapped(tool_event)
+    await wrapped(other_event)  # filtered out, never reaches the callback
+
+    assert seen == [tool_event]
+
+
+@pytest.mark.e2e
+async def test_adapter_runs_blocking_callback_via_to_thread() -> None:
+    seen: list = []
+    ev = make_event(session_id="thread")
+    await as_async_event_callback(seen.append, to_thread=True)(ev)
+    assert seen == [ev]
+
+
+@pytest.mark.e2e
+async def test_adapter_awaits_sync_callable_returning_awaitable() -> None:
+    seen: list = []
+
+    async def _store(e):
+        seen.append(e)
+
+    def sync_returning_coro(e):
+        return _store(e)  # sync function, but hands back a coroutine
+
+    ev = make_event(session_id="defer")
+    await as_async_event_callback(sync_returning_coro)(ev)
+    assert seen == [ev]
+
+
+@pytest.mark.e2e
+def test_adapter_rejects_non_callable() -> None:
+    with pytest.raises(TypeError, match="callable"):
+        as_async_event_callback(123)  # type: ignore[arg-type]

--- a/tests/e2e/test_sink_console_e2e.py
+++ b/tests/e2e/test_sink_console_e2e.py
@@ -1,0 +1,90 @@
+"""End-to-end tests for :class:`traceforge.sinks.console.ConsoleSink` (issue #83).
+
+Injects a real stream and reads back exactly what the sink prints, asserting the
+stable human-facing format: the governance-action filter decides which events
+surface, the risk score and argument preview are rendered, closed segments come
+out as indented TOC lines, and ANSI coloring is present only when enabled against
+a TTY. This is the sink's actual ``print`` path, captured verbatim.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from tests.conftest import make_event
+from tests.e2e._sink_governance import governed_event
+from traceforge.sinks.console import ConsoleSink
+from traceforge.types import TitleUpdate
+
+
+class _TtyStream(io.StringIO):
+    """A StringIO that claims to be a TTY so ``ConsoleSink`` enables color."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+@pytest.mark.e2e
+async def test_console_deny_event_rendered_with_risk_and_args() -> None:
+    buf = io.StringIO()
+    sink = ConsoleSink(color=False, stream=buf)
+    await sink.on_event(governed_event("deny", tool_name="rm", arguments="-rf /tmp/x", score=90))
+
+    out = buf.getvalue()
+    assert "DENY" in out
+    assert "rm" in out
+    assert "[risk:90]" in out
+    assert "-rf /tmp/x" in out
+    assert "\033[" not in out  # color=False -> no ANSI
+
+
+@pytest.mark.e2e
+async def test_console_warn_event_rendered() -> None:
+    buf = io.StringIO()
+    sink = ConsoleSink(color=False, stream=buf)
+    await sink.on_event(governed_event("warn", tool_name="edit"))
+    assert "WARN" in buf.getvalue()
+
+
+@pytest.mark.e2e
+async def test_console_allow_is_filtered_by_default() -> None:
+    buf = io.StringIO()
+    sink = ConsoleSink(color=False, stream=buf)  # default filter: warn/deny/escalate
+    await sink.on_event(governed_event("allow"))
+    assert buf.getvalue() == ""
+
+
+@pytest.mark.e2e
+async def test_console_event_without_classification_is_suppressed() -> None:
+    buf = io.StringIO()
+    sink = ConsoleSink(color=False, stream=buf)
+    await sink.on_event(make_event(session_id="plain"))  # no metadata/classification
+    assert buf.getvalue() == ""
+
+
+@pytest.mark.e2e
+async def test_console_title_updates_render_as_toc_lines() -> None:
+    buf = io.StringIO()
+    sink = ConsoleSink(color=False, stream=buf)
+    await sink.on_title_update(
+        TitleUpdate(session_id="s", segment_id="a", kind="activity", title="Fix the bug")
+    )
+    await sink.on_title_update(
+        TitleUpdate(session_id="s", segment_id="b", kind="step", title="Write a test")
+    )
+
+    lines = buf.getvalue().splitlines()
+    assert lines[0] == "ACTIVITY Fix the bug"  # activity: no indent
+    assert lines[1] == "  STEP Write a test"  # nested kind: indented
+
+
+@pytest.mark.e2e
+async def test_console_color_emits_ansi_on_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    tty = _TtyStream()
+    monkeypatch.setattr(sys, "stderr", tty)  # color gate consults sys.stderr.isatty()
+    sink = ConsoleSink(color=True)  # stream defaults to the patched sys.stderr
+    await sink.on_event(governed_event("deny"))
+    assert "\033[" in tty.getvalue()

--- a/tests/e2e/test_sink_jsonl_e2e.py
+++ b/tests/e2e/test_sink_jsonl_e2e.py
@@ -1,0 +1,152 @@
+"""End-to-end tests for :class:`traceforge.sinks.jsonl.JsonlSink` (issue #83).
+
+Asserts the sink's real output artifact: the JSONL file it writes is parsed back
+and each line is checked field-for-field against the source event — a true
+round-trip, not a mock. Covers the live-event path, the governance envelope
+(``on_enriched_event`` for live events and context-gap markers), title updates,
+the ``{session_id}`` path template, and the *defined* failure behavior (a write
+error is dropped and logged, never raised — the pipeline keeps running).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from tests.conftest import make_event
+from traceforge.governance.envelope import ContextGapEvent, EnrichedEvent
+from traceforge.governance.results import SessionMeta
+from traceforge.sinks.jsonl import JsonlSink
+from traceforge.types import EventKind, TitleUpdate
+
+
+def _read_lines(path: Path) -> list[dict]:
+    text = path.read_text(encoding="utf-8")
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+@pytest.mark.e2e
+async def test_jsonl_round_trip_serializes_every_event(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    sink = JsonlSink(path=str(path))
+    events = [
+        make_event(kind=EventKind.MESSAGE_USER, session_id="rt", payload={"content": f"msg-{i}"})
+        for i in range(3)
+    ]
+    for event in events:
+        await sink.on_event(event)
+
+    lines = _read_lines(path)
+    assert len(lines) == len(events)
+    for line, event in zip(lines, events):
+        assert line["id"] == event.id
+        assert line["kind"] == event.kind
+        assert line["session_id"] == event.session_id
+        assert line["timestamp"] == event.timestamp.isoformat()
+        assert line["payload"] == event.payload
+        assert "metadata" in line
+
+
+@pytest.mark.e2e
+async def test_jsonl_session_id_template_routes_per_session(tmp_path: Path) -> None:
+    sink = JsonlSink(path=str(tmp_path / "{session_id}.jsonl"))
+    await sink.on_event(make_event(session_id="alpha"))
+    await sink.on_event(make_event(session_id="beta"))
+    await sink.on_event(make_event(session_id="alpha"))
+
+    assert _read_lines(tmp_path / "alpha.jsonl").__len__() == 2
+    assert _read_lines(tmp_path / "beta.jsonl").__len__() == 1
+
+
+@pytest.mark.e2e
+async def test_jsonl_enriched_live_event_is_byte_identical(tmp_path: Path) -> None:
+    """A live event routed through the governance envelope writes the same record
+    as ``on_event`` — governance is carried inside ``metadata`` for a live event."""
+    direct = tmp_path / "direct.jsonl"
+    enriched_path = tmp_path / "enriched.jsonl"
+
+    event = make_event(session_id="env", payload={"content": "hi"})
+
+    await JsonlSink(path=str(direct)).on_event(event)
+
+    sink = JsonlSink(path=str(enriched_path))
+    envelope = EnrichedEvent(
+        event=event, governance=SessionMeta(classification=None, risk_assessment=None)
+    )
+    await sink.on_enriched_event(envelope)
+
+    assert direct.read_text(encoding="utf-8") == enriched_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.e2e
+async def test_jsonl_context_gap_marker_is_persisted(tmp_path: Path) -> None:
+    path = tmp_path / "gaps.jsonl"
+    sink = JsonlSink(path=str(path))
+    gap = ContextGapEvent(
+        id="gap-1",
+        session_id="gapsess",
+        timestamp=datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        source_event_key="gap:gapsess:1:5",
+        dropped_count=5,
+        first_dropped_sequence=1,
+        last_dropped_sequence=5,
+        gap_ordinal=2,
+    )
+    envelope = EnrichedEvent(
+        event=gap, governance=SessionMeta(classification=None, risk_assessment=None)
+    )
+    await sink.on_enriched_event(envelope)
+
+    (line,) = _read_lines(path)
+    assert line["record"] == "context_gap"
+    assert line["id"] == "gap-1"
+    assert line["session_id"] == "gapsess"
+    assert line["dropped_count"] == 5
+    assert line["first_dropped_sequence"] == 1
+    assert line["last_dropped_sequence"] == 5
+    assert line["gap_ordinal"] == 2
+    assert line["reason"] == "backpressure"
+    assert line["source_event_key"] == "gap:gapsess:1:5"
+
+
+@pytest.mark.e2e
+async def test_jsonl_title_update_record(tmp_path: Path) -> None:
+    path = tmp_path / "titles.jsonl"
+    sink = JsonlSink(path=str(path))
+    await sink.on_title_update(
+        TitleUpdate(
+            session_id="ts",
+            segment_id="act-1",
+            kind="activity",
+            title="Refactor the parser",
+            version=3,
+            parent_id=None,
+        )
+    )
+
+    (line,) = _read_lines(path)
+    assert line["record"] == "title_update"
+    assert line["segment_id"] == "act-1"
+    assert line["kind"] == "activity"
+    assert line["title"] == "Refactor the parser"
+    assert line["version"] == 3
+
+
+@pytest.mark.e2e
+async def test_jsonl_write_error_is_dropped_not_raised(tmp_path: Path, caplog) -> None:
+    """Defined failure behavior: an OSError on write is logged and the event
+    dropped — the sink never propagates the error to the pipeline."""
+    path = tmp_path / "fail.jsonl"
+    sink = JsonlSink(path=str(path))
+
+    with caplog.at_level(logging.ERROR, logger="traceforge.sinks.jsonl"):
+        with mock.patch("builtins.open", side_effect=OSError("No space left on device")):
+            await sink.on_event(make_event(session_id="drop"))  # must NOT raise
+
+    assert not path.exists()  # nothing was written
+    assert any("failed to write" in r.message.lower() for r in caplog.records)

--- a/tests/e2e/test_sink_otel_e2e.py
+++ b/tests/e2e/test_sink_otel_e2e.py
@@ -1,0 +1,115 @@
+"""End-to-end tests for :class:`traceforge.sinks.otel_exporter.OtelExporterSink`.
+
+POSTs real OTLP/HTTP JSON at a loopback collector (the ``otel_collector``
+fixture) and asserts the spans it receives carry the expected name and
+attributes — the sink's actual serialize+HTTP path, not a mock. Also pins the
+*defined* failure/retry behavior: a failed flush (HTTP 5xx or a refused
+connection) is swallowed and the batch is *retained* so the next flush retries
+it — the exporter never drops spans on a single transient failure and never
+raises into the pipeline.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from tests.conftest import make_event
+from tests.e2e._sink_governance import governed_event
+from traceforge.sinks.otel_exporter import OtelExporterSink
+from traceforge.types import TitleUpdate
+
+pytestmark = [pytest.mark.e2e, pytest.mark.net]
+
+
+def _attr_map(span: dict) -> dict:
+    out: dict = {}
+    for attr in span.get("attributes", []):
+        value = attr["value"]
+        out[attr["key"]] = value.get("stringValue", value.get("intValue"))
+    return out
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_otel_event_span_attributes(otel_collector) -> None:
+    sink = OtelExporterSink(endpoint=otel_collector.endpoint)
+    await sink.on_event(governed_event("deny", session_id="otel-1", tool_name="curl", score=77))
+    await sink.flush()
+
+    spans = otel_collector.spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["name"] == "traceforge.tool.call.started"
+    attrs = _attr_map(span)
+    assert attrs["traceforge.session.id"] == "otel-1"
+    assert attrs["gen_ai.tool.name"] == "curl"
+    assert attrs["traceforge.risk.score"] == 77
+    assert attrs["traceforge.risk.level"] == "critical"
+    assert attrs["traceforge.action"] == "deny"
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_otel_title_update_span(otel_collector) -> None:
+    sink = OtelExporterSink(endpoint=otel_collector.endpoint)
+    await sink.on_title_update(
+        TitleUpdate(session_id="ts", segment_id="seg", kind="activity", title="Do the thing")
+    )
+    await sink.flush()
+
+    (span,) = otel_collector.spans()
+    assert span["name"] == "traceforge.title.activity"
+    attrs = _attr_map(span)
+    assert attrs["traceforge.segment.title"] == "Do the thing"
+    assert attrs["traceforge.segment.kind"] == "activity"
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_otel_batch_size_auto_flushes(otel_collector) -> None:
+    sink = OtelExporterSink(endpoint=otel_collector.endpoint)
+    for _ in range(32):  # _batch_size == 32 -> auto-flush, no explicit flush() needed
+        await sink.on_event(make_event(session_id="batch"))
+    assert len(otel_collector.spans()) == 32
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_otel_5xx_retained_and_retried_on_next_flush(otel_collector) -> None:
+    """Defined behavior: a 5xx response is swallowed and the batch is retained;
+    the next flush re-POSTs it and, on success, clears the batch."""
+    otel_collector.set_status(500)
+    sink = OtelExporterSink(endpoint=otel_collector.endpoint)
+    await sink.on_event(make_event(session_id="retry"))
+
+    await sink.flush()  # first attempt -> 500, must NOT raise
+    assert otel_collector.request_count == 1
+    assert len(sink._batch) == 1  # retained for retry
+
+    otel_collector.set_status(200)
+    await sink.flush()  # retry succeeds
+    assert otel_collector.request_count == 2
+    assert sink._batch == []  # cleared only after a successful send
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_otel_connection_refused_is_swallowed_and_retained() -> None:
+    sink = OtelExporterSink(endpoint=f"http://127.0.0.1:{_free_port()}/v1/traces")
+    await sink.on_event(make_event(session_id="down"))
+    await sink.flush()  # connection refused -> swallowed, no raise
+    assert len(sink._batch) == 1  # nothing delivered, batch kept for a later retry
+
+
+@pytest.mark.e2e
+def test_otel_rejects_non_http_endpoint() -> None:
+    with pytest.raises(ValueError, match="http"):
+        OtelExporterSink(endpoint="ftp://collector/v1/traces")

--- a/tests/e2e/test_sink_parquet_e2e.py
+++ b/tests/e2e/test_sink_parquet_e2e.py
@@ -1,0 +1,148 @@
+"""End-to-end tests for :class:`traceforge.sinks.parquet.ParquetSink` (issue #83).
+
+Proves the real columnar artifact: parquet files are written then *read back with
+pyarrow* to check schema, row count, and values (including multi-valued
+classification dimensions that must round-trip as ``list<string>``). Also covers
+the per-session title sidecar and the sink's *defined* failure behavior — unlike
+the file/db sinks, a write ``OSError`` is re-raised (propagated), because silently
+dropping a whole session's analytics data is worse than a loud failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pyarrow.parquet as pq
+import pytest
+
+from tests.conftest import make_event
+from traceforge import EventKind
+from traceforge.classify.core import Classification
+from traceforge.sinks.parquet import ParquetSink
+from traceforge.types import EventMetadata, Phase, ToolMotivation, TitleUpdate
+
+
+@pytest.mark.e2e
+async def test_parquet_round_trip_row_count_and_values(tmp_path: Path) -> None:
+    sink = ParquetSink(path=str(tmp_path))
+    for i in range(4):
+        await sink.on_event(make_event(session_id="run", payload={"content": f"m{i}"}))
+    await sink.on_event(make_event(kind=EventKind.SESSION_ENDED, session_id="run"))
+    await sink.close()
+
+    table = pq.read_table(tmp_path / "run.parquet")
+    assert table.num_rows == 5
+    assert table.column("session_id").to_pylist() == ["run"] * 5
+    assert table.column("seq").to_pylist() == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.e2e
+async def test_parquet_schema_is_stable(tmp_path: Path) -> None:
+    sink = ParquetSink(path=str(tmp_path))
+    await sink.on_event(make_event(session_id="sc"))
+    await sink.close()
+
+    table = pq.read_table(tmp_path / "sc.parquet")
+    expected = {
+        "event_id",
+        "session_id",
+        "kind",
+        "timestamp_ns",
+        "seq",
+        "tool_name",
+        "mechanism",
+        "effect",
+        "scope",
+        "role",
+        "action",
+        "capability",
+        "structure",
+        "source_labels",
+        "shell_dialect",
+        "binaries",
+        "phase_signals",
+        "motivation",
+        "payload_json",
+        "metadata_json",
+        "duration_ms",
+    }
+    assert expected <= set(table.column_names)
+
+
+@pytest.mark.e2e
+async def test_parquet_classification_dimensions_round_trip_as_lists(tmp_path: Path) -> None:
+    classification = Classification(
+        mechanism="shell",
+        effect="mutating",
+        scope=frozenset({"fs.write", "fs.read"}),
+        action=frozenset({"edit", "build"}),
+        capability=frozenset({"writes-files"}),
+        shell_dialect="bash",
+        binaries=("git", "npm"),
+    )
+    metadata = EventMetadata(
+        classification=classification,
+        phases=frozenset({Phase.IMPLEMENTATION, Phase.VERIFICATION}),
+        motivation=ToolMotivation(intent="add retry logic"),
+    )
+    sink = ParquetSink(path=str(tmp_path))
+    await sink.on_event(
+        make_event(
+            kind=EventKind.TOOL_CALL_STARTED,
+            session_id="cls",
+            payload={"tool_name": "bash"},
+            metadata=metadata,
+        )
+    )
+    await sink.on_event(make_event(kind=EventKind.SESSION_ENDED, session_id="cls"))
+    await sink.close()
+
+    table = pq.read_table(tmp_path / "cls.parquet")
+    first = {col: table.column(col)[0].as_py() for col in table.column_names}
+    assert first["mechanism"] == "shell"
+    assert first["effect"] == "mutating"
+    assert sorted(first["scope"]) == ["fs.read", "fs.write"]
+    assert sorted(first["action"]) == ["build", "edit"]
+    assert first["capability"] == ["writes-files"]
+    assert first["shell_dialect"] == "bash"
+    assert first["binaries"] == ["git", "npm"]
+    assert sorted(first["phase_signals"]) == ["implementation", "verification"]
+    assert first["motivation"] == "add retry logic"
+
+
+@pytest.mark.e2e
+async def test_parquet_title_sidecar_is_written(tmp_path: Path) -> None:
+    sink = ParquetSink(path=str(tmp_path))
+    await sink.on_event(make_event(session_id="withtitle"))
+    await sink.on_title_update(
+        TitleUpdate(
+            session_id="withtitle",
+            segment_id="withtitle",
+            kind="session",
+            title="Investigate the flake",
+            version=1,
+        )
+    )
+    await sink.close()
+
+    sidecar = tmp_path / "withtitle.titles.parquet"
+    assert sidecar.exists()
+    table = pq.read_table(sidecar)
+    assert table.num_rows == 1
+    assert table.column("title").to_pylist() == ["Investigate the flake"]
+    assert table.column("kind").to_pylist() == ["session"]
+
+
+@pytest.mark.e2e
+async def test_parquet_write_error_propagates(tmp_path: Path) -> None:
+    """Defined failure behavior: an OSError while writing the parquet file is
+    logged and *re-raised* — the sink deliberately does not swallow it."""
+    sink = ParquetSink(path=str(tmp_path))
+    await sink.on_event(make_event(session_id="boom"))
+
+    with mock.patch(
+        "traceforge.sinks.parquet.pq.write_table", side_effect=OSError("No space left on device")
+    ):
+        with pytest.raises(OSError, match="No space left"):
+            await sink.close()  # flush -> write_table -> re-raised

--- a/tests/e2e/test_sink_s3_e2e.py
+++ b/tests/e2e/test_sink_s3_e2e.py
@@ -1,0 +1,93 @@
+"""End-to-end tests for :class:`traceforge.sinks.s3.S3Sink` (issue #83).
+
+Runs the sink's real ``boto3`` ``put_object`` path against an in-process moto
+bucket (the ``fake_s3`` fixture), then reads the uploaded object back to assert
+its key structure and JSONL body — a true wire round-trip, no mocks. Also pins
+the sink's *defined* failure behavior: an upload error is logged and the buffer
+is cleared with no retry and no propagation (fire-and-forget; the buffered
+events are dropped).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from tests.conftest import make_event, make_span, make_usage
+from traceforge.sinks.s3 import S3Sink
+from traceforge.types import TitleUpdate
+
+pytestmark = [pytest.mark.e2e, pytest.mark.net]
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_s3_put_object_round_trip(fake_s3) -> None:
+    sink = S3Sink(bucket=fake_s3.bucket, region=fake_s3.region, prefix="traces/")
+    events = [make_event(session_id="round", payload={"content": f"m{i}"}) for i in range(3)]
+    for event in events:
+        await sink.on_event(event)
+    await sink.close()  # flushes the buffer -> one PUT
+
+    keys = fake_s3.list_keys()
+    assert len(keys) == 1
+    key = keys[0]
+    assert key.startswith("traces/round/")
+    assert key.endswith(".jsonl")
+    assert len(key.split("/")) == 4  # prefix/session/date/file
+
+    body = fake_s3.read_object(key)
+    lines = [json.loads(line) for line in body.splitlines() if line]
+    assert [line["id"] for line in lines] == [e.id for e in events]
+    assert {line["session_id"] for line in lines} == {"round"}
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_s3_buffer_size_triggers_flush(fake_s3) -> None:
+    sink = S3Sink(bucket=fake_s3.bucket, region=fake_s3.region, buffer_size=2, flush_interval=9999)
+    await sink.on_event(make_event(session_id="thresh"))
+    assert fake_s3.list_keys() == []  # below threshold, nothing uploaded yet
+    await sink.on_event(make_event(session_id="thresh"))  # hits buffer_size -> flush
+    assert len(fake_s3.list_keys()) == 1
+    await sink.close()
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_s3_mixed_records_serialized_in_body(fake_s3) -> None:
+    sink = S3Sink(bucket=fake_s3.bucket, region=fake_s3.region, buffer_size=100)
+    await sink.on_event(make_event(session_id="mix"))
+    await sink.on_span(make_span(session_id="mix"))
+    await sink.on_usage(make_usage(session_id="mix"))
+    await sink.on_title_update(
+        TitleUpdate(session_id="mix", segment_id="mix", kind="session", title="T")
+    )
+    await sink.close()
+
+    (key,) = fake_s3.list_keys()
+    records = [json.loads(line) for line in fake_s3.read_object(key).splitlines() if line]
+    assert len(records) == 4
+    assert records[0]["kind"]  # event
+    assert records[1]["type"] == "span"
+    assert records[2]["type"] == "usage"
+    assert records[3]["type"] == "title_update"
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_s3_upload_failure_drops_buffer_without_raising(fake_s3, caplog) -> None:
+    """Defined failure behavior: pointing at a non-existent bucket makes the real
+    boto3 client raise; the sink logs, clears the buffer (dropping the events),
+    and does NOT raise or retry. The valid bucket stays untouched."""
+    sink = S3Sink(bucket="does-not-exist-bucket", region=fake_s3.region, buffer_size=100)
+    await sink.on_event(make_event(session_id="lost"))
+
+    with caplog.at_level(logging.ERROR, logger="traceforge.sinks.s3"):
+        await sink.flush()  # must NOT raise
+
+    assert sink._buffer == []  # events were dropped, not retried
+    assert fake_s3.list_keys() == []  # nothing leaked into the real bucket
+    assert any("failed to upload" in r.message.lower() for r in caplog.records)

--- a/tests/e2e/test_sink_sqlite_e2e.py
+++ b/tests/e2e/test_sink_sqlite_e2e.py
@@ -1,0 +1,197 @@
+"""End-to-end tests for :class:`traceforge.sinks.sqlite_output.SqliteOutputSink`.
+
+Drives the real SQLite artifact: events are written, the sink is closed, and the
+database is *reopened with a fresh connection* and queried to prove rows,
+columns, and values persisted. Covers the queryable governance columns, the
+title upsert (keep-highest-version), the context-gaps table, id de-duplication,
+and the two *defined* failure behaviors observed in this sink — a write error is
+swallowed and logged (prior rows survive), while a connection error propagates.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import make_event
+from tests.e2e._sink_governance import governed_event
+from traceforge.governance.envelope import ContextGapEvent, EnrichedEvent
+from traceforge.governance.results import SessionMeta
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+from traceforge.types import EventKind, TitleUpdate
+
+
+def _query(db: Path, sql: str, params: tuple = ()) -> list[tuple]:
+    conn = sqlite3.connect(str(db))
+    try:
+        return conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+
+
+@pytest.mark.e2e
+async def test_sqlite_rows_persist_with_values(tmp_path: Path) -> None:
+    db = tmp_path / "out.db"
+    sink = SqliteOutputSink(path=str(db))
+    event = make_event(
+        kind=EventKind.TOOL_CALL_STARTED,
+        session_id="sess-1",
+        payload={"tool_name": "bash"},
+    )
+    await sink.on_event(event)
+    await sink.close()  # release the connection before reopening
+
+    rows = _query(
+        db,
+        "SELECT id, session_id, kind, tool_name FROM enriched_events WHERE session_id = ?",
+        ("sess-1",),
+    )
+    assert rows == [(event.id, "sess-1", EventKind.TOOL_CALL_STARTED, "bash")]
+
+
+@pytest.mark.e2e
+async def test_sqlite_schema_columns(tmp_path: Path) -> None:
+    db = tmp_path / "schema.db"
+    sink = SqliteOutputSink(path=str(db))
+    await sink.on_event(make_event(session_id="s"))
+    await sink.close()
+
+    cols = {row[1] for row in _query(db, "PRAGMA table_info(enriched_events)")}
+    assert {
+        "id",
+        "session_id",
+        "kind",
+        "timestamp",
+        "tool_name",
+        "risk_level",
+        "risk_score",
+        "action",
+        "payload_json",
+        "metadata_json",
+        "created_at",
+    } <= cols
+
+
+@pytest.mark.e2e
+async def test_sqlite_governance_columns_populated(tmp_path: Path) -> None:
+    db = tmp_path / "gov.db"
+    sink = SqliteOutputSink(path=str(db))
+    await sink.on_event(governed_event("deny", session_id="g1", tool_name="rm", score=88))
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT tool_name, risk_level, risk_score, action FROM enriched_events WHERE session_id = ?",
+        ("g1",),
+    )
+    assert rows == [("rm", "critical", 88, "deny")]
+
+
+@pytest.mark.e2e
+async def test_sqlite_duplicate_event_id_is_ignored(tmp_path: Path) -> None:
+    db = tmp_path / "dedup.db"
+    sink = SqliteOutputSink(path=str(db))
+    event = make_event(session_id="dup")
+    await sink.on_event(event)
+    await sink.on_event(event)  # same id -> INSERT OR IGNORE
+    await sink.close()
+
+    (count,) = _query(db, "SELECT COUNT(*) FROM enriched_events")[0]
+    assert count == 1
+
+
+@pytest.mark.e2e
+async def test_sqlite_title_upsert_keeps_highest_version(tmp_path: Path) -> None:
+    db = tmp_path / "titles.db"
+    sink = SqliteOutputSink(path=str(db))
+
+    async def title(version: int, text: str) -> None:
+        await sink.on_title_update(
+            TitleUpdate(
+                session_id="t",
+                segment_id="seg-1",
+                kind="activity",
+                title=text,
+                version=version,
+            )
+        )
+
+    await title(1, "provisional")
+    await title(3, "final")
+    await title(2, "stale")  # lower version -> must NOT overwrite
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT title, version FROM segment_titles WHERE segment_id = ? AND kind = ?",
+        ("seg-1", "activity"),
+    )
+    assert rows == [("final", 3)]
+
+
+@pytest.mark.e2e
+async def test_sqlite_context_gap_table(tmp_path: Path) -> None:
+    db = tmp_path / "gaps.db"
+    sink = SqliteOutputSink(path=str(db))
+    gap = ContextGapEvent(
+        id="g-1",
+        session_id="gs",
+        timestamp=datetime(2024, 5, 6, tzinfo=timezone.utc),
+        source_event_key="gap:gs:1:9",
+        dropped_count=9,
+        first_dropped_sequence=1,
+        last_dropped_sequence=9,
+        gap_ordinal=0,
+    )
+    await sink.on_enriched_event(
+        EnrichedEvent(event=gap, governance=SessionMeta(classification=None, risk_assessment=None))
+    )
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT id, session_id, dropped_count, reason FROM context_gaps WHERE session_id = ?",
+        ("gs",),
+    )
+    assert rows == [("g-1", "gs", 9, "backpressure")]
+
+
+@pytest.mark.e2e
+async def test_sqlite_write_error_is_dropped_prior_rows_survive(tmp_path: Path, caplog) -> None:
+    """Defined failure behavior: a write error is caught and logged, the event is
+    dropped, and previously-committed rows remain intact (no raise, no rollback)."""
+    db = tmp_path / "wfail.db"
+    sink = SqliteOutputSink(path=str(db))
+    await sink.on_event(make_event(session_id="ok"))  # opens conn + tables, 1 row
+    real_conn = sink._conn
+
+    class _BrokenConn:
+        def execute(self, *args, **kwargs):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        def commit(self) -> None:
+            pass
+
+    sink._conn = _BrokenConn()
+    with caplog.at_level(logging.ERROR, logger="traceforge.sinks.sqlite_output"):
+        await sink.on_event(make_event(session_id="boom"))  # must NOT raise
+
+    sink._conn = real_conn
+    await sink.close()
+
+    assert any("write failed" in r.message.lower() for r in caplog.records)
+    (count,) = _query(db, "SELECT COUNT(*) FROM enriched_events")[0]
+    assert count == 1  # the pre-existing row survived
+
+
+@pytest.mark.e2e
+async def test_sqlite_connection_error_propagates(tmp_path: Path) -> None:
+    """Defined failure behavior: a connection error (opening the db) is NOT
+    swallowed — it propagates, because ``_get_conn`` runs outside the write guard."""
+    sink = SqliteOutputSink(path=str(tmp_path))  # a directory, not a file
+    with pytest.raises(sqlite3.OperationalError):
+        await sink.on_event(make_event(session_id="x"))

--- a/tests/e2e/test_sink_webhook_e2e.py
+++ b/tests/e2e/test_sink_webhook_e2e.py
@@ -1,0 +1,113 @@
+"""End-to-end tests for :class:`traceforge.sinks.webhook.WebhookSink` (issue #83).
+
+POSTs real JSON over loopback HTTP to the ``webhook_receiver`` fixture and reads
+the recorded body + headers back to assert the delivered payload — including
+custom headers round-tripping and the governance-action filter deciding what is
+sent. Also pins the *defined* retry behavior: a transient failure is retried and
+eventually delivered; a permanent failure is retried exactly ``max_retries``
+times and then dropped (logged, never raised); a refused connection likewise
+never raises into the pipeline.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from tests.e2e._sink_governance import governed_event
+from traceforge.sinks.webhook import WebhookSink
+from traceforge.types import TitleUpdate
+
+pytestmark = [pytest.mark.e2e, pytest.mark.net]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_deny_delivers_payload_and_custom_headers(webhook_receiver) -> None:
+    sink = WebhookSink(url=webhook_receiver.url, headers={"X-Api-Key": "s3cr3t"})
+    event = governed_event("deny", session_id="wh-1", tool_name="rm", score=90)
+    await sink.on_event(event)
+
+    assert webhook_receiver.request_count == 1
+    (payload,) = webhook_receiver.received
+    assert payload["id"] == event.id
+    assert payload["session_id"] == "wh-1"
+    assert payload["governance"]["recommendation"]["action"] == "deny"
+    assert payload["governance"]["risk_assessment"]["score"] == 90
+
+    headers = webhook_receiver.requests[0]["headers"]
+    assert headers["content-type"] == "application/json"
+    assert headers["x-api-key"] == "s3cr3t"  # custom header round-trips
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_allow_is_filtered_out(webhook_receiver) -> None:
+    sink = WebhookSink(url=webhook_receiver.url)  # default filter: deny/escalate
+    await sink.on_event(governed_event("allow", session_id="wh-allow"))
+    assert webhook_receiver.request_count == 0
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_filter_actions_override(webhook_receiver) -> None:
+    sink = WebhookSink(url=webhook_receiver.url, filter_actions=["allow"])
+    await sink.on_event(governed_event("allow", session_id="wh-ovr"))
+    assert webhook_receiver.request_count == 1
+    assert webhook_receiver.received[0]["governance"]["recommendation"]["action"] == "allow"
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_title_update_posts_unconditionally(webhook_receiver) -> None:
+    sink = WebhookSink(url=webhook_receiver.url)
+    await sink.on_title_update(
+        TitleUpdate(session_id="wh-t", segment_id="seg", kind="session", title="Ship it", version=2)
+    )
+    (payload,) = webhook_receiver.received
+    assert payload["record"] == "title_update"
+    assert payload["title"] == "Ship it"
+    assert payload["version"] == 2
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_transient_failure_is_retried_then_delivered(webhook_receiver) -> None:
+    """Defined behavior: a single 503 is retried and the second attempt succeeds."""
+    webhook_receiver.fail_next(1)
+    sink = WebhookSink(url=webhook_receiver.url, max_retries=3)
+    await sink.on_event(governed_event("deny", session_id="wh-retry"))
+
+    assert webhook_receiver.request_count == 2  # first 503, second 200
+    assert webhook_receiver.received[-1]["session_id"] == "wh-retry"
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_permanent_failure_drops_after_max_retries(webhook_receiver) -> None:
+    """Defined behavior: a permanent 500 is retried exactly ``max_retries`` times
+    then dropped — logged, never raised."""
+    webhook_receiver.set_status(500)
+    sink = WebhookSink(url=webhook_receiver.url, max_retries=2)
+    await sink.on_event(governed_event("deny", session_id="wh-dead"))  # must NOT raise
+    assert webhook_receiver.request_count == 2  # exactly max_retries attempts
+
+
+@pytest.mark.e2e
+@pytest.mark.net
+async def test_webhook_connection_refused_does_not_raise() -> None:
+    sink = WebhookSink(url=f"http://127.0.0.1:{_free_port()}/hook", max_retries=2)
+    await sink.on_event(governed_event("deny", session_id="wh-refused"))  # swallowed, no raise
+
+
+@pytest.mark.e2e
+def test_webhook_rejects_non_http_scheme() -> None:
+    with pytest.raises(ValueError, match="scheme"):
+        WebhookSink(url="ftp://example.com/hook")


### PR DESCRIPTION
Closes #83

Wave 3 (🟠 output edge) of the E2E Test Coverage Epic (#90). **Tests only — no `src/` changes.** One e2e module per sink under `tests/e2e/`, each asserting the *real* output artifact plus the sink's defined failure/retry behavior. Deterministic, loopback-only (no external network).

## Modules added (54 tests)
| Module | Sink | Real artifact asserted |
| --- | --- | --- |
| `test_sink_jsonl_e2e.py` | JsonlSink | emitted file lines round-trip to the serialized event |
| `test_sink_sqlite_e2e.py` | SqliteOutputSink | rows reopened + queried; schema/values, upsert, gaps |
| `test_sink_parquet_e2e.py` | ParquetSink | file read back with pyarrow; schema, row count, list dims |
| `test_sink_s3_e2e.py` (net) | S3Sink | object PUT to moto bucket; key format + JSONL body |
| `test_sink_otel_e2e.py` (net) | OtelExporterSink | spans received by collector; names + attributes |
| `test_sink_webhook_e2e.py` (net) | WebhookSink | POST body + headers received; action filter |
| `test_sink_console_e2e.py` | ConsoleSink | injected stream captured verbatim; format + color |
| `test_sink_callback_e2e.py` | CallbackSink + adapter | per-record invocation with object identity |
| `test_sink_base_e2e.py` | StorageSink defaults | envelope forward/drop-warn + no-ops |

Plus `_sink_governance.py` — a shared governed-event factory (underscore-prefixed, not collected).

## Failure/retry paths (all assert *defined* behavior)
- **JSONL / SQLite write error** → dropped + logged, no raise (prior rows survive).
- **SQLite connect-to-dir** → propagates `OperationalError`.
- **Parquet write `OSError`** → propagates (re-raised by design).
- **S3 upload failure** → dropped + logged, buffer cleared, no retry, no raise.
- **OTel 5xx / connection refused** → swallowed, batch retained → retried on next flush.
- **Webhook transient 5xx** → retried then delivered; **permanent 5xx** → exactly `max_retries` attempts then dropped; **connection refused** → no raise.

No product bug warranted a strict-xfail: every failure path resolves to one of {retry, drop, propagate}. Design observations reported separately to the coordinator.

## Verification
- `uv run --no-progress python -m pytest -q -p no:cacheprovider tests/e2e/test_sink_*_e2e.py` → **54 passed**.
- Full suite: **2615 passed / 4 skipped / 4 xfailed** (baseline 2561/4/4 → +54, only-add; skips & xfails unchanged).
- `ruff check tests` + `ruff format --check tests` (0.15.20) → clean.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>