### PR TITLE
test(e2e): config precedence + SDK facade coverage (issue #88)

### DIFF
--- a/tests/e2e/test_config_precedence_e2e.py
+++ b/tests/e2e/test_config_precedence_e2e.py
@@ -1,0 +1,334 @@
+"""End-to-end tests for configuration precedence and ``TRACEFORGE_*`` overrides.
+
+Covers issue #88 (Wave 7a): ``config/loader.py::load_config`` resolves values with
+the precedence chain **kwargs > TRACEFORGE_* env > YAML > Pydantic defaults**, the
+module singleton is reset via ``reset_config()``, and the resolved config makes a
+real round-trip through :meth:`traceforge.sdk.Pipeline.from_config`.
+
+Isolation is load-bearing here, for two reasons the coordinator flagged as the
+flakiness risk:
+
+* The config layer is a **module singleton** (``loader._config`` / ``_bootstrapped``).
+  Every test calls ``reset_config()`` before and after so no config state leaks
+  across tests.
+* The loader resolves the ``~/.traceforge`` paths as **module-level constants
+  computed at import time** — long before ``tmp_traceforge_home`` patches ``$HOME``.
+  The ``config_env`` fixture ``monkeypatch.setattr``s those constants into the
+  throwaway home so bootstrap/discovery can never read or write the real
+  ``~/.traceforge``.
+
+The matrix tests drive ``TRACEFORGE_CONFIG`` at a written YAML file: that env var
+short-circuits file discovery to exactly one file (see ``_find_config_files``), so
+each layer under test is controlled and the user/project bootstrap files never
+bleed in.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from traceforge.config import loader
+from traceforge.config.loader import get_config, load_config, reset_config
+from traceforge.config.models import TraceforgeConfig
+from traceforge.sdk import Pipeline
+
+pytestmark = pytest.mark.e2e
+
+
+# ─── Isolation fixture + layering helpers ─────────────────────────────────────
+
+
+@pytest.fixture
+def config_env(tmp_traceforge_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fully isolate the config-singleton surface for one test.
+
+    Builds on ``tmp_traceforge_home`` (isolated ``$HOME``) and additionally:
+
+    * redirects the loader's import-time path constants into the sandbox so
+      bootstrap/discovery stay off the real ``~/.traceforge``;
+    * scrubs **every** ``TRACEFORGE_*`` env var (``tmp_traceforge_home`` only drops
+      ``TRACEFORGE_CONFIG``), so a stray override from the host can't contaminate;
+    * calls ``reset_config()`` before *and* after so the singleton never leaks.
+    """
+    tf_dir = tmp_traceforge_home / ".traceforge"
+    monkeypatch.setattr(loader, "_USER_CONFIG_DIR", tf_dir)
+    monkeypatch.setattr(loader, "_USER_MAPPINGS_DIR", tf_dir / "mappings")
+    monkeypatch.setattr(loader, "_USER_CONFIG_FILE", tf_dir / "config.yaml")
+    monkeypatch.setattr(loader, "_PROJECT_CONFIG_FILE", tmp_traceforge_home / "traceforge.yaml")
+
+    for key in [k for k in os.environ if k.startswith("TRACEFORGE_")]:
+        monkeypatch.delenv(key, raising=False)
+
+    reset_config()
+    yield tmp_traceforge_home
+    reset_config()
+
+
+def _nested(dotted: str, value) -> dict:
+    """Expand ``"a.b.c", 1`` into ``{"a": {"b": {"c": 1}}}`` for YAML bodies."""
+    out: dict = {}
+    cursor = out
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        cursor[part] = {}
+        cursor = cursor[part]
+    cursor[parts[-1]] = value
+    return out
+
+
+def _get(cfg: TraceforgeConfig, dotted: str):
+    """Read a dotted attribute path off a resolved config object."""
+    obj = cfg
+    for part in dotted.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+def _load_layered(
+    home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    yaml_data: dict | None = None,
+    env: dict[str, str] | None = None,
+    kwargs: dict | None = None,
+) -> TraceforgeConfig:
+    """Write a YAML file, point ``TRACEFORGE_CONFIG`` at it, layer env + kwargs, load.
+
+    ``TRACEFORGE_CONFIG`` makes discovery return exactly this file, so the YAML
+    layer is precisely what we wrote — nothing from the sandbox bootstrap leaks in.
+    """
+    cfg_file = home / "layered.yaml"
+    cfg_file.write_text(yaml.safe_dump(yaml_data or {}), encoding="utf-8")
+    monkeypatch.setenv("TRACEFORGE_CONFIG", str(cfg_file))
+    for key, val in (env or {}).items():
+        monkeypatch.setenv(key, val)
+    reset_config()
+    return load_config(**(kwargs or {}))
+
+
+# Representative keys spanning the shapes the AC calls out: a threshold int, a
+# gate-enable bool, a deeply-nested threshold, and a model-path string. Each YAML
+# value is chosen to differ from the Pydantic default so "YAML beats default" is
+# an honest assertion. (Defaults: sdk.batch_size=64, score.enabled=True,
+# governance.budget.max_tool_calls=None, title...api.model="gpt-4o-mini".)
+NESTED_KEYS = [
+    ("sdk.batch_size", "TRACEFORGE_SDK__BATCH_SIZE", 16, "128", 128),
+    ("score.enabled", "TRACEFORGE_SCORE__ENABLED", False, "true", True),
+    (
+        "governance.budget.max_tool_calls",
+        "TRACEFORGE_GOVERNANCE__BUDGET__MAX_TOOL_CALLS",
+        3,
+        "9",
+        9,
+    ),
+    (
+        "title.session_naming.api.model",
+        "TRACEFORGE_TITLE__SESSION_NAMING__API__MODEL",
+        "yaml-model",
+        "env-model",
+        "env-model",
+    ),
+]
+
+
+# ─── Scalar precedence: full chain on one top-level key (log_level) ────────────
+
+
+def test_kwarg_beats_env_beats_yaml_scalar(config_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """All four layers set on ``log_level`` -> the explicit kwarg wins."""
+    cfg = _load_layered(
+        config_env,
+        monkeypatch,
+        yaml_data={"log_level": "WARNING"},
+        env={"TRACEFORGE_LOG_LEVEL": "ERROR"},
+        kwargs={"log_level": "DEBUG"},
+    )
+    assert cfg.log_level == "DEBUG"
+
+
+def test_env_beats_yaml_scalar(config_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """No kwarg -> the ``TRACEFORGE_*`` env override beats the YAML value."""
+    cfg = _load_layered(
+        config_env,
+        monkeypatch,
+        yaml_data={"log_level": "WARNING"},
+        env={"TRACEFORGE_LOG_LEVEL": "ERROR"},
+    )
+    assert cfg.log_level == "ERROR"
+
+
+def test_yaml_beats_default_scalar(config_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """No env/kwarg -> YAML beats the Pydantic default (which differs)."""
+    cfg = _load_layered(config_env, monkeypatch, yaml_data={"log_level": "WARNING"})
+    assert cfg.log_level == "WARNING"
+    assert TraceforgeConfig().log_level != "WARNING"  # default is INFO
+
+
+def test_unset_falls_back_to_default_scalar(config_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """Empty YAML, no env/kwarg -> the Pydantic default surfaces."""
+    cfg = _load_layered(config_env, monkeypatch, yaml_data={})
+    assert cfg.log_level == TraceforgeConfig().log_level == "INFO"
+
+
+# ─── Nested representative keys: thresholds, gate-enable, model path ───────────
+
+
+@pytest.mark.parametrize(
+    "dotted,env_var,yaml_val,env_str,env_typed",
+    NESTED_KEYS,
+    ids=[row[0] for row in NESTED_KEYS],
+)
+def test_env_beats_yaml_nested(
+    config_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dotted: str,
+    env_var: str,
+    yaml_val,
+    env_str: str,
+    env_typed,
+):
+    """For each representative key, the env override beats YAML and is coerced
+    to the right scalar type (bool/int/str) by ``_coerce_env_value``."""
+    cfg = _load_layered(
+        config_env,
+        monkeypatch,
+        yaml_data=_nested(dotted, yaml_val),
+        env={env_var: env_str},
+    )
+    resolved = _get(cfg, dotted)
+    assert resolved == env_typed
+    assert type(resolved) is type(env_typed)  # e.g. "false" -> bool, "9" -> int
+
+
+@pytest.mark.parametrize(
+    "dotted,env_var,yaml_val,env_str,env_typed",
+    NESTED_KEYS,
+    ids=[row[0] for row in NESTED_KEYS],
+)
+def test_yaml_beats_default_nested(
+    config_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dotted: str,
+    env_var: str,
+    yaml_val,
+    env_str: str,
+    env_typed,
+):
+    """With no env override, the YAML value populates the key and differs from
+    the built-in default (proving YAML > defaults)."""
+    cfg = _load_layered(config_env, monkeypatch, yaml_data=_nested(dotted, yaml_val))
+    assert _get(cfg, dotted) == yaml_val
+    assert _get(TraceforgeConfig(), dotted) != yaml_val
+
+
+@pytest.mark.parametrize(
+    "dotted,env_var,yaml_val,env_str,env_typed",
+    NESTED_KEYS,
+    ids=[row[0] for row in NESTED_KEYS],
+)
+def test_unset_falls_back_to_default_nested(
+    config_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dotted: str,
+    env_var: str,
+    yaml_val,
+    env_str: str,
+    env_typed,
+):
+    """Empty YAML and no env -> each key falls back to its Pydantic default."""
+    cfg = _load_layered(config_env, monkeypatch, yaml_data={})
+    assert _get(cfg, dotted) == _get(TraceforgeConfig(), dotted)
+
+
+def test_kwarg_deep_merge_beats_env_nested(config_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """A nested-dict kwarg is deep-merged last, so it beats the env override too."""
+    cfg = _load_layered(
+        config_env,
+        monkeypatch,
+        yaml_data={"sdk": {"batch_size": 16}},
+        env={"TRACEFORGE_SDK__BATCH_SIZE": "128"},
+        kwargs={"sdk": {"batch_size": 999}},
+    )
+    assert cfg.sdk.batch_size == 999
+
+
+def test_env_bool_coercion_both_directions(config_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """The gate-enable bool coerces from string in both directions ("false"/"true")."""
+    off = _load_layered(config_env, monkeypatch, env={"TRACEFORGE_SCORE__ENABLED": "false"})
+    assert off.score.enabled is False
+    on = _load_layered(config_env, monkeypatch, env={"TRACEFORGE_SCORE__ENABLED": "true"})
+    assert on.score.enabled is True
+
+
+# ─── Singleton reset semantics (the cross-test contamination guard) ───────────
+
+
+def test_reset_config_prevents_singleton_leak(config_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """``get_config`` caches; only ``reset_config`` picks up a changed YAML.
+
+    This is the exact mechanic the coordinator flagged: without ``reset_config``
+    the module singleton would carry a prior test's config forward.
+    """
+    home = config_env
+    cfg_file = home / "singleton.yaml"
+    monkeypatch.setenv("TRACEFORGE_CONFIG", str(cfg_file))
+
+    cfg_file.write_text(yaml.safe_dump({"sdk": {"batch_size": 16}}), encoding="utf-8")
+    reset_config()
+    assert load_config().sdk.batch_size == 16
+    assert get_config().sdk.batch_size == 16  # cached singleton
+
+    # Rewrite the file but do NOT reset -> the cached singleton is unchanged.
+    cfg_file.write_text(yaml.safe_dump({"sdk": {"batch_size": 32}}), encoding="utf-8")
+    assert get_config().sdk.batch_size == 16
+
+    # After an explicit reset the next access reloads from disk.
+    reset_config()
+    assert get_config().sdk.batch_size == 32
+
+
+# ─── Real round-trip through Pipeline.from_config ─────────────────────────────
+
+
+def test_pipeline_from_config_env_beats_yaml_project_root(
+    config_env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A real ``Pipeline.from_config`` resolves ``governance.project_root`` with
+    env beating YAML.
+
+    ``governance._project_root`` is the genuine config-flow observable: the value
+    threads config -> ``GovernancePipeline.create`` -> ``instance._project_root``
+    (see governance/pipeline.py), so asserting on it proves the resolved config
+    actually reached the constructed pipeline — not just the loader dict.
+    """
+    home = config_env
+    cfg_file = home / "roundtrip.yaml"
+    cfg_file.write_text(
+        yaml.safe_dump({"governance": {"project_root": "yaml-root"}}), encoding="utf-8"
+    )
+    monkeypatch.setenv("TRACEFORGE_GOVERNANCE__PROJECT_ROOT", "env-root")
+    reset_config()
+
+    pipeline = Pipeline.from_config(path=cfg_file)
+    assert pipeline.governance._project_root == "env-root"
+
+
+def test_pipeline_from_config_yaml_beats_default_project_root(
+    config_env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """With no env override, ``Pipeline.from_config`` carries the YAML value
+    (default ``project_root`` is ``None``)."""
+    home = config_env
+    cfg_file = home / "roundtrip.yaml"
+    cfg_file.write_text(
+        yaml.safe_dump({"governance": {"project_root": "yaml-root"}}), encoding="utf-8"
+    )
+    reset_config()
+
+    pipeline = Pipeline.from_config(path=cfg_file)
+    assert pipeline.governance._project_root == "yaml-root"
+    assert TraceforgeConfig().governance.project_root is None

--- a/tests/e2e/test_sdk_facade_e2e.py
+++ b/tests/e2e/test_sdk_facade_e2e.py
@@ -1,0 +1,225 @@
+"""End-to-end tests for the SDK programmatic facade (``traceforge.sdk.Pipeline``).
+
+Covers issue #88 (Wave 7a). The existing suite exercises ``GovernancePipeline``
+directly; nothing drove the public ``traceforge.sdk.Pipeline`` facade end-to-end
+until now. These tests close that gap:
+
+* **Preflight scoring** — ``Pipeline.score_tool_call`` on a dangerous request
+  yields a high risk score + an escalating recommendation; a benign request scores
+  low. (Deterministic, engine-driven — no ML mock.)
+* **Full observe path** — ``Pipeline.create(sinks=[...]).push(...)`` enriches,
+  classifies, governs, and emits: the governance ``SessionMeta`` lands on
+  ``event.metadata.governance`` for both a real file sink (JSONL into the isolated
+  home) and a live callback sink.
+* **Gating layer** — a :class:`GatePolicy` preflight denies a dangerous call with a
+  surfaced reason and allows a benign one; a postflight redacts/suppresses tool
+  output; and the :class:`Verdict` allow/deny + reason surface is asserted directly.
+
+Structuring (phase/boundary/title ML) is disabled on the pushed pipelines: it is a
+separate story's surface (#87), loads models lazily, and would only add nondeterminism
+here. Governance stays on — it is the surface under test.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from traceforge.governance.shield import Shield
+from traceforge.sdk import GatePolicy, Pipeline, Verdict
+from traceforge.sdk.gate_types import PostflightAction, PostflightVerdict
+from traceforge.sinks.jsonl import JsonlSink
+from traceforge.types import EventKind, SessionEvent
+
+pytestmark = pytest.mark.e2e
+
+_DANGEROUS_CMD = "rm -rf /"
+_BENIGN_CMD = "cat README.md"
+
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+
+def _score_payload(command: str, session_id: str) -> dict:
+    """A ``score_tool_call`` payload (uses the ``tool_input`` shape)."""
+    return {
+        "tool_name": "bash",
+        "tool_input": {"command": command},
+        "session_id": session_id,
+    }
+
+
+def _tool_event(kind: str, command: str, session_id: str, call_id: str) -> SessionEvent:
+    """A push-path tool event (uses the ``arguments`` shape the enricher reads)."""
+    return SessionEvent(
+        kind=kind,
+        session_id=session_id,
+        timestamp=datetime.now(timezone.utc),
+        payload={
+            "tool_name": "bash",
+            "arguments": {"command": command},
+            "tool_call_id": call_id,
+        },
+    )
+
+
+def _deny_high_risk(request, ctx) -> Verdict:
+    """Preflight gate: deny anything the engine scored as materially risky."""
+    if request.risk_score >= 50:
+        return Verdict.deny(f"blocked: risk {request.risk_score} over threshold")
+    return Verdict.allow()
+
+
+def _postflight_redact_or_suppress(result, ctx) -> PostflightVerdict:
+    """Postflight gate: redact a known secret marker, suppress a block marker."""
+    text = str(result.output)
+    if "SECRET" in text:
+        return PostflightVerdict(
+            action=PostflightAction.REDACT, reason="pii", redaction_keys=("SECRET",)
+        )
+    if "BLOCKME" in text:
+        return PostflightVerdict(action=PostflightAction.SUPPRESS, reason="policy block")
+    return PostflightVerdict(action=PostflightAction.ACCEPT)
+
+
+# ─── Preflight scoring via the facade ─────────────────────────────────────────
+
+
+def test_score_tool_call_flags_dangerous_command(tmp_traceforge_home: Path):
+    """``Pipeline.score_tool_call`` on ``rm -rf /`` -> high score + escalation."""
+    pipeline = Pipeline.create(enable_structure=False, enable_title=False)
+    trace = pipeline.score_tool_call(_score_payload(_DANGEROUS_CMD, "score-danger"))
+
+    assert trace.risk_score > 50
+    assert str(trace.risk_band) in {"danger", "critical"}
+    # suggested_action is a Recommendation StrEnum; a dangerous call must escalate.
+    assert str(trace.suggested_action) in {"warn", "escalate", "deny"}
+
+
+def test_score_tool_call_benign_command_low_risk(tmp_traceforge_home: Path):
+    """A read-only ``cat`` scores low and does not escalate."""
+    pipeline = Pipeline.create(enable_structure=False, enable_title=False)
+    trace = pipeline.score_tool_call(_score_payload(_BENIGN_CMD, "score-benign"))
+
+    assert trace.risk_score < 50
+    assert str(trace.suggested_action or "allow") in {"allow", "warn"}
+    # And it must score strictly below the dangerous request on the same engine.
+    danger = pipeline.score_tool_call(_score_payload(_DANGEROUS_CMD, "score-benign"))
+    assert trace.risk_score < danger.risk_score
+
+
+# ─── Full observe path: create -> push -> enriched/governed output to a sink ──
+
+
+async def test_push_stamps_governance_into_jsonl_sink(tmp_traceforge_home: Path):
+    """The facade's push path writes an enriched, governed event to a real sink.
+
+    A started+completed tool pair merges into one emitted event; the JSONL record
+    carries both ``metadata.classification`` (enrichment ran) and
+    ``metadata.governance`` with a high risk score (the governance stage ran).
+    """
+    out_dir = tmp_traceforge_home / ".traceforge" / "sink-out"
+    sink = JsonlSink(str(out_dir / "{session_id}.jsonl"))
+    session_id = "danger-sess"
+
+    async with Pipeline.create(
+        sinks=[sink], enable_structure=False, enable_title=False
+    ) as pipeline:
+        await pipeline.push(
+            _tool_event(EventKind.TOOL_CALL_STARTED, _DANGEROUS_CMD, session_id, "tc1")
+        )
+        await pipeline.push(
+            _tool_event(EventKind.TOOL_CALL_COMPLETED, _DANGEROUS_CMD, session_id, "tc1")
+        )
+
+    written = out_dir / f"{session_id}.jsonl"
+    lines = [ln for ln in written.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 1
+
+    record = json.loads(lines[0])
+    metadata = record["metadata"]
+    assert metadata.get("classification") is not None
+    governance = metadata.get("governance")
+    assert governance is not None
+    assert governance["risk_assessment"]["score"] > 50
+
+
+async def test_push_delivers_governed_event_to_callback_sink(
+    tmp_traceforge_home: Path, recording_sink
+):
+    """The same push path stamps governance onto the live ``SessionEvent`` object
+    a callback sink receives (not just the serialized form)."""
+    session_id = "cb-danger"
+    async with Pipeline.create(
+        sinks=[recording_sink.sink], enable_structure=False, enable_title=False
+    ) as pipeline:
+        await pipeline.push(
+            _tool_event(EventKind.TOOL_CALL_STARTED, _DANGEROUS_CMD, session_id, "tc1")
+        )
+        await pipeline.push(
+            _tool_event(EventKind.TOOL_CALL_COMPLETED, _DANGEROUS_CMD, session_id, "tc1")
+        )
+
+    governed = [
+        e for e in recording_sink.events if e.metadata is not None and e.metadata.governance
+    ]
+    assert len(governed) == 1
+    event = governed[0]
+    assert event.metadata.classification is not None
+    assert event.metadata.governance.risk_assessment.score > 50
+
+
+# ─── Gating layer: preflight deny/allow, postflight redact/suppress, Verdict ──
+
+
+def test_gatepolicy_preflight_denies_dangerous_and_allows_benign(tmp_traceforge_home: Path):
+    """A ``GatePolicy`` preflight denies a dangerous call (reason surfaced) and
+    allows a benign one, driven through the facade's governance engine."""
+    policy = GatePolicy().preflight(_deny_high_risk)
+    pipeline = Pipeline.create(policy=policy, enable_structure=False, enable_title=False)
+
+    danger_trace = pipeline.score_tool_call(_score_payload(_DANGEROUS_CMD, "gate-d"))
+    verdict = pipeline.governance._run_preflight(danger_trace, session_id="gate-d")
+    assert verdict.denied is True
+    assert "blocked" in verdict.reason and str(danger_trace.risk_score) in verdict.reason
+
+    benign_trace = pipeline.score_tool_call(_score_payload(_BENIGN_CMD, "gate-b"))
+    allow = pipeline.governance._run_preflight(benign_trace, session_id="gate-b")
+    assert allow.allowed is True
+    assert allow.denied is False
+
+
+def test_gatepolicy_postflight_redacts_and_suppresses(tmp_traceforge_home: Path):
+    """A postflight gate can redact secrets and suppress blocked output; the
+    resulting verdict rewrites the tool output string accordingly."""
+    policy = GatePolicy().postflight(_postflight_redact_or_suppress)
+    pipeline = Pipeline.create(policy=policy, enable_structure=False, enable_title=False)
+    trace = pipeline.score_tool_call(_score_payload(_DANGEROUS_CMD, "post"))
+
+    redact = pipeline.governance._run_postflight(
+        trace, session_id="post", output={"data": "SECRET token"}
+    )
+    assert redact.action == PostflightAction.REDACT
+    assert redact.redaction_keys == ("SECRET",)
+    assert Shield.apply_postflight_to_output(redact, "value=SECRET") == "value=[REDACTED]"
+
+    suppress = pipeline.governance._run_postflight(
+        trace, session_id="post", output={"data": "BLOCKME now"}
+    )
+    assert suppress.action == PostflightAction.SUPPRESS
+    assert Shield.apply_postflight_to_output(suppress, "leak") == "[output suppressed by policy]"
+
+
+def test_verdict_allow_deny_reason_surface():
+    """The ``Verdict`` value object surfaces allow/deny and a denial reason."""
+    allow = Verdict.allow()
+    assert allow.allowed is True
+    assert allow.denied is False
+
+    deny = Verdict.deny("policy: too risky")
+    assert deny.denied is True
+    assert deny.allowed is False
+    assert deny.reason == "policy: too risky"


### PR DESCRIPTION
## Wave 7a — Config precedence + SDK programmatic facade

Child of the E2E Test Coverage Epic (#90). **Tests-only; no `src/` changes.** Adds two deterministic, isolated end-to-end modules.

### `tests/e2e/test_config_precedence_e2e.py` (21 tests)
Exercises `config/loader.py::load_config` through the real precedence chain:
- **kwargs > TRACEFORGE_* env > YAML > Pydantic defaults** — full chain on a scalar (`log_level`), plus env>YAML>default across representative keys: a threshold int (`sdk.batch_size`), a gate-enable bool (`score.enabled`), a nested threshold (`governance.budget.max_tool_calls`), and a model path (`title.session_naming.api.model`).
- **TRACEFORGE_* env coercion** (`"false"`/`"true"` -> bool, `"9"` -> int) and nested-dict kwarg deep-merge winning over env.
- **`reset_config()` singleton guard** — proves `get_config()` caches and only a reset picks up a changed config (the cross-test-contamination guard).
- **Real round-trip through `Pipeline.from_config`** — `governance.project_root` resolves env-over-YAML and YAML-over-default, observed on the constructed pipeline.

Isolation: builds on `tmp_traceforge_home`, additionally redirects the loader's import-time `~/.traceforge` path constants into the sandbox, scrubs **all** `TRACEFORGE_*` env vars, and calls `reset_config()` before and after every test.

### `tests/e2e/test_sdk_facade_e2e.py` (7 tests)
Drives the public `traceforge.sdk.Pipeline` facade end-to-end (the existing suite only covered `GovernancePipeline` directly):
- `score_tool_call` — dangerous `rm -rf /` -> high risk + escalating recommendation; benign `cat` -> low risk (and strictly below the dangerous score).
- **Full observe path** — `create(sinks=[...]) -> push()` writes an enriched, governed event (`metadata.classification` + `metadata.governance` with high risk) to a real JSONL sink in the isolated home, and to a live callback sink (asserting the stamped `SessionEvent` object, not just serialized form).
- **Gating layer** — `GatePolicy` preflight denies a dangerous call with the reason surfaced and allows a benign one; postflight redacts a secret and suppresses blocked output; `Verdict` allow/deny + reason surface asserted directly.

Structuring (phase/boundary/title ML) is disabled on pushed pipelines — separate story (#87), lazy-loading, and a nondeterminism source; governance stays on.

### Verification (Windows dev)
- New files: **28 passed** in ~2.6s.
- Full suite **without** these files: `2680 passed, 5 skipped, 11 xfailed`.
- Full suite **with** these files: `2708 passed, 5 skipped, 11 xfailed`.
- Delta: **+28 passed, 0 change to skips/xfails** — the config singleton reset leaks nothing into the rest of the suite.
- Lint: `ruff@0.15.20 check tests` + `ruff format --check tests` clean.

No product bugs found in the surfaces under test — every precedence and SDK-facade path behaved as specified, so no `xfail` pins were needed.

Closes #88

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>