### PR TITLE
test(e2e): gate/IPC enforcement coverage (#86)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,5 +148,7 @@ dev = [
     "semantic-kernel>=1.20",
     "smolagents>=1.0",
     "openai-agents>=0.1",
+    "pydantic-ai-slim>=1.0",
+    "agent-framework-core>=1.0",
 ]
 

--- a/tests/e2e/test_gate_frameworks_e2e.py
+++ b/tests/e2e/test_gate_frameworks_e2e.py
@@ -1,0 +1,239 @@
+"""End-to-end tests: Microsoft Agent Framework (MAF) + Pydantic AI gate adapters.
+
+Wave 5 (issue #86) — the ENFORCEMENT path. These cover the two framework gate
+adapters that had no e2e coverage:
+
+  * ``pipeline.gate_maf()`` — a real MAF ``FunctionMiddleware`` driven through
+    its native ``process(context, call_next)`` protocol. Only the tool body is
+    faked; the middleware, ``MiddlewareTermination`` deny, and postflight
+    redact/suppress transforms are the real traceforge code paths.
+  * ``pipeline.gate_pydantic_ai()`` — Pydantic AI tool hooks. This adapter is
+    currently BROKEN (it calls ``agent.tool_hook(...)`` which does not exist on
+    pydantic-ai>=1); the single test below is an ``xfail(strict=True)`` pinning
+    the bug so a future fix flips it to XPASS and alerts us.
+
+Both frameworks are guarded with ``importorskip`` so a missing optional dep
+skips (rather than errors) that framework's tests independently.
+"""
+
+import asyncio
+import types
+
+import pytest
+
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.gate_types import (
+    GateContext,
+    PostflightAction,
+    PostflightVerdict,
+    ToolCallRequest,
+    ToolCallResult,
+)
+from traceforge.sdk.verdict import Verdict
+
+pytestmark = pytest.mark.e2e
+
+
+# ─── Shared gate functions ────────────────────────────────────────────────────
+
+
+def allow_all_gate(request: ToolCallRequest, ctx: GateContext) -> Verdict:
+    """Preflight gate that allows everything."""
+    return Verdict.allow()
+
+
+def deny_rm_gate(request: ToolCallRequest, ctx: GateContext) -> Verdict:
+    """Preflight gate that blocks any tool named 'rm' or 'delete'."""
+    if request.tool in ("rm", "delete", "bash_rm"):
+        return Verdict.deny(f"Destructive tool blocked: {request.tool}")
+    return Verdict.allow()
+
+
+def redact_secret_postflight(result: ToolCallResult, ctx: GateContext) -> PostflightVerdict:
+    """Postflight gate that redacts the literal token 'SECRET' from output."""
+    if "SECRET" in str(result.output):
+        return PostflightVerdict(
+            action=PostflightAction.REDACT,
+            reason="PII detected in output",
+            redaction_keys=("SECRET",),
+        )
+    return PostflightVerdict(action=PostflightAction.ACCEPT)
+
+
+def suppress_if_output_contains_hide(result: ToolCallResult, ctx: GateContext) -> PostflightVerdict:
+    """Postflight gate that SUPPRESSES a successful result containing 'HIDE'.
+
+    This deliberately fires on the SUCCESS path (not on error): in the MAF
+    middleware a tool error re-raises before the suppress branch is reached, so
+    a success-path trigger is the only way to observe SUPPRESS enforcement.
+    """
+    if "HIDE" in str(result.output):
+        return PostflightVerdict(
+            action=PostflightAction.SUPPRESS,
+            reason="output marked for suppression",
+        )
+    return PostflightVerdict(action=PostflightAction.ACCEPT)
+
+
+# ─── Pipeline factory ─────────────────────────────────────────────────────────
+
+
+def make_pipeline(*, preflight=None, postflight=None) -> GovernancePipeline:
+    """Create a fresh GovernancePipeline with the given gates."""
+    policy = GatePolicy()
+    if preflight:
+        for g in preflight if isinstance(preflight, list) else [preflight]:
+            policy.preflight(g)
+    if postflight:
+        for g in postflight if isinstance(postflight, list) else [postflight]:
+            policy.postflight(g)
+
+    pipeline = GovernancePipeline.create()
+    pipeline.policy = policy
+    return pipeline
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Microsoft Agent Framework (MAF) E2E
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _maf_ctx(tool_name, arguments, *, result=None):
+    """Build a minimal MAF middleware context (duck-typed SimpleNamespace).
+
+    gate_maf reads: context.function.name, context.arguments, context.session,
+    context.call_id, and context.result.
+    """
+    return types.SimpleNamespace(
+        function=types.SimpleNamespace(name=tool_name),
+        arguments=arguments,
+        session=None,
+        result=result,
+        call_id="call-1",
+    )
+
+
+class TestMAFGating:
+    """E2E: pipeline.gate_maf() FunctionMiddleware enforcement."""
+
+    def test_gate_maf_returns_function_middleware(self):
+        """gate_maf returns a real FunctionMiddleware subclass instance."""
+        agent_framework = pytest.importorskip("agent_framework")
+
+        pipeline = make_pipeline(preflight=allow_all_gate)
+        mw = pipeline.gate_maf()
+        assert isinstance(mw, agent_framework.FunctionMiddleware)
+
+    def test_dangerous_call_denied(self):
+        """A dangerous tool raises MiddlewareTermination and never calls the tool."""
+        pytest.importorskip("agent_framework")
+        from agent_framework import MiddlewareTermination
+
+        pipeline = make_pipeline(preflight=deny_rm_gate)
+        mw = pipeline.gate_maf()
+
+        ctx = _maf_ctx("rm", {"path": "/etc/passwd"})
+        called = {"n": 0}
+
+        async def call_next(_ctx):
+            called["n"] += 1
+
+        with pytest.raises(MiddlewareTermination) as exc_info:
+            asyncio.run(mw.process(ctx, call_next))
+
+        assert "Destructive tool blocked: rm" in str(exc_info.value)
+        assert called["n"] == 0  # tool body never executed
+
+    def test_safe_call_allowed(self):
+        """A safe tool is allowed: call_next runs and its result passes through."""
+        pytest.importorskip("agent_framework")
+
+        pipeline = make_pipeline(preflight=deny_rm_gate)
+        mw = pipeline.gate_maf()
+
+        ctx = _maf_ctx("read_file", {"path": "/tmp/hello.txt"})
+        called = {"n": 0}
+
+        async def call_next(c):
+            called["n"] += 1
+            c.result = "contents of /tmp/hello.txt"
+
+        asyncio.run(mw.process(ctx, call_next))
+
+        assert called["n"] == 1
+        assert ctx.result == "contents of /tmp/hello.txt"
+
+    def test_postflight_redacts_secret(self):
+        """A successful result containing SECRET is redacted in place."""
+        pytest.importorskip("agent_framework")
+
+        pipeline = make_pipeline(
+            preflight=allow_all_gate,
+            postflight=redact_secret_postflight,
+        )
+        mw = pipeline.gate_maf()
+
+        ctx = _maf_ctx("search", {"query": "passwords"})
+
+        async def call_next(c):
+            c.result = "the SECRET api key is 42"
+
+        asyncio.run(mw.process(ctx, call_next))
+
+        assert "SECRET" not in ctx.result
+        assert "[REDACTED]" in ctx.result
+
+    def test_postflight_suppresses_output(self):
+        """A successful result flagged for suppression is replaced wholesale."""
+        pytest.importorskip("agent_framework")
+
+        pipeline = make_pipeline(
+            preflight=allow_all_gate,
+            postflight=suppress_if_output_contains_hide,
+        )
+        mw = pipeline.gate_maf()
+
+        ctx = _maf_ctx("dump", {"what": "everything"})
+
+        async def call_next(c):
+            c.result = "please HIDE this from the caller"
+
+        asyncio.run(mw.process(ctx, call_next))
+
+        assert ctx.result == "[output suppressed by policy]"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Pydantic AI E2E
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPydanticAIGating:
+    """E2E: pipeline.gate_pydantic_ai() tool-hook registration."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "bug: gate_pydantic_ai registers hooks via agent.tool_hook('before'/'after'), "
+            "but pydantic-ai>=1 Agent has no tool_hook attribute. "
+            "EXPECTED: hooks register and a dangerous call is denied. "
+            "ACTUAL: AttributeError: 'Agent' object has no attribute 'tool_hook'. "
+            "src/traceforge/governance/pipeline.py:740 and :758."
+        ),
+    )
+    def test_gate_pydantic_ai_registers_hooks(self):
+        pytest.importorskip("pydantic_ai")
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        pipeline = make_pipeline(preflight=deny_rm_gate)
+        agent = Agent(TestModel())
+
+        # Currently raises AttributeError inside gate_pydantic_ai (the bug).
+        pipeline.gate_pydantic_ai(agent)
+
+        # Reached only once the adapter is fixed: registration must be idempotent
+        # and mark the agent as gated.
+        assert getattr(agent, "_traceforge_gated", False) is True
+        pipeline.gate_pydantic_ai(agent)  # idempotent no-op

--- a/tests/e2e/test_gate_init_e2e.py
+++ b/tests/e2e/test_gate_init_e2e.py
@@ -1,0 +1,118 @@
+"""End-to-end tests for ``traceforge init claude-code`` hook injection (issue #86).
+
+Issue #85 pinned the light operator contract for ``init`` (a supported agent
+writes ``.claude/settings.json``; the success echo trips the Windows cp1252
+Unicode bug). This Wave-5 file adds the *enforcement-scaffold* assertions #85
+deferred to #86:
+
+* **Idempotency** — running ``init`` twice must not append a second ``traceforge
+  gate`` hook (the injector skips when any PreToolUse command already mentions
+  ``traceforge``).
+* **Scaffold shape** — the injected PreToolUse entry matches all tools (``.*``)
+  and its command actually invokes ``traceforge ... gate --stdin``, the relay the
+  gate story is built on.
+* **Non-destructive** — pre-existing, unrelated settings and hooks survive.
+
+All assertions read the resulting ``settings.json`` rather than the exit code:
+the injector writes the file *before* the ``✓`` echo that crashes a Windows
+cp1252 stdout (src/traceforge/cli/init_cmd.py:73), so the on-disk hook state is
+correct and identical across platforms even when the process exits 1. That keeps
+these tests green cross-platform without duplicating #85's exit-code xfail.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._cli import run_cli
+
+
+def _read_settings(project: Path) -> dict:
+    settings = project / ".claude" / "settings.json"
+    assert settings.is_file(), f"init did not write {settings}"
+    return json.loads(settings.read_text(encoding="utf-8"))
+
+
+def _traceforge_entries(data: dict) -> list[tuple[dict, dict]]:
+    """Return ``(matcher_entry, hook)`` pairs whose command invokes traceforge."""
+    pairs: list[tuple[dict, dict]] = []
+    for entry in data.get("hooks", {}).get("PreToolUse", []):
+        if not isinstance(entry, dict):
+            continue
+        for hook in entry.get("hooks", []):
+            if isinstance(hook, dict) and "traceforge" in hook.get("command", ""):
+                pairs.append((entry, hook))
+    return pairs
+
+
+@pytest.mark.e2e
+def test_init_is_idempotent_no_duplicate_hook(tmp_traceforge_home: Path) -> None:
+    project = tmp_traceforge_home / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+
+    run_cli("init", "claude-code", "--project", str(project))
+    run_cli("init", "claude-code", "--project", str(project))
+
+    entries = _traceforge_entries(_read_settings(project))
+    assert len(entries) == 1, f"expected exactly one traceforge hook, got {len(entries)}"
+
+
+@pytest.mark.e2e
+def test_init_writes_deep_gate_scaffold(tmp_traceforge_home: Path) -> None:
+    project = tmp_traceforge_home / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+
+    run_cli("init", "claude-code", "--project", str(project))
+
+    entries = _traceforge_entries(_read_settings(project))
+    assert len(entries) == 1
+    matcher_entry, hook = entries[0]
+    # Gates every tool call, and the command is the real gate relay.
+    assert matcher_entry.get("matcher") == ".*", matcher_entry
+    assert hook.get("type") == "command", hook
+    assert "gate --stdin" in hook.get("command", ""), hook
+
+
+@pytest.mark.e2e
+def test_init_preserves_existing_settings(tmp_traceforge_home: Path) -> None:
+    project = tmp_traceforge_home / "proj"
+    settings_dir = project / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_file = settings_dir / "settings.json"
+
+    # Seed unrelated user configuration the injector must not clobber.
+    settings_file.write_text(
+        json.dumps(
+            {
+                "model": "claude-sonnet-4",
+                "hooks": {
+                    "PreToolUse": [
+                        {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi"}]}
+                    ]
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_cli("init", "claude-code", "--project", str(project))
+
+    data = _read_settings(project)
+    # Unrelated top-level key survives.
+    assert data.get("model") == "claude-sonnet-4", data
+    # The pre-existing non-traceforge hook survives.
+    commands = [
+        h.get("command", "")
+        for entry in data["hooks"]["PreToolUse"]
+        if isinstance(entry, dict)
+        for h in entry.get("hooks", [])
+        if isinstance(h, dict)
+    ]
+    assert any("echo hi" in c for c in commands), data
+    # And the traceforge gate hook was added exactly once.
+    assert len(_traceforge_entries(data)) == 1, data

--- a/tests/e2e/test_gate_ipc_e2e.py
+++ b/tests/e2e/test_gate_ipc_e2e.py
@@ -1,0 +1,278 @@
+"""End-to-end tests for the gate IPC server + endpoint registry (issue #86).
+
+These cover the transport and bookkeeping underneath ``traceforge gate``:
+
+* :class:`GateServer` binds a real socket — AF_UNIX under ``~/.traceforge/gates``
+  on POSIX, ``tcp://127.0.0.1:<port>`` on Windows — and answers length-prefixed
+  gate requests from :func:`traceforge.gate.client.send_gate_request`.
+* The ``gate_endpoints`` registry maps ``session_id → sock_path`` in the
+  sandboxed ``system.db`` and validates the owning PID on lookup, self-healing
+  stale rows (a pipeline that died without cleaning up) so a dead endpoint can
+  never resolve.
+* ``traceforge watch`` registers its pipeline as ``_default`` for the lifetime of
+  the daemon and the endpoint stops resolving once it exits.
+
+Every socket wait is bounded so a wedged endpoint fails the test instead of
+hanging the suite. The Windows-only TCP transport is genuinely platform-specific
+(POSIX has no localhost-TCP fallback), so that case is marked ``windows_only`` and
+auto-skips on the Linux CI matrix.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from traceforge.gate import registry
+from traceforge.gate.client import send_gate_request
+from traceforge.gate.server import GateServer
+from traceforge.governance.persistence import SystemStore
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.verdict import Verdict
+
+from tests.e2e._cli import combined_output, run_cli
+
+_SOCKET_TIMEOUT = 10.0
+_PIPELINE_TIMEOUT = 90.0
+
+
+def _allow_all(request, ctx) -> Verdict:
+    return Verdict.allow()
+
+
+def _deny_all(request, ctx) -> Verdict:
+    return Verdict.deny("blocked by test policy")
+
+
+def _make_pipeline(policy: GatePolicy | None = None) -> GovernancePipeline:
+    pipeline = GovernancePipeline.create()
+    pipeline.policy = policy
+    return pipeline
+
+
+def _bootstrap_system_db() -> Path:
+    """Create the sandboxed ``system.db`` (with the ``gate_endpoints`` table)."""
+    system_db = Path.home() / ".traceforge" / "system.db"
+    SystemStore(str(system_db)).connection.close()
+    return system_db
+
+
+def _dead_pid() -> int:
+    """Return a PID that reads as dead via :func:`registry._pid_alive`.
+
+    Spawning a no-op and reaping it is not enough on Windows: the kernel keeps the
+    process object (and thus ``OpenProcess``) alive while any handle stays open,
+    and ``Popen`` holds one until it is finalized. So drop the handle and force a
+    collection, then confirm the PID actually reads dead before using it — looping
+    guards against both the lingering handle and (vanishingly rare) PID reuse.
+    """
+    for _ in range(10):
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait(timeout=_SOCKET_TIMEOUT)
+        pid = proc.pid
+        del proc
+        gc.collect()
+        if not registry._pid_alive(pid):
+            return pid
+    pytest.skip("could not obtain a reliably-dead PID on this platform")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GateServer <-> client round-trip
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_send_gate_request_round_trip_allow(tmp_traceforge_home: Path) -> None:
+    """The real client relays a payload to the server and gets a scored verdict."""
+    server = GateServer(_make_pipeline(GatePolicy().preflight(_allow_all)))
+    server.start()
+    try:
+        verdict = send_gate_request(
+            server.sock_path,
+            {"tool_name": "read_file", "tool_input": {"path": "a.txt"}, "session_id": "s"},
+        )
+    finally:
+        server.stop()
+
+    assert verdict["decision"] == "allow", verdict
+    # The IPC contract carries the risk score/band alongside the decision.
+    assert "score" in verdict and "level" in verdict, verdict
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_send_gate_request_round_trip_deny(tmp_traceforge_home: Path) -> None:
+    server = GateServer(_make_pipeline(GatePolicy().preflight(_deny_all)))
+    server.start()
+    try:
+        verdict = send_gate_request(
+            server.sock_path,
+            {"tool_name": "rm", "tool_input": {}, "session_id": "s"},
+        )
+    finally:
+        server.stop()
+
+    assert verdict["decision"] == "deny", verdict
+    assert verdict["reason"] == "blocked by test policy", verdict
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.windows_only
+def test_windows_tcp_transport_round_trip(tmp_traceforge_home: Path) -> None:
+    """On Windows the gate server binds localhost TCP and verdicts round-trip it."""
+    server = GateServer(_make_pipeline(GatePolicy().preflight(_deny_all)))
+    server.start()
+    try:
+        assert server.sock_path.startswith("tcp://127.0.0.1:"), server.sock_path
+        verdict = send_gate_request(
+            server.sock_path,
+            {"tool_name": "rm", "tool_input": {"path": "/"}, "session_id": "win"},
+        )
+    finally:
+        server.stop()
+
+    assert verdict["decision"] == "deny", verdict
+    assert verdict["reason"] == "blocked by test policy", verdict
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="AF_UNIX socket file is POSIX-only; Windows uses a TCP endpoint with no file to clean up",
+)
+def test_server_stop_removes_unix_socket_file(tmp_traceforge_home: Path) -> None:
+    server = GateServer(_make_pipeline())
+    server.start()
+    try:
+        path = server.sock_path
+        assert not path.startswith("tcp://"), path
+        assert os.path.exists(path), path
+    finally:
+        server.stop()
+
+    assert not os.path.exists(path), f"socket file left behind: {path}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Registry lifecycle: register / lookup / unregister / PID self-heal
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.e2e
+def test_register_then_lookup_round_trips(tmp_traceforge_home: Path) -> None:
+    _bootstrap_system_db()
+    registry.register_session("live-session", "tcp://127.0.0.1:5555")
+    # Registered under the current (alive) PID, so lookup resolves it.
+    assert registry.lookup_session("live-session") == "tcp://127.0.0.1:5555"
+
+
+@pytest.mark.e2e
+def test_unregister_session_removes_endpoint(tmp_traceforge_home: Path) -> None:
+    _bootstrap_system_db()
+    registry.register_session("temp-session", "tcp://127.0.0.1:6000")
+    assert registry.lookup_session("temp-session") is not None
+    registry.unregister_session("temp-session")
+    assert registry.lookup_session("temp-session") is None
+
+
+@pytest.mark.e2e
+def test_unregister_pid_clears_all_current_endpoints(tmp_traceforge_home: Path) -> None:
+    _bootstrap_system_db()
+    registry.register_session("sess-a", "tcp://127.0.0.1:6001")
+    registry.register_session("sess-b", "tcp://127.0.0.1:6002")
+    registry.unregister_pid()
+    assert registry.lookup_session("sess-a") is None
+    assert registry.lookup_session("sess-b") is None
+
+
+@pytest.mark.e2e
+def test_lookup_self_heals_stale_pid(tmp_traceforge_home: Path) -> None:
+    """A row owned by a dead PID must not resolve and must be deleted on lookup."""
+    system_db = _bootstrap_system_db()
+    dead = _dead_pid()
+
+    conn = sqlite3.connect(str(system_db))
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO gate_endpoints (session_id, sock_path, pid) VALUES (?, ?, ?)",
+            ("stale-session", "tcp://127.0.0.1:1", dead),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Stale endpoint must not resolve...
+    assert registry.lookup_session("stale-session") is None
+    # ...and the self-heal must have removed the row.
+    conn = sqlite3.connect(str(system_db))
+    try:
+        row = conn.execute(
+            "SELECT session_id FROM gate_endpoints WHERE session_id = ?", ("stale-session",)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is None, "stale endpoint row was not cleaned up"
+
+
+@pytest.mark.e2e
+def test_lookup_missing_db_returns_none(tmp_traceforge_home: Path) -> None:
+    """Before any pipeline runs there is no system.db — lookup must fail closed to None."""
+    assert not (Path.home() / ".traceforge" / "system.db").exists()
+    assert registry.lookup_session("anything") is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Full daemon lifecycle: watch registers _default and cleans up on shutdown
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_watch_default_endpoint_registers_and_stops_gating_on_shutdown(
+    watch_daemon, gate_socket_lookup
+):
+    """Full lifecycle through the real ``traceforge watch`` daemon.
+
+    While the daemon lives its ``_default`` endpoint is registered and a real
+    ``gate --stdin`` request round-trips it (allowed by the daemon's default
+    policy). Once the daemon stops, the relay must fail closed: on POSIX the row
+    is gone / its PID is dead ("not registered"); on a Windows hard kill the row
+    lingers but its socket is dead ("pipeline unreachable"). Either way the gate
+    stops allowing tool calls through a dead pipeline.
+    """
+    raw = gate_socket_lookup("_default")
+    assert raw is not None, "watch did not register the _default gate endpoint"
+    assert registry.lookup_session("_default") is not None
+
+    # Transport shape matches the platform.
+    if sys.platform == "win32":
+        assert raw.startswith("tcp://127.0.0.1:"), raw
+    else:
+        assert raw.endswith(".sock"), raw
+
+    event = json.dumps({"tool_name": "read_file", "tool_input": {}, "session_id": "_default"})
+
+    # A live gate request round-trips through the real daemon and is allowed.
+    live = run_cli("gate", "--stdin", "--format", "json", stdin=event, timeout=_PIPELINE_TIMEOUT)
+    assert live.returncode == 0, combined_output(live)
+    assert json.loads(live.stdout.strip()) == {"decision": "allow"}, live.stdout
+
+    # Shut the daemon down and confirm the relay now fails closed within a bound.
+    watch_daemon.process.terminate()
+    watch_daemon.process.wait(timeout=_SOCKET_TIMEOUT)
+
+    down = run_cli("gate", "--stdin", "--format", "json", stdin=event, timeout=_PIPELINE_TIMEOUT)
+    assert down.returncode == 0, combined_output(down)
+    assert json.loads(down.stdout.strip())["decision"] == "deny", down.stdout

--- a/tests/e2e/test_gate_stdin_e2e.py
+++ b/tests/e2e/test_gate_stdin_e2e.py
@@ -1,0 +1,235 @@
+"""End-to-end tests for the ``traceforge gate --stdin`` verdict relay (issue #86).
+
+This is the 🔴 enforcement path: an external agent hook (Claude Code PreToolUse,
+Copilot/Codex CLI, ...) pipes a tool-call event to ``traceforge gate --stdin``,
+which looks up the running pipeline's IPC server by ``session_id`` and relays the
+event for scoring. The subprocess prints a verdict and the agent blocks or allows
+the tool accordingly.
+
+Two layers are exercised, both against the *real* ``python -m traceforge gate``
+subprocess (via :func:`tests.e2e._cli.run_cli`):
+
+* **Fail-closed grammar** (fast, no server): empty / whitespace / malformed /
+  session-less / unregistered stdin must all DENY. A hook that can't produce a
+  usable event must never silently allow a tool call.
+* **Live verdicts** (``slow``): an in-process :class:`GateServer` backed by a real
+  :class:`GovernancePipeline` answers the subprocess over the actual IPC socket
+  (AF_UNIX on POSIX, ``tcp://127.0.0.1:<port>`` on Windows). Swapping the
+  pipeline's policy flips the round-tripped verdict between allow and deny.
+
+The verdict lives in the child's *stdout JSON*, not its exit code — a fail-closed
+deny still exits 0 (the JSON is the contract), so these tests assert on the parsed
+verdict, and assert ``returncode == 0`` only to catch an unexpected crash.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+
+import pytest
+
+from traceforge.gate.server import GateServer
+from traceforge.governance.persistence import SystemStore
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.verdict import Verdict
+
+from tests.e2e._cli import combined_output, run_cli
+
+# A generous ceiling for the server-backed subprocess calls: the child connects
+# to a loopback socket and returns immediately, but the pipeline scorer may load
+# ML models on first construction, so give it the same headroom as ``score``.
+_LIVE_TIMEOUT = 90.0
+
+
+# ─── Policies ─────────────────────────────────────────────────────────────────
+
+
+def _allow_all(request, ctx) -> Verdict:
+    return Verdict.allow()
+
+
+def _deny_all(request, ctx) -> Verdict:
+    return Verdict.deny("blocked by test policy")
+
+
+# ─── Verdict parsing / assertions ─────────────────────────────────────────────
+
+
+def _parse_verdict(result) -> dict:
+    """Parse the single verdict JSON object the child writes to stdout."""
+    text = result.stdout.strip()
+    assert text, f"no stdout verdict.\n{combined_output(result)}"
+    # The relay prints exactly one JSON object; be forgiving of stray blank lines.
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            return json.loads(line)
+    raise AssertionError(f"no JSON verdict in stdout: {text!r}")
+
+
+def _assert_deny(result, fmt: str, reason_contains: str | None = None) -> None:
+    assert result.returncode == 0, combined_output(result)
+    verdict = _parse_verdict(result)
+    if fmt == "json":
+        assert verdict.get("decision") == "deny", verdict
+        reason = verdict.get("reason", "")
+    else:  # claude-code
+        hook = verdict["hookSpecificOutput"]
+        assert hook["hookEventName"] == "PreToolUse", verdict
+        assert hook["permissionDecision"] == "deny", verdict
+        reason = hook["permissionDecisionReason"]
+    if reason_contains is not None:
+        assert reason_contains in reason, reason
+
+
+def _assert_allow(result, fmt: str) -> None:
+    assert result.returncode == 0, combined_output(result)
+    verdict = _parse_verdict(result)
+    if fmt == "json":
+        assert verdict == {"decision": "allow"}, verdict
+    else:  # claude-code: empty object hands back to the normal permission flow
+        assert verdict == {}, verdict
+
+
+@contextlib.contextmanager
+def _live_gate(*session_ids: str, policy: GatePolicy | None = None):
+    """Start an in-process gate IPC server registered under ``session_ids``.
+
+    Bootstraps the sandboxed ``system.db`` first (constructing a ``SystemStore``
+    runs the Alembic migration that creates the ``gate_endpoints`` table the
+    registry writes to; the pipeline's own store is in-memory and never creates
+    it). Yields the running :class:`GateServer`; the child ``gate --stdin``
+    subprocess reaches it through the registry over the real socket.
+    """
+    system_db = Path.home() / ".traceforge" / "system.db"
+    SystemStore(str(system_db)).connection.close()
+
+    pipeline = GovernancePipeline.create()
+    pipeline.policy = policy
+    server = GateServer(pipeline)
+    server.start()
+    try:
+        for sid in session_ids:
+            server.register_session(sid)
+        yield server
+    finally:
+        server.stop()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fail-closed grammar (no pipeline running) — every malformed input must DENY
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("fmt", ["json", "claude-code"])
+def test_empty_stdin_denies(tmp_traceforge_home: Path, fmt: str) -> None:
+    result = run_cli("gate", "--stdin", "--format", fmt, stdin="")
+    _assert_deny(result, fmt, reason_contains="empty event")
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("fmt", ["json", "claude-code"])
+def test_whitespace_only_stdin_denies(tmp_traceforge_home: Path, fmt: str) -> None:
+    result = run_cli("gate", "--stdin", "--format", fmt, stdin="   \n\t  \n")
+    _assert_deny(result, fmt, reason_contains="empty event")
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("fmt", ["json", "claude-code"])
+def test_malformed_json_denies_fail_closed(tmp_traceforge_home: Path, fmt: str) -> None:
+    result = run_cli("gate", "--stdin", "--format", fmt, stdin='{"tool_name": "rm", ')
+    _assert_deny(result, fmt, reason_contains="malformed event JSON")
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("fmt", ["json", "claude-code"])
+def test_missing_session_id_denies(tmp_traceforge_home: Path, fmt: str) -> None:
+    result = run_cli("gate", "--stdin", "--format", fmt, stdin=json.dumps({"tool_name": "rm"}))
+    _assert_deny(result, fmt, reason_contains="no session_id")
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("fmt", ["json", "claude-code"])
+def test_unregistered_session_denies(tmp_traceforge_home: Path, fmt: str) -> None:
+    event = {"tool_name": "rm", "tool_input": {"path": "/"}, "session_id": "ghost-session"}
+    result = run_cli("gate", "--stdin", "--format", fmt, stdin=json.dumps(event))
+    _assert_deny(result, fmt, reason_contains="not registered")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Live verdicts — real subprocess client → in-process GateServer round-trip
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.parametrize("fmt", ["json", "claude-code"])
+def test_registered_session_allows(tmp_traceforge_home: Path, fmt: str) -> None:
+    event = {
+        "tool_name": "read_file",
+        "tool_input": {"path": "notes.txt"},
+        "session_id": "sess-allow",
+    }
+    with _live_gate("sess-allow", policy=GatePolicy().preflight(_allow_all)):
+        result = run_cli(
+            "gate", "--stdin", "--format", fmt, stdin=json.dumps(event), timeout=_LIVE_TIMEOUT
+        )
+    _assert_allow(result, fmt)
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@pytest.mark.parametrize("fmt", ["json", "claude-code"])
+def test_registered_session_denies_with_reason(tmp_traceforge_home: Path, fmt: str) -> None:
+    event = {
+        "tool_name": "rm",
+        "tool_input": {"path": "/etc/passwd"},
+        "session_id": "sess-deny",
+    }
+    with _live_gate("sess-deny", policy=GatePolicy().preflight(_deny_all)):
+        result = run_cli(
+            "gate", "--stdin", "--format", fmt, stdin=json.dumps(event), timeout=_LIVE_TIMEOUT
+        )
+    _assert_deny(result, fmt, reason_contains="blocked by test policy")
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_unknown_session_falls_back_to_default(tmp_traceforge_home: Path) -> None:
+    """A session_id with no registration routes to the ``_default`` pipeline.
+
+    ``traceforge watch`` always registers its pipeline as ``_default``; the relay
+    falls back to it when the event's own session_id isn't registered, so a CLI
+    agent whose session id the daemon never saw is still gated.
+    """
+    event = {
+        "tool_name": "read_file",
+        "tool_input": {},
+        "session_id": "never-registered-directly",
+    }
+    with _live_gate("_default", policy=GatePolicy().preflight(_allow_all)):
+        result = run_cli(
+            "gate", "--stdin", "--format", "json", stdin=json.dumps(event), timeout=_LIVE_TIMEOUT
+        )
+    _assert_allow(result, "json")
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_default_fallback_enforces_deny(tmp_traceforge_home: Path) -> None:
+    """The ``_default`` fallback carries the pipeline's policy — including deny."""
+    event = {"tool_name": "rm", "tool_input": {}, "session_id": "some-cli-session"}
+    with _live_gate("_default", policy=GatePolicy().preflight(_deny_all)):
+        result = run_cli(
+            "gate",
+            "--stdin",
+            "--format",
+            "claude-code",
+            stdin=json.dumps(event),
+            timeout=_LIVE_TIMEOUT,
+        )
+    _assert_deny(result, "claude-code", reason_contains="blocked by test policy")

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "agent-framework-core"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/92/a3551481406a6c3dc437fc8a0f139352f4ad4271525d39018857cd066ee0/agent_framework_core-1.10.0.tar.gz", hash = "sha256:a373b3bec966e4d186d968e248ac683549cce464a0db345b6ebeebfeafdc7025", size = 476779, upload-time = "2026-06-30T21:00:32.968Z" }
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1065,6 +1077,19 @@ wheels = [
 ]
 
 [[package]]
+name = "genai-prices"
+version = "0.0.69"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/17/b9a96d31908f1415b38e3bcba7883691fa2e0e69e18d0d9d6e80bf24be88/genai_prices-0.0.69.tar.gz", hash = "sha256:80ca72c4b59b62ef986be3f04ea528bf4aaac4bc91e1c34f32f354c0c0b23d16", size = 81492, upload-time = "2026-07-02T09:40:21.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/05/6bb176d603210b61d2bf4585c7119dcf5491bbcae195e21254668c5ee07a/genai_prices-0.0.69-py3-none-any.whl", hash = "sha256:281821349e301e938e00ba9a9e8df5be23336e2f04218a4979f6c5f89db083bb", size = 83972, upload-time = "2026-07-02T09:40:20.844Z" },
+]
+
+[[package]]
 name = "genson"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1248,6 +1273,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1298,6 +1336,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]
@@ -1787,6 +1841,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
+]
+
+[[package]]
+name = "logfire-api"
+version = "4.37.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/04/471b916249fe7e22056818ca734af46418cd3ff9b9b920c1829c3627b4d2/logfire_api-4.37.0.tar.gz", hash = "sha256:0f62debd6ed593d51307277bd6d5636b57bda07935b5604b96db10fe64441af4", size = 88906, upload-time = "2026-06-12T20:47:08.163Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/2f/23e5b8fa22f75f73965c72e5c29e6fb8715263457394601e254fe26fbe31/logfire_api-4.37.0-py3-none-any.whl", hash = "sha256:1d756f8ba23aa56d438e0ba2c0f529a00fcac975b8785c561b058267f9465088", size = 138710, upload-time = "2026-06-12T20:47:05.526Z" },
 ]
 
 [[package]]
@@ -2350,32 +2413,31 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.34.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/5e/94a8cb759e4e409022229418294e098ca7feca00eb3c467bb20cbd329bda/opentelemetry_api-1.34.1.tar.gz", hash = "sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3", size = 64987, upload-time = "2025-06-10T08:55:19.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/3a/2ba85557e8dc024c0842ad22c570418dc02c36cbd1ab4b832a93edf071b8/opentelemetry_api-1.34.1-py3-none-any.whl", hash = "sha256:b7df4cb0830d5a6c29ad0c0691dbae874d8daefa934b8b1d642de48323d32a8c", size = 65767, upload-time = "2025-06-10T08:54:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.34.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/f0/ff235936ee40db93360233b62da932d4fd9e8d103cd090c6bcb9afaf5f01/opentelemetry_exporter_otlp_proto_common-1.34.1.tar.gz", hash = "sha256:b59a20a927facd5eac06edaf87a07e49f9e4a13db487b7d8a52b37cb87710f8b", size = 20817, upload-time = "2025-06-10T08:55:22.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/e8/8b292a11cc8d8d87ec0c4089ae21b6a58af49ca2e51fa916435bc922fdc7/opentelemetry_exporter_otlp_proto_common-1.34.1-py3-none-any.whl", hash = "sha256:8e2019284bf24d3deebbb6c59c71e6eef3307cd88eff8c633e061abba33f7e87", size = 18834, upload-time = "2025-06-10T08:55:00.806Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.34.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -2386,14 +2448,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/f7/bb63837a3edb9ca857aaf5760796874e7cecddc88a2571b0992865a48fb6/opentelemetry_exporter_otlp_proto_grpc-1.34.1.tar.gz", hash = "sha256:7c841b90caa3aafcfc4fee58487a6c71743c34c6dc1787089d8b0578bbd794dd", size = 22566, upload-time = "2025-06-10T08:55:23.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/42/0a4dd47e7ef54edf670c81fc06a83d68ea42727b82126a1df9dd0477695d/opentelemetry_exporter_otlp_proto_grpc-1.34.1-py3-none-any.whl", hash = "sha256:04bb8b732b02295be79f8a86a4ad28fae3d4ddb07307a98c7aa6f331de18cca6", size = 18615, upload-time = "2025-06-10T08:55:02.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.34.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -2404,48 +2466,48 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/8f/954bc725961cbe425a749d55c0ba1df46832a5999eae764d1a7349ac1c29/opentelemetry_exporter_otlp_proto_http-1.34.1.tar.gz", hash = "sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad", size = 15351, upload-time = "2025-06-10T08:55:24.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/54/b05251c04e30c1ac70cf4a7c5653c085dfcf2c8b98af71661d6a252adc39/opentelemetry_exporter_otlp_proto_http-1.34.1-py3-none-any.whl", hash = "sha256:5251f00ca85872ce50d871f6d3cc89fe203b94c3c14c964bbdc3883366c705d8", size = 17744, upload-time = "2025-06-10T08:55:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.34.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/b3/c3158dd012463bb7c0eb7304a85a6f63baeeb5b4c93a53845cf89f848c7e/opentelemetry_proto-1.34.1.tar.gz", hash = "sha256:16286214e405c211fc774187f3e4bbb1351290b8dfb88e8948af209ce85b719e", size = 34344, upload-time = "2025-06-10T08:55:32.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/ab/4591bfa54e946350ce8b3f28e5c658fe9785e7cd11e9c11b1671a867822b/opentelemetry_proto-1.34.1-py3-none-any.whl", hash = "sha256:eb4bb5ac27f2562df2d6857fc557b3a481b5e298bc04f94cc68041f00cebcbd2", size = 55692, upload-time = "2025-06-10T08:55:14.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.34.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/41/fe20f9036433da8e0fcef568984da4c1d1c771fa072ecd1a4d98779dccdd/opentelemetry_sdk-1.34.1.tar.gz", hash = "sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d", size = 159441, upload-time = "2025-06-10T08:55:33.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/1b/def4fe6aa73f483cabf4c748f4c25070d5f7604dcc8b52e962983491b29e/opentelemetry_sdk-1.34.1-py3-none-any.whl", hash = "sha256:308effad4059562f1d92163c61c8141df649da24ce361827812c40abb2a1e96e", size = 118477, upload-time = "2025-06-10T08:55:16.02Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.55b1"
+version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/f0/f33458486da911f47c4aa6db9bda308bb80f3236c111bf848bd870c16b16/opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3", size = 119829, upload-time = "2025-06-10T08:55:33.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/89/267b0af1b1d0ba828f0e60642b6a5116ac1fd917cde7fc02821627029bd1/opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl", hash = "sha256:5da81dfdf7d52e3d37f8fe88d5e771e191de924cfff5f550ab0b8f7b2409baed", size = 196223, upload-time = "2025-06-10T08:55:17.638Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
 ]
 
 [[package]]
@@ -3023,6 +3085,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-ai-slim"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "griffe" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/97/f73f439f3d415d43f38250f76852121188d0ef6114ec702e84e7d69c301d/pydantic_ai_slim-1.60.0.tar.gz", hash = "sha256:12ba3e6ef933fcb9fc6a307dbdaa43ca15bbc1b8ec77521afd1b7a526d12330f", size = 418839, upload-time = "2026-02-17T00:33:29.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/40/8cb494a4d2ba62b5f92ae8bc79a2abbbf8509cb692edd4bc841695187780/pydantic_ai_slim-1.60.0-py3-none-any.whl", hash = "sha256:6865188a225a2979c82bb022a299d438d805d258c6d3f9810f7fe4e3c86af80a", size = 546410, upload-time = "2026-02-17T00:33:21.901Z" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.33.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3085,6 +3165,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
     { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
     { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
+]
+
+[[package]]
+name = "pydantic-graph"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e6/1cae7cd39ab29f2eebc87c0a82c7ffcdfbe88492d2fb4afaaad91534e1ff/pydantic_graph-1.60.0.tar.gz", hash = "sha256:9710e457c2f8c113fd63629f05174e45bdca917d90c69ec8cf558649f995505f", size = 58492, upload-time = "2026-02-17T00:33:32.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/6c/ce1c0eca77c6efbf7c7168c05a244c2756bde876a52575f750471d522024/pydantic_graph-1.60.0-py3-none-any.whl", hash = "sha256:741fa1e48424b0def86079a01100ad0652e75882f0352cd157232b75ace468a5", size = 72345, upload-time = "2026-02-17T00:33:25.077Z" },
 ]
 
 [[package]]
@@ -4078,6 +4173,7 @@ s3 = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "agent-framework-core" },
     { name = "boto3" },
     { name = "crewai" },
     { name = "datamodel-code-generator" },
@@ -4085,6 +4181,7 @@ dev = [
     { name = "langgraph" },
     { name = "moto", extra = ["s3"] },
     { name = "openai-agents" },
+    { name = "pydantic-ai-slim" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -4125,6 +4222,7 @@ provides-extras = ["dev", "s3"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "agent-framework-core", specifier = ">=1.0" },
     { name = "boto3", specifier = ">=1.28" },
     { name = "crewai", specifier = ">=0.80" },
     { name = "datamodel-code-generator", specifier = ">=0.63.0" },
@@ -4132,6 +4230,7 @@ dev = [
     { name = "langgraph", specifier = ">=0.2" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0" },
     { name = "openai-agents", specifier = ">=0.1" },
+    { name = "pydantic-ai-slim", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -4219,6 +4318,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/17/b2/f4a5f63774da2dbc497f902ce605a82655a020d0c55010176a43a6aa3734/tree_sitter_powershell-0.26.4-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b2222e192edba88930b89ed5e5da66c75ea21a064768a10261c5bb01e1348de8", size = 131274, upload-time = "2026-05-04T15:13:15.063Z" },
     { url = "https://files.pythonhosted.org/packages/6a/0e/48df1017fda824627a7508080a8a9ef654b4ffc85e55f50185eae419ca0f/tree_sitter_powershell-0.26.4-cp310-abi3-win_amd64.whl", hash = "sha256:702eadf70ec8b1fd0bbf9b4169ed58f0ee0bcab333e5103e97c0f562be299088", size = 116092, upload-time = "2026-05-04T15:13:16.563Z" },
     { url = "https://files.pythonhosted.org/packages/49/2d/566e4ca4ca02a142c66bc25ac2d77733367674050aa27cb2e8ad8aaf803e/tree_sitter_powershell-0.26.4-cp310-abi3-win_arm64.whl", hash = "sha256:5651d240387d5b9cd23ae20afdd8aad17934304a1a21d4e7825e4df38e39dda6", size = 111028, upload-time = "2026-05-04T15:13:17.644Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #86

Wave 5 of the E2E Test Coverage Epic (#90) — the 🔴 **ENFORCEMENT** path (where TraceForge actually blocks a tool call). **Tests only; no `src/` changes.**

## Files added (`tests/e2e/`)

| File | Coverage |
| --- | --- |
| `test_gate_stdin_e2e.py` | `traceforge gate --stdin` **fail-closed** grammar — empty / whitespace-only / malformed-JSON / no-session / unregistered-session all → **deny**, across both `--format json` and `--format claude-code` output shapes (parametrized). Plus live in-process `GateServer`-backed **allow / deny + reason** relay over the real subprocess, and the `_default` session fallback (allow & deny). |
| `test_gate_ipc_e2e.py` | Gate IPC client↔server round-trip (allow/deny); **Windows TCP transport** (`tcp://127.0.0.1:port`, marked `windows_only`); POSIX `.sock` socket-file cleanup (skips on Windows); `gate_endpoints` registry register / lookup / unregister / unregister-by-pid; **stale-PID self-heal**; missing-DB → `None`; and a **watch-daemon lifecycle** test (real `traceforge watch` daemon: live request → allow, then after shutdown a real `gate --stdin` for `_default` **fails closed → deny**). |
| `test_gate_init_e2e.py` | `traceforge init claude-code --project <dir>` writes a valid `.claude/settings.json` with a `traceforge gate` **PreToolUse** hook; **idempotent** (2nd run adds no duplicate hook); deep scaffold shape (matcher `.*`, command contains `gate --stdin`); preserves pre-existing settings. Extends the existing init-injection coverage rather than duplicating it. |
| `test_gate_frameworks_e2e.py` | **MAF** (`gate_maf`) real `FunctionMiddleware` driven through its native `process(context, call_next)` protocol: dangerous → `MiddlewareTermination` (tool never runs); safe → allowed + result passes through; postflight **redact** (`SECRET` → `[REDACTED]`) and success-path **suppress** (→ `[output suppressed by policy]`). **Pydantic AI** (`gate_pydantic_ai`) → one `xfail(strict=True)` pinning a real product bug (see below). |

## Test count / suite delta

- **New tests: 35** → **33 passed, 1 skipped, 1 xfailed** (the skip is the POSIX-only socket-file test on the Windows dev box; it runs on Linux CI. The xfail is the pydantic-ai bug below).
- **Full Windows suite after this change: 2713 passed, 6 skipped, 12 xfailed — 0 failures.** Only-add confirmed: no pre-existing test changed result; the OpenTelemetry bump (below) left `test_sink_otel_e2e` and `test_otel_adapter` fully green.
- Deterministic: every socket / subprocess wait is bounded by an explicit timeout.

## Product bug found (NOT fixed — pinned + reported per issue policy)

**`gate_pydantic_ai` is broken on pydantic-ai ≥ 1.** `src/traceforge/governance/pipeline.py:740` and `:758` register hooks via `@agent.tool_hook("before")` / `@agent.tool_hook("after")`, but the `Agent` class has no `tool_hook` attribute.

- **Repro:** `GovernancePipeline.create().gate_pydantic_ai(Agent(TestModel()))` → `AttributeError: 'Agent' object has no attribute 'tool_hook'`.
- Verified against **pydantic-ai-slim 1.60.0** (the locked version) and independently against 2.5.1 — `tool_hook` is absent from the entire package in both.
- Note: `agent._traceforge_gated = True` is set at `pipeline.py:733` *before* the crash at `:740`, so a partially-"gated" agent is left with no hooks actually attached.
- Pinned as `xfail(strict=True)` so a future fix flips it to XPASS and fails loudly, signalling the adapter needs real allow/deny coverage.

## Dependencies added (flagged)

Added to `[dependency-groups].dev` (test-only, not runtime) + `uv lock`:

- `pydantic-ai-slim>=1.0` (resolved 1.60.0)
- `agent-framework-core>=1.0` (resolved 1.10.0)

Resolution blast radius (all additive except one bump): new `genai-prices`, `httpcore2`, `httpx2`, `logfire-api`, `pydantic-graph`, `truststore`; and an **OpenTelemetry bump 1.34.1 → 1.43.0** (+ semantic-conventions 0.55b1 → 0.64b0). All OTel-dependent tests remain green locally. Cannot verify Ubuntu 3.11–3.13 locally, but both new deps advertise support and the lock is deterministic (`uv sync --group dev`).

## Deviations

- The watch-daemon lifecycle test asserts the **observable enforcement property** (post-shutdown gate fails closed) rather than directly asserting registry-row PID self-heal in-test. Reason: the shared harness's `BackgroundProcess` holds the daemon's `Popen` handle open for the fixture lifetime, so on Windows the kernel keeps the process object alive and `_pid_alive(daemon_pid)` reads True even after `terminate()` — a **test-harness artifact, not a product issue** (in production the `gate --stdin` client holds no such handle). The chosen assertion is true on both platforms and is what actually matters for enforcement.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
