### PR TITLE
Force UTF-8 CLI output to fix Windows Unicode crash (cli-win-unicode)

### DIFF
--- a/src/traceforge/cli/__init__.py
+++ b/src/traceforge/cli/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import click
 
 from traceforge.cli.detect import detect
@@ -19,6 +21,14 @@ from traceforge.cli.download_cmd import download_model
 @click.version_option(package_name="traceforge")
 def main() -> None:
     """Traceforge — governance pipeline for AI coding agents."""
+    # Force UTF-8 on stdout/stderr so the CLI's Unicode glyphs (box rules,
+    # ✓/✗) never raise UnicodeEncodeError on a non-UTF-8 console such as a
+    # Windows cp1252 stdout. Guarded because streams may lack reconfigure
+    # (e.g. when replaced by an in-memory buffer under test).
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8")
 
 
 main.add_command(watch)

--- a/src/traceforge/cli/config_cmd.py
+++ b/src/traceforge/cli/config_cmd.py
@@ -60,10 +60,13 @@ def validate(config_path: str | None) -> None:
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             raise ValueError("Config must be a YAML mapping")
-        click.echo(f"✓ Config valid: {path}")
     except Exception as exc:
         click.echo(f"✗ Config invalid: {exc}", err=True)
         sys.exit(1)
+
+    # Emit the success line outside the try so a valid config is never
+    # misreported as invalid if the echo itself were to fail.
+    click.echo(f"✓ Config valid: {path}")
 
 
 def _resolve_config_path() -> Path | None:

--- a/tests/e2e/test_cli_config_e2e.py
+++ b/tests/e2e/test_cli_config_e2e.py
@@ -5,9 +5,9 @@ Covers the operator config lifecycle — ``init`` (write the default file),
 bad) — as real subprocesses against an isolated ``~/.traceforge``.
 
 Two happy paths (``validate`` on a valid file, ``show``) echo Unicode via
-``click.echo`` (a ``✓`` glyph and the ``─`` rules inside the default template)
-and therefore crash on a Windows cp1252 stdout. They are pinned with a strict
-conditional xfail so they are real passes on Linux CI and bug-pins on Windows.
+``click.echo`` (a ``✓`` glyph and the ``─`` rules inside the default template);
+the CLI entry point forces UTF-8 output so they pass on every platform,
+including a Windows cp1252 stdout.
 """
 
 from __future__ import annotations
@@ -20,19 +20,6 @@ import pytest
 from tests.e2e._cli import combined_output, run_cli
 
 _CONFIG_REL = Path(".traceforge") / "config.yaml"
-
-_WIN_UNICODE_BUG_VALIDATE = (
-    "bug: `config validate` on a VALID file echoes '✓ Config valid' "
-    "(src/traceforge/cli/config_cmd.py:63); on Windows cp1252 stdout the glyph "
-    "raises UnicodeEncodeError, caught by the except clause, so a valid config "
-    "wrongly reports invalid and exits 1 instead of 0."
-)
-_WIN_UNICODE_BUG_SHOW = (
-    "bug: `config show` prints the default template, whose section rules use "
-    "U+2500 (src/traceforge/config/defaults.py); click.echo of that content "
-    "raises UnicodeEncodeError on Windows cp1252 stdout, exiting 1 instead of 0 "
-    "(src/traceforge/cli/config_cmd.py:47)."
-)
 
 
 @pytest.mark.e2e
@@ -109,7 +96,6 @@ def test_config_validate_missing_path_is_usage_error(tmp_traceforge_home: Path) 
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG_VALIDATE)
 def test_config_validate_accepts_valid_file(tmp_traceforge_home: Path) -> None:
     assert run_cli("config", "init").returncode == 0
 
@@ -120,7 +106,6 @@ def test_config_validate_accepts_valid_file(tmp_traceforge_home: Path) -> None:
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG_SHOW)
 def test_config_show_prints_effective_config(tmp_traceforge_home: Path) -> None:
     assert run_cli("config", "init").returncode == 0
 

--- a/tests/e2e/test_cli_detect_e2e.py
+++ b/tests/e2e/test_cli_detect_e2e.py
@@ -5,27 +5,19 @@ These drive the real subprocess against the isolated ``tmp_traceforge_home`` and
 assert the exit code + output contract for the JSON surface (the machine-readable
 path an integration would parse) and the argument grammar.
 
-The human-readable table path emits a ``─`` rule via ``click.echo`` and so
-crashes on a Windows cp1252 stdout — a real product bug pinned below.
+The human-readable table path emits a ``─`` rule via ``click.echo``; the CLI
+entry point forces UTF-8 output so this succeeds on every platform, including a
+Windows cp1252 stdout.
 """
 
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
 
 from tests.e2e._cli import combined_output, run_cli
-
-# See test_config_cmd / status / init: one root cause across the CLI — Unicode
-# glyphs echoed without forcing UTF-8 fail on Windows' default cp1252 stdout.
-_WIN_UNICODE_BUG = (
-    "bug: `detect` (non-JSON) prints a U+2500 rule via click.echo "
-    "(src/traceforge/cli/detect.py:44); on Windows cp1252 stdout this raises "
-    "UnicodeEncodeError and the command exits 1 instead of 0."
-)
 
 
 def _seed_claude(home: Path) -> None:
@@ -86,13 +78,11 @@ def test_detect_unknown_framework_is_silently_empty(tmp_traceforge_home: Path) -
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG)
 def test_detect_plain_table_succeeds(tmp_traceforge_home: Path) -> None:
     """The default (table) output should print detected frameworks and exit 0.
 
-    On Windows it currently crashes (see ``_WIN_UNICODE_BUG``); this is a strict
-    conditional xfail, so it is a real PASS on the Linux CI matrix and an
-    xfailed bug-pin on Windows.
+    The ``─`` rule is emitted via ``click.echo``; the CLI forces UTF-8 output
+    so this passes on every platform, including a Windows cp1252 stdout.
     """
     _seed_claude(tmp_traceforge_home)
 

--- a/tests/e2e/test_cli_init_e2e.py
+++ b/tests/e2e/test_cli_init_e2e.py
@@ -6,31 +6,22 @@ Wave-5 gate story (#86); here we assert the operator contract lightly — a
 supported agent writes the settings file, an unsupported one is a Click usage
 error.
 
-The success path echoes a ``✓`` glyph *after* writing the file, so on a Windows
-cp1252 stdout it crashes with exit 1 (the file is still written). That is the
-same CLI-wide Unicode bug pinned elsewhere; here via a strict conditional xfail.
+The success path echoes a ``✓`` glyph *after* writing the file; the CLI entry
+point forces UTF-8 output so this succeeds on every platform, including a
+Windows cp1252 stdout.
 """
 
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
 
 from tests.e2e._cli import combined_output, run_cli
 
-_WIN_UNICODE_BUG = (
-    "bug: `init claude-code` echoes '✓ Wrote PreToolUse hook' after writing the "
-    "settings file (src/traceforge/cli/init_cmd.py:73); on Windows cp1252 stdout "
-    "the glyph raises UnicodeEncodeError and the command exits 1 instead of 0 "
-    "(the file is still written)."
-)
-
 
 @pytest.mark.e2e
-@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG)
 def test_init_claude_code_writes_settings(tmp_traceforge_home: Path) -> None:
     project = tmp_traceforge_home / "proj"
     project.mkdir(parents=True, exist_ok=True)

--- a/tests/e2e/test_cli_status_e2e.py
+++ b/tests/e2e/test_cli_status_e2e.py
@@ -6,25 +6,18 @@ pipeline has run. We build a real (empty) ``system.db`` through the production
 machine-readable JSON contract cross-platform. The missing-DB path must fail
 cleanly (exit 1, not a traceback).
 
-The human-readable table draws a ``─`` rule and so crashes on a Windows cp1252
-stdout — pinned with a strict conditional xfail (real pass on Linux CI).
+The human-readable table draws a ``─`` rule; the CLI entry point forces UTF-8
+output so this succeeds on every platform, including a Windows cp1252 stdout.
 """
 
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 
 import pytest
 
 from tests.e2e._cli import combined_output, run_cli
-
-_WIN_UNICODE_BUG = (
-    "bug: `status` (non-JSON) prints a U+2500 rule via click.echo "
-    "(src/traceforge/cli/status.py:59); on Windows cp1252 stdout this raises "
-    "UnicodeEncodeError and the command exits 1 instead of 0."
-)
 
 _EXPECTED_KEYS = {
     "active_sessions",
@@ -72,7 +65,6 @@ def test_status_missing_db_reports_cleanly(tmp_traceforge_home: Path) -> None:
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(sys.platform.startswith("win"), strict=True, reason=_WIN_UNICODE_BUG)
 def test_status_plain_table_succeeds(tmp_traceforge_home: Path) -> None:
     db_path = _build_system_db(tmp_traceforge_home)
 


### PR DESCRIPTION
## Summary

The CLI `click.echo`s Unicode glyphs — the box rule `─` (U+2500) and the
check/cross `✓`/`✗` (U+2713/U+2717) — without forcing UTF-8 output. On a
Windows **cp1252** stdout these raise `UnicodeEncodeError`, so the command
exits 1.

**Worst case:** `config validate` on a *valid* config file was wrongly
reported as invalid and exited 1 — the `✓` success echo raised inside the
broad `except`, which swallowed it and printed "Config invalid". JSON/ASCII
output paths were unaffected.

## Fix

- **Single-point UTF-8 at the CLI entry** — reconfigure `sys.stdout` and
  `sys.stderr` to UTF-8 in the top-level Click group callback
  (`src/traceforge/cli/__init__.py`), guarded via `getattr(stream,
  "reconfigure", None)`. This one change fixes the whole class of glyph
  crashes (`detect`, `status`, `config show`/`validate`, `init`, and the
  `─` rules embedded in the default config template) and covers both
  `python -m traceforge` and the `traceforge` console-script entry point —
  no per-glyph rewrites, no compat shims.
- **`config validate` broad-except hardened** — the `✓ Config valid` echo
  is moved *outside* the `try`, so a successful validation can never be
  flipped to "invalid"/exit 1 by an echo failure.

## Un-pinned guards

The bug was pinned by 5 Windows-only `@pytest.mark.xfail(strict=True)`
markers (real passes on Linux CI, xfail-pins on Windows). Those markers —
plus their now-unused `_WIN_UNICODE_BUG*` constants and `import sys` — are
removed so the tests are normal passing tests on every platform:

- `tests/e2e/test_cli_detect_e2e.py::test_detect_plain_table_succeeds`
- `tests/e2e/test_cli_status_e2e.py::test_status_plain_table_succeeds`
- `tests/e2e/test_cli_config_e2e.py::test_config_validate_accepts_valid_file`
- `tests/e2e/test_cli_config_e2e.py::test_config_show_prints_effective_config`
- `tests/e2e/test_cli_init_e2e.py::test_init_claude_code_writes_settings`

## Validation

CI runs on Linux where these already passed, so CI green does **not** prove
the Windows fix. Verified locally **on Windows** (piped child stdout probes
as `cp1252`):

- All 5 previously-pinned tests **PASS** (not xfail, not fail).
- `config validate <valid-config>` through a piped cp1252 subprocess exits
  **0** and prints the `✓`.
- Full suite: **2803 passed, 6 skipped, 12 xfailed** (the 5 un-pinned tests
  moved xfailed→passed; the remaining 12 xfailed are unrelated bugs).
- Lint clean: `ruff check .` and `ruff format --check .` (pinned
  `ruff==0.15.20`).

Refs #104 (fixes bug 2 of 4: cli-win-unicode-echo)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
