### PR TITLE
Add client-side dedup to SSE source (sse-dedup)

### DIFF
--- a/src/traceforge/sources/sse.py
+++ b/src/traceforge/sources/sse.py
@@ -126,13 +126,18 @@ class SSESource(Source):
                     # Dispatch event
                     if data_buf:
                         data = "\n".join(data_buf)
-                        if last_id is not None:
-                            self._last_event_id = last_id
-                        yield SSEEvent(
-                            data=data,
-                            event_type=event_type or "message",
-                            last_event_id=self._last_event_id,
-                        )
+                        # SSE is at-least-once: after a reconnect the server may
+                        # redeliver an already-seen id (e.g. resumed via Last-Event-ID).
+                        # Drop such redeliveries; only emit ids newer than the last one
+                        # we emitted, advancing _last_event_id solely for emitted events.
+                        if last_id is None or not self._is_duplicate(last_id):
+                            if last_id is not None:
+                                self._last_event_id = last_id
+                            yield SSEEvent(
+                                data=data,
+                                event_type=event_type or "message",
+                                last_event_id=self._last_event_id,
+                            )
                     # Reset per-event state
                     data_buf = []
                     event_type = ""
@@ -157,6 +162,25 @@ class SSESource(Source):
                 elif field == "retry":
                     if value.isdigit():
                         self.reconnect_delay = max(int(value) / 1000.0, 0.0)
+
+    def _is_duplicate(self, event_id: str) -> bool:
+        """Return True if ``event_id`` was already emitted (at-least-once redelivery).
+
+        After a reconnect an SSE server may redeliver events the client has already
+        seen. When both the last-emitted id and the candidate are integers, treat any
+        id not strictly greater than the last-seen id as a duplicate (monotonic ids,
+        the common case). For ids that cannot be ordered numerically, drop only an id
+        that exactly equals the last-emitted one (the immediately-preceding event).
+        """
+        last = self._last_event_id
+        if not last:
+            return False
+        if event_id == last:
+            return True
+        try:
+            return int(event_id) <= int(last)
+        except ValueError:
+            return False
 
     def _backoff_delay(self, reconnects: int) -> float:
         exponent = max(reconnects - 1, 0)

--- a/tests/e2e/test_sse_source_e2e.py
+++ b/tests/e2e/test_sse_source_e2e.py
@@ -158,15 +158,6 @@ async def test_sse_reconnect_sends_last_event_id(sse_server: SSEServer) -> None:
 # ─── duplicate id after reconnect NOT re-emitted (dedup) ─────────────────────
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "bug: SSESource performs no client-side dedup. When a server redelivers an "
-        "already-seen id after reconnect (at-least-once delivery), the source re-emits it: "
-        "sources/sse.py _iter_records/_stream_once yield every parsed event and _last_event_id "
-        "is only sent on reconnect, never used to filter ids <= the last seen."
-    ),
-)
 @pytest.mark.e2e
 @pytest.mark.net
 async def test_sse_duplicate_id_after_reconnect_not_reemitted(sse_server: SSEServer) -> None:


### PR DESCRIPTION
## Summary

`SSESource` performed no client-side deduplication. SSE is an at-least-once transport: after a reconnect the server may **redeliver** an already-seen event `id` (e.g. when the client resumes via the `Last-Event-ID` header). The source re-emitted those duplicates — `_last_event_id` was only *sent* on reconnect and was never *used* to filter incoming events. Repro observed `[alpha, beta, beta, gamma]` after a reconnect that redelivered `id=2`.

## Fix

Surgical change in `src/traceforge/sources/sse.py`, reusing the existing `_last_event_id` state (no new config, toggles, or legacy modes):

- Added a small `_is_duplicate(event_id)` helper. When both the last-emitted id and the candidate are integers it treats any id **not strictly greater** than the last-seen id as a duplicate (monotonic ids — the common case, `id <= last-seen`). For ids that can't be ordered numerically it drops only an id that **exactly equals** the last-emitted one (the immediately-preceding event).
- In the `_stream_once` dispatch block, redelivered/old events are now dropped instead of yielded, and `_last_event_id` advances **only for events that are actually emitted**.

This preserves the normal in-order streaming path and the `Last-Event-ID` resume behavior (the high-water mark still equals the last id we emitted), while dropping post-reconnect redeliveries. Result is now `[alpha, beta, gamma]`.

## Un-pinned guard

Removed the `@pytest.mark.xfail(strict=True)` marker on `tests/e2e/test_sse_source_e2e.py::test_sse_duplicate_id_after_reconnect_not_reemitted` so it is now a normal passing regression test (a strict-xfail that starts passing would XPASS and fail CI). Its assertion is unchanged (already an exact `["alpha", "beta", "gamma"]` equality). No other tests touched.

## Validation

- Full suite green: `uv run --no-progress python -m pytest -q -p no:cacheprovider` → **2799 passed, 6 skipped, 16 xfailed** (was 17 xfailed; the dedup guard flipped to a pass).
- Lint: `ruff==0.15.20 ruff check` → all checks passed; `ruff format --check` → 403 files already formatted.

Refs #104 (fixes bug 3 of 4: sse-no-dedup)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>