### PR TITLE
test(e2e): CLI subprocess e2e coverage (issue #85)

### DIFF
--- a/tests/e2e/_cli.py
+++ b/tests/e2e/_cli.py
@@ -1,0 +1,62 @@
+"""Shared subprocess driver for the CLI e2e stories (issue #85).
+
+Every CLI test runs ``python -m traceforge <cmd>`` as a *real* subprocess — the
+operator entry point — and asserts its exit code and stdout/stderr contract.
+Isolation is provided by the ``tmp_traceforge_home`` fixture (see
+``tests/e2e/conftest.py``): it patches ``$HOME``/``%USERPROFILE%`` (and the
+framework-detection env vars) in this pytest process, and ``subprocess.run``
+inherits that patched environment, so anything the child reads under
+``~/.traceforge`` / ``~/.claude`` lands in the sandbox.
+
+The parent decodes the child's streams as UTF-8 with ``errors="replace"`` so a
+child that itself fails to encode Unicode to a cp1252 console (a real Windows
+bug these tests pin) still yields capturable output instead of blowing up the
+harness.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+#: Generous ceiling for fast Click-validation invocations (they finish in ~2s);
+#: heavy commands that load the ML pipeline pass their own larger timeout.
+DEFAULT_TIMEOUT = 60.0
+
+
+def run_cli(
+    *args: str,
+    cwd: str | Path | None = None,
+    stdin: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke ``python -m traceforge`` with ``args`` and capture the result.
+
+    Args:
+        args: CLI arguments after ``traceforge`` (e.g. ``"detect", "--json-output"``).
+        cwd: Working directory for the child (defaults to the current one). Set it
+            to the sandbox home when a command probes ``Path.cwd()`` (``detect``'s
+            aider check) so detection stays deterministic.
+        stdin: Optional text piped to the child's stdin.
+        timeout: Hard wall-clock ceiling so a hung daemon can never wedge the suite.
+
+    Returns:
+        The completed process with ``.returncode``, ``.stdout``, ``.stderr``.
+    """
+    cmd: list[str] = [sys.executable, "-m", "traceforge", *args]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(cwd) if cwd is not None else None,
+        input=stdin,
+        timeout=timeout,
+    )
+
+
+def combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    """stdout + stderr joined, for asserting on a message regardless of stream."""
+    return f"{result.stdout}\n{result.stderr}"

--- a/tests/e2e/test_cli_config_e2e.py
+++ b/tests/e2e/test_cli_config_e2e.py
@@ -1,0 +1,147 @@
+"""End-to-end tests for the ``traceforge config`` group (issue #85).
+
+Covers the operator config lifecycle — ``init`` (write the default file),
+``show`` (print the effective config) and ``validate`` (accept good YAML, reject
+bad) — as real subprocesses against an isolated ``~/.traceforge``.
+
+Two happy paths (``validate`` on a valid file, ``show``) echo Unicode via
+``click.echo`` (a ``✓`` glyph and the ``─`` rules inside the default template)
+and therefore crash on a Windows cp1252 stdout. They are pinned with a strict
+conditional xfail so they are real passes on Linux CI and bug-pins on Windows.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+_CONFIG_REL = Path(".traceforge") / "config.yaml"
+
+_WIN_UNICODE_BUG_VALIDATE = (
+    "bug: `config validate` on a VALID file echoes '✓ Config valid' "
+    "(src/traceforge/cli/config_cmd.py:63); on Windows cp1252 stdout the glyph "
+    "raises UnicodeEncodeError, caught by the except clause, so a valid config "
+    "wrongly reports invalid and exits 1 instead of 0."
+)
+_WIN_UNICODE_BUG_SHOW = (
+    "bug: `config show` prints the default template, whose section rules use "
+    "U+2500 (src/traceforge/config/defaults.py); click.echo of that content "
+    "raises UnicodeEncodeError on Windows cp1252 stdout, exiting 1 instead of 0 "
+    "(src/traceforge/cli/config_cmd.py:47)."
+)
+
+
+@pytest.mark.e2e
+def test_config_init_writes_default_file(tmp_traceforge_home: Path) -> None:
+    target = tmp_traceforge_home / _CONFIG_REL
+    assert not target.exists()
+
+    result = run_cli("config", "init")
+
+    assert result.returncode == 0, combined_output(result)
+    assert target.is_file()
+    assert "Wrote default config" in result.stdout
+    assert target.read_text(encoding="utf-8").strip(), "config file is empty"
+
+
+@pytest.mark.e2e
+def test_config_init_refuses_to_clobber_without_force(tmp_traceforge_home: Path) -> None:
+    first = run_cli("config", "init")
+    assert first.returncode == 0, combined_output(first)
+
+    second = run_cli("config", "init")
+
+    assert second.returncode == 1
+    out = combined_output(second)
+    assert "already exists" in out
+    assert "--force" in out
+
+
+@pytest.mark.e2e
+def test_config_init_force_overwrites(tmp_traceforge_home: Path) -> None:
+    assert run_cli("config", "init").returncode == 0
+
+    result = run_cli("config", "init", "--force")
+
+    assert result.returncode == 0, combined_output(result)
+    assert "Wrote default config" in result.stdout
+
+
+@pytest.mark.e2e
+def test_config_validate_rejects_malformed_yaml(tmp_traceforge_home: Path) -> None:
+    bad = tmp_traceforge_home / "bad.yaml"
+    bad.write_text("foo: bar: baz\n", encoding="utf-8")  # nested mapping value → YAML error
+
+    result = run_cli("config", "validate", "--config", str(bad))
+
+    # Exit 1 holds on every platform (on Windows the '✗' echo also crashes, but
+    # the process still exits 1); the clean message is asserted where it is not
+    # masked by the Unicode crash.
+    assert result.returncode == 1, combined_output(result)
+    if not sys.platform.startswith("win"):
+        assert "Config invalid" in combined_output(result)
+
+
+@pytest.mark.e2e
+def test_config_validate_rejects_non_mapping(tmp_traceforge_home: Path) -> None:
+    seq = tmp_traceforge_home / "seq.yaml"
+    seq.write_text("- one\n- two\n", encoding="utf-8")  # valid YAML, but a list
+
+    result = run_cli("config", "validate", "--config", str(seq))
+
+    assert result.returncode == 1, combined_output(result)
+    if not sys.platform.startswith("win"):
+        assert "mapping" in combined_output(result).lower()
+
+
+@pytest.mark.e2e
+def test_config_validate_missing_path_is_usage_error(tmp_traceforge_home: Path) -> None:
+    missing = tmp_traceforge_home / "nope.yaml"
+
+    result = run_cli("config", "validate", "--config", str(missing))
+
+    assert result.returncode == 2
+    assert "does not exist" in combined_output(result)
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG_VALIDATE)
+def test_config_validate_accepts_valid_file(tmp_traceforge_home: Path) -> None:
+    assert run_cli("config", "init").returncode == 0
+
+    result = run_cli("config", "validate", cwd=tmp_traceforge_home)
+
+    assert result.returncode == 0, combined_output(result)
+    assert "valid" in combined_output(result).lower()
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG_SHOW)
+def test_config_show_prints_effective_config(tmp_traceforge_home: Path) -> None:
+    assert run_cli("config", "init").returncode == 0
+
+    result = run_cli("config", "show", cwd=tmp_traceforge_home)
+
+    assert result.returncode == 0, combined_output(result)
+    assert "# Source:" in result.stdout
+    assert "log_level" in result.stdout
+
+
+@pytest.mark.e2e
+def test_config_show_without_config_reports_cleanly(tmp_traceforge_home: Path) -> None:
+    result = run_cli("config", "show", cwd=tmp_traceforge_home)
+
+    assert result.returncode == 1
+    assert "No config file found" in combined_output(result)
+
+
+@pytest.mark.e2e
+def test_config_unknown_subcommand_is_usage_error(tmp_traceforge_home: Path) -> None:
+    result = run_cli("config", "definitely-not-a-subcommand")
+
+    assert result.returncode == 2
+    assert "No such command" in combined_output(result)

--- a/tests/e2e/test_cli_detect_e2e.py
+++ b/tests/e2e/test_cli_detect_e2e.py
@@ -1,0 +1,110 @@
+"""End-to-end tests for ``traceforge detect`` (issue #85).
+
+``detect`` is how an operator confirms traceforge can see their installed agents.
+These drive the real subprocess against the isolated ``tmp_traceforge_home`` and
+assert the exit code + output contract for the JSON surface (the machine-readable
+path an integration would parse) and the argument grammar.
+
+The human-readable table path emits a ``─`` rule via ``click.echo`` and so
+crashes on a Windows cp1252 stdout — a real product bug pinned below.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+# See test_config_cmd / status / init: one root cause across the CLI — Unicode
+# glyphs echoed without forcing UTF-8 fail on Windows' default cp1252 stdout.
+_WIN_UNICODE_BUG = (
+    "bug: `detect` (non-JSON) prints a U+2500 rule via click.echo "
+    "(src/traceforge/cli/detect.py:44); on Windows cp1252 stdout this raises "
+    "UnicodeEncodeError and the command exits 1 instead of 0."
+)
+
+
+def _seed_claude(home: Path) -> None:
+    (home / ".claude" / "projects").mkdir(parents=True, exist_ok=True)
+
+
+@pytest.mark.e2e
+def test_detect_json_output_reports_seeded_claude(tmp_traceforge_home: Path) -> None:
+    _seed_claude(tmp_traceforge_home)
+
+    # cwd=home so the aider detector (which probes Path.cwd()) also sees the
+    # sandbox — makes the detected set exactly {claude}.
+    result = run_cli("detect", "--json-output", cwd=tmp_traceforge_home)
+
+    assert result.returncode == 0, combined_output(result)
+    payload = json.loads(result.stdout)
+    assert isinstance(payload, list)
+    assert {entry["name"] for entry in payload} == {"claude"}
+    (claude,) = payload
+    assert claude["adapter"] == "claude"
+    assert claude["ingestion_mode"] == "file_watch"
+
+
+@pytest.mark.e2e
+def test_detect_json_output_empty_when_nothing_installed(tmp_traceforge_home: Path) -> None:
+    result = run_cli("detect", "--json-output", cwd=tmp_traceforge_home)
+
+    assert result.returncode == 0, combined_output(result)
+    assert json.loads(result.stdout) == []
+
+
+@pytest.mark.e2e
+def test_detect_frameworks_filter_scopes_detection(tmp_traceforge_home: Path) -> None:
+    _seed_claude(tmp_traceforge_home)
+
+    only_claude = run_cli(
+        "detect", "--frameworks", "claude", "--json-output", cwd=tmp_traceforge_home
+    )
+    assert only_claude.returncode == 0, combined_output(only_claude)
+    assert {e["name"] for e in json.loads(only_claude.stdout)} == {"claude"}
+
+    # Filtering to a framework that isn't installed yields an empty set even
+    # though claude *is* present — the filter, not availability, decides.
+    only_codex = run_cli(
+        "detect", "--frameworks", "codex", "--json-output", cwd=tmp_traceforge_home
+    )
+    assert only_codex.returncode == 0, combined_output(only_codex)
+    assert json.loads(only_codex.stdout) == []
+
+
+@pytest.mark.e2e
+def test_detect_unknown_framework_is_silently_empty(tmp_traceforge_home: Path) -> None:
+    result = run_cli(
+        "detect", "--frameworks", "not-a-framework", "--json-output", cwd=tmp_traceforge_home
+    )
+    assert result.returncode == 0, combined_output(result)
+    assert json.loads(result.stdout) == []
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG)
+def test_detect_plain_table_succeeds(tmp_traceforge_home: Path) -> None:
+    """The default (table) output should print detected frameworks and exit 0.
+
+    On Windows it currently crashes (see ``_WIN_UNICODE_BUG``); this is a strict
+    conditional xfail, so it is a real PASS on the Linux CI matrix and an
+    xfailed bug-pin on Windows.
+    """
+    _seed_claude(tmp_traceforge_home)
+
+    result = run_cli("detect", cwd=tmp_traceforge_home)
+
+    assert result.returncode == 0, combined_output(result)
+    assert "claude" in result.stdout
+
+
+@pytest.mark.e2e
+def test_detect_missing_frameworks_value_is_usage_error(tmp_traceforge_home: Path) -> None:
+    result = run_cli("detect", "--frameworks", cwd=tmp_traceforge_home)
+
+    assert result.returncode == 2
+    assert "requires an argument" in combined_output(result)

--- a/tests/e2e/test_cli_download_model_e2e.py
+++ b/tests/e2e/test_cli_download_model_e2e.py
@@ -1,0 +1,51 @@
+"""End-to-end tests for ``traceforge download-model`` (issue #85).
+
+This command (re)installs the titler weights, optionally from a GitHub-release
+mirror (``--source gh``). The DoD is explicit: assert argument handling only and
+**never hit the network**. So we drive the real subprocess for the arg grammar
+(help text + choice validation, which Click resolves before any install runs)
+and assert the ``gh`` mirror *target URL* in-process via the command's own URL
+builder — proving the ``--source gh`` path without downloading anything.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+
+@pytest.mark.e2e
+def test_download_model_help_lists_sources() -> None:
+    result = run_cli("download-model", "--help")
+
+    assert result.returncode == 0, combined_output(result)
+    out = result.stdout
+    assert "--source" in out
+    assert "pypi" in out and "gh" in out
+    assert "--version" in out
+
+
+@pytest.mark.e2e
+def test_download_model_rejects_unknown_source() -> None:
+    # Click validates the choice before the callback, so no install is attempted.
+    result = run_cli("download-model", "--source", "not-a-source")
+
+    assert result.returncode == 2
+    assert "Invalid value for '--source'" in combined_output(result)
+
+
+@pytest.mark.e2e
+def test_download_model_gh_mirror_url_shape() -> None:
+    """The ``--source gh`` path resolves to the pinned GitHub-release wheel URL.
+
+    Asserted through the command's own builder (no subprocess, no network) so the
+    mirror target is verified without triggering a real install/download.
+    """
+    from traceforge.cli.download_cmd import _MIRROR_VERSION, _REPO, _gh_wheel_url
+
+    url = _gh_wheel_url(_MIRROR_VERSION)
+
+    assert url.startswith(f"https://github.com/{_REPO}/releases/download/")
+    assert _MIRROR_VERSION in url
+    assert url.endswith(".whl")

--- a/tests/e2e/test_cli_gate_e2e.py
+++ b/tests/e2e/test_cli_gate_e2e.py
@@ -1,0 +1,39 @@
+"""End-to-end tests for ``traceforge gate`` (issue #85).
+
+``gate`` is the hook relay invoked by an agent (e.g. Claude Code PreToolUse). Its
+full stdin→IPC→verdict behavior against a live pipeline is the Wave-5 gate story
+(#86); here we pin the operator-facing *argument grammar* — the command refuses
+to run without ``--stdin`` and validates ``--format`` — as a real subprocess.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+
+@pytest.mark.e2e
+def test_gate_without_stdin_is_usage_error() -> None:
+    result = run_cli("gate")
+
+    assert result.returncode == 2
+    assert "--stdin is required" in combined_output(result)
+
+
+@pytest.mark.e2e
+def test_gate_rejects_unknown_format() -> None:
+    result = run_cli("gate", "--stdin", "--format", "not-a-format", stdin="{}")
+
+    assert result.returncode == 2
+    out = combined_output(result)
+    assert "Invalid value for '--format'" in out
+
+
+@pytest.mark.e2e
+def test_gate_help_lists_options() -> None:
+    result = run_cli("gate", "--help")
+
+    assert result.returncode == 0, combined_output(result)
+    assert "--stdin" in result.stdout
+    assert "--format" in result.stdout

--- a/tests/e2e/test_cli_init_e2e.py
+++ b/tests/e2e/test_cli_init_e2e.py
@@ -1,0 +1,54 @@
+"""End-to-end tests for ``traceforge init`` (issue #85, cross-ref #86).
+
+``init claude-code`` injects a PreToolUse hook into a project's
+``.claude/settings.json``. The deep gate-scaffold assertions belong to the
+Wave-5 gate story (#86); here we assert the operator contract lightly — a
+supported agent writes the settings file, an unsupported one is a Click usage
+error.
+
+The success path echoes a ``✓`` glyph *after* writing the file, so on a Windows
+cp1252 stdout it crashes with exit 1 (the file is still written). That is the
+same CLI-wide Unicode bug pinned elsewhere; here via a strict conditional xfail.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+_WIN_UNICODE_BUG = (
+    "bug: `init claude-code` echoes '✓ Wrote PreToolUse hook' after writing the "
+    "settings file (src/traceforge/cli/init_cmd.py:73); on Windows cp1252 stdout "
+    "the glyph raises UnicodeEncodeError and the command exits 1 instead of 0 "
+    "(the file is still written)."
+)
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG)
+def test_init_claude_code_writes_settings(tmp_traceforge_home: Path) -> None:
+    project = tmp_traceforge_home / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+
+    result = run_cli("init", "claude-code", "--project", str(project))
+
+    assert result.returncode == 0, combined_output(result)
+    settings = project / ".claude" / "settings.json"
+    assert settings.is_file()
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    pre_tool_use = data["hooks"]["PreToolUse"]
+    commands = [h.get("command", "") for entry in pre_tool_use for h in entry.get("hooks", [])]
+    assert any("gate --stdin" in c for c in commands), data
+
+
+@pytest.mark.e2e
+def test_init_unknown_agent_is_usage_error(tmp_traceforge_home: Path) -> None:
+    result = run_cli("init", "not-a-real-agent")
+
+    assert result.returncode == 2
+    assert "Invalid value" in combined_output(result)

--- a/tests/e2e/test_cli_replay_e2e.py
+++ b/tests/e2e/test_cli_replay_e2e.py
@@ -1,0 +1,84 @@
+"""End-to-end tests for ``traceforge replay`` (issue #85).
+
+``replay`` is the one-shot operator path: feed a captured session file through
+the real governance pipeline and emit governed events to a sink. The happy path
+loads the full ML pipeline (phase/boundary/titler), so it is marked ``slow`` and
+given a generous timeout; it writes to a JSONL sink (not the console) so its
+output is deterministic and free of the Unicode console pitfall.
+
+Argument-grammar failures are validated by Click *before* the callback runs, so
+those tests stay fast (no model load).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CLAUDE_TRACE = (
+    _REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "raw_traces"
+    / "claude"
+    / "demo_issue_tracker_contributing.jsonl"
+)
+
+
+def _small_claude_input(home: Path) -> Path:
+    """A trimmed copy of the committed claude trace — real native records, few
+    enough to keep processing bounded while the pipeline does the heavy lifting."""
+    if not _CLAUDE_TRACE.is_file():
+        pytest.skip(f"claude raw trace fixture missing: {_CLAUDE_TRACE}")
+    lines = _CLAUDE_TRACE.read_text(encoding="utf-8").splitlines()[:15]
+    dest = home / "session.jsonl"
+    dest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return dest
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_replay_processes_file_to_jsonl_sink(tmp_traceforge_home: Path) -> None:
+    source = _small_claude_input(tmp_traceforge_home)
+    out_path = tmp_traceforge_home / "governed.jsonl"
+
+    result = run_cli(
+        "replay",
+        str(source),
+        "--adapter",
+        "claude",
+        "--output",
+        str(out_path),
+        timeout=240.0,
+    )
+
+    assert result.returncode == 0, combined_output(result)
+    assert "Replay complete" in result.stdout
+    assert out_path.is_file(), "replay did not write the JSONL sink"
+    lines = [ln for ln in out_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert lines, "replay produced no governed events in the sink"
+
+
+@pytest.mark.e2e
+def test_replay_missing_path_is_usage_error(tmp_traceforge_home: Path) -> None:
+    missing = tmp_traceforge_home / "does-not-exist.jsonl"
+
+    result = run_cli("replay", str(missing), "--adapter", "claude")
+
+    assert result.returncode == 2
+    assert "does not exist" in combined_output(result)
+
+
+@pytest.mark.e2e
+def test_replay_requires_adapter(tmp_traceforge_home: Path) -> None:
+    source = tmp_traceforge_home / "session.jsonl"
+    source.write_text("{}\n", encoding="utf-8")  # existing path so PATH check passes
+
+    result = run_cli("replay", str(source))
+
+    assert result.returncode == 2
+    assert "adapter" in combined_output(result).lower()

--- a/tests/e2e/test_cli_score_e2e.py
+++ b/tests/e2e/test_cli_score_e2e.py
@@ -1,0 +1,71 @@
+"""End-to-end tests for ``traceforge score`` (issue #85).
+
+The Score API is the preflight HTTP surface a gate integration calls to ask
+"should this tool call proceed?". The ``score_server_url`` fixture spawns the
+real ``traceforge score`` subprocess on a free port and blocks until
+``GET /health`` returns 200, so a green test proves the CLI binds, serves, and
+scores. Everything is consolidated into one test to spawn the (ML-loading)
+server just once.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+
+def _get(url: str) -> tuple[int, object]:
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310 (loopback)
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, (json.loads(raw) if raw else None)
+
+
+def _post(url: str, payload: dict) -> tuple[int, object]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310 (loopback)
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, (json.loads(raw) if raw else None)
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_score_server_health_score_and_404(score_server_url: str) -> None:
+    # /health — the readiness contract the fixture and gate clients rely on.
+    status, body = _get(f"{score_server_url}/health")
+    assert status == 200
+    assert isinstance(body, dict) and body["status"] == "ok"
+
+    # /score — a real preflight scoring request returns a JSON verdict object.
+    status, verdict = _post(
+        f"{score_server_url}/score",
+        {"tool_name": "read_file", "arguments": {"path": "README.md"}, "session_id": "score-e2e"},
+    )
+    assert status == 200
+    assert isinstance(verdict, dict) and verdict
+
+    # Unknown routes are a clean 404, not a hang or a 500.
+    status, _ = _get(f"{score_server_url}/definitely-not-a-route")
+    assert status == 404
+
+
+@pytest.mark.e2e
+def test_score_bad_config_path_is_usage_error(tmp_traceforge_home: Path) -> None:
+    result = run_cli("score", "--config", str(tmp_traceforge_home / "nope.yaml"))
+
+    assert result.returncode == 2
+    assert "does not exist" in combined_output(result)

--- a/tests/e2e/test_cli_status_e2e.py
+++ b/tests/e2e/test_cli_status_e2e.py
@@ -1,0 +1,90 @@
+"""End-to-end tests for ``traceforge status`` (issue #85).
+
+``status`` reports governance-DB counters an operator uses to confirm the
+pipeline has run. We build a real (empty) ``system.db`` through the production
+``SystemStore`` so the schema matches, point ``--db`` at it, and assert the
+machine-readable JSON contract cross-platform. The missing-DB path must fail
+cleanly (exit 1, not a traceback).
+
+The human-readable table draws a ``─`` rule and so crashes on a Windows cp1252
+stdout — pinned with a strict conditional xfail (real pass on Linux CI).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+_WIN_UNICODE_BUG = (
+    "bug: `status` (non-JSON) prints a U+2500 rule via click.echo "
+    "(src/traceforge/cli/status.py:59); on Windows cp1252 stdout this raises "
+    "UnicodeEncodeError and the command exits 1 instead of 0."
+)
+
+_EXPECTED_KEYS = {
+    "active_sessions",
+    "processed_events",
+    "mcp_profiles",
+    "completed_sessions",
+    "last_session_recommendations",
+}
+
+
+def _build_system_db(home: Path) -> Path:
+    """Create an empty but schema-complete governance DB via the real store."""
+    from traceforge.governance.persistence import SystemStore
+
+    db_path = home / "system.db"
+    store = SystemStore(db_path)  # runs migrations → all tables status queries
+    store.close()
+    return db_path
+
+
+@pytest.mark.e2e
+def test_status_json_output_reports_zeroed_counters(tmp_traceforge_home: Path) -> None:
+    db_path = _build_system_db(tmp_traceforge_home)
+
+    result = run_cli("status", "--json-output", "--db", str(db_path))
+
+    assert result.returncode == 0, combined_output(result)
+    stats = json.loads(result.stdout)
+    assert set(stats) == _EXPECTED_KEYS
+    assert stats["active_sessions"] == 0
+    assert stats["processed_events"] == 0
+    assert stats["mcp_profiles"] == 0
+    assert stats["completed_sessions"] == 0
+    assert stats["last_session_recommendations"] is None
+
+
+@pytest.mark.e2e
+def test_status_missing_db_reports_cleanly(tmp_traceforge_home: Path) -> None:
+    missing = tmp_traceforge_home / "absent.db"
+
+    result = run_cli("status", "--json-output", "--db", str(missing))
+
+    assert result.returncode == 1
+    assert "No system database found" in combined_output(result)
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG)
+def test_status_plain_table_succeeds(tmp_traceforge_home: Path) -> None:
+    db_path = _build_system_db(tmp_traceforge_home)
+
+    result = run_cli("status", "--db", str(db_path))
+
+    assert result.returncode == 0, combined_output(result)
+    assert "System Status" in result.stdout
+
+
+@pytest.mark.e2e
+def test_status_unknown_option_is_usage_error(tmp_traceforge_home: Path) -> None:
+    result = run_cli("status", "--not-a-real-option")
+
+    assert result.returncode == 2
+    assert "No such option" in combined_output(result)

--- a/tests/e2e/test_cli_watch_e2e.py
+++ b/tests/e2e/test_cli_watch_e2e.py
@@ -1,0 +1,72 @@
+"""End-to-end tests for ``traceforge watch`` (issue #85).
+
+``watch`` is the primary daemon: detect frameworks, bind the gate IPC server,
+run the governance pipeline. We exercise three lifecycles as real subprocesses:
+
+* **no detection** — exits 0 with a clear message (fast, no pipeline).
+* **``--once``** — a bounded run that starts the pipeline, processes existing
+  content, and shuts down cleanly with exit 0 (the ``--once``-style teardown the
+  DoD calls for).
+* **daemon** — via the shared ``watch_daemon`` fixture: it binds the gate IPC
+  server and registers the ``_default`` session before we assert.
+
+Argument-grammar failures (Click) round out the contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import combined_output, run_cli
+
+
+@pytest.mark.e2e
+def test_watch_without_detected_framework_exits_zero(tmp_traceforge_home: Path) -> None:
+    # No ~/.claude/projects seeded → nothing to watch → clean exit, not a hang.
+    result = run_cli("watch", "--frameworks", "claude")
+
+    assert result.returncode == 0, combined_output(result)
+    assert "No frameworks detected" in combined_output(result)
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_watch_once_starts_pipeline_and_exits_clean(tmp_traceforge_home: Path) -> None:
+    # Seed the framework so detection succeeds; --once processes existing content
+    # (none) and tears the pipeline down, so the daemon returns on its own.
+    (tmp_traceforge_home / ".claude" / "projects").mkdir(parents=True, exist_ok=True)
+
+    result = run_cli("watch", "--frameworks", "claude", "--once", "--no-score", timeout=240.0)
+
+    assert result.returncode == 0, combined_output(result)
+    assert "Detected 1 framework" in combined_output(result)
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_watch_daemon_binds_gate_ipc(watch_daemon, gate_socket_lookup) -> None:
+    assert watch_daemon.is_running(), watch_daemon.output
+    assert watch_daemon.system_db.exists()
+
+    # The CLI's operator-facing wiring: it announced the gate server and
+    # registered the default session so hook clients can find it.
+    assert "Gate IPC server listening" in watch_daemon.output
+    assert gate_socket_lookup("_default"), watch_daemon.output
+
+
+@pytest.mark.e2e
+def test_watch_bad_config_path_is_usage_error(tmp_traceforge_home: Path) -> None:
+    result = run_cli("watch", "--config", str(tmp_traceforge_home / "nope.yaml"))
+
+    assert result.returncode == 2
+    assert "does not exist" in combined_output(result)
+
+
+@pytest.mark.e2e
+def test_watch_unknown_option_is_usage_error(tmp_traceforge_home: Path) -> None:
+    result = run_cli("watch", "--not-a-real-option")
+
+    assert result.returncode == 2
+    assert "No such option" in combined_output(result)


### PR DESCRIPTION
## Summary

Wave 4 of the E2E Test Coverage Epic (#90): operator-entry-point (CLI) end-to-end tests. Each test drives the **real** `python -m traceforge <cmd>` subprocess through the shared e2e harness and asserts exit codes + stdout/stderr/JSON contracts. **Tests only — no `src/` changes.**

Commands covered: `watch`, `replay`, `score`, `gate`, `detect`, `init`, `status`, `config`, `download-model`.

## What's added (all under `tests/e2e/`)

- `_cli.py` — shared subprocess driver (`run_cli`, `combined_output`) using UTF-8 capture with `errors="replace"`.
- `test_cli_detect_e2e.py` — JSON detected-set (seeded via `tmp_traceforge_home`), `--frameworks` filter, empty/unknown, plain-table, arg errors.
- `test_cli_config_e2e.py` — `config init`/`--force`/`show`/`validate` (valid + malformed + non-mapping), missing paths, unknown subcommand.
- `test_cli_status_e2e.py` — `--json-output --db <path>` counters (DB built in-test via `SystemStore`), missing-DB error, plain table, unknown option.
- `test_cli_replay_e2e.py` — happy path (real ML pipeline → JSONL sink) + arg errors.
- `test_cli_watch_e2e.py` — no-detection exit 0, `--once` clean teardown, daemon gate-IPC bind (`watch_daemon` + `gate_socket_lookup`), arg errors.
- `test_cli_score_e2e.py` — `/health`, `/score` verdict, 404 via `score_server_url`; bad-config arg error.
- `test_cli_gate_e2e.py` — `--stdin` required, `--format` validation, `--help` (relay depth deferred to #86).
- `test_cli_init_e2e.py` — `init claude-code` writes `.claude/settings.json`; unknown agent usage error (scaffold depth deferred to #86).
- `test_cli_download_model_e2e.py` — `--help`/`--source` arg grammar + in-process `gh` mirror-URL assertion. **No network is hit.**

Every command also asserts bad args → non-zero exit + Click usage error. Long-running/daemon tests are marked `slow` and bounded by timeouts / `--once` teardown; all tests marked `e2e`.

## Suite delta

Windows local: **2594 passed, 4 skipped, 9 xfailed** (baseline 2561 / 4 / 4) → **+33 passed, +5 xfailed, 0 new skips**. 38 new tests (33 pass + 5 conditional-xfail on Windows). Only additions.

Lint: `ruff check` clean, `ruff format --check` clean (ruff==0.15.20).

## Product bug pinned (NOT fixed — see #85 constraints)

**Windows cp1252 Unicode-echo crash.** The CLI `click.echo`s Unicode glyphs (`─` U+2500, `✓` U+2713, `✗` U+2717) without forcing UTF-8. On a Windows cp1252 stdout this raises `UnicodeEncodeError` and the command exits 1. Notably, `config validate` on a **valid** config wrongly exits 1 (the `✓` echo raises, is caught by a broad `except`, then misreported as invalid).

Affected source:
- `src/traceforge/cli/detect.py` (plain-table `─` rule)
- `src/traceforge/cli/status.py` (plain-table `─` rule)
- `src/traceforge/cli/config_cmd.py` (`show` template `─`; `validate` `✓`/`✗`)
- `src/traceforge/cli/init_cmd.py` (`✓ Wrote PreToolUse hook` after writing the file)
- `src/traceforge/config/defaults.py` (template contains `─` box rules)

Repro (Windows): `python -m traceforge detect` (or `config validate <valid.yaml>`) on a cp1252 console → `UnicodeEncodeError` → exit 1. JSON/ASCII paths are unaffected.

Pinned via `@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, ...)` on the 5 glyph-echoing tests — real PASS on Linux CI, strict XFAIL bug-pin on Windows. Machine-readable (JSON) paths are asserted cross-platform with no xfail.

Closes #85

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>