### PR TITLE
Fix gate_pydantic_ai for pydantic-ai ≥1 via wrapping toolset (pydantic-ai-gate)

### DIFF
--- a/src/traceforge/governance/pipeline.py
+++ b/src/traceforge/governance/pipeline.py
@@ -722,60 +722,65 @@ class GovernancePipeline:
         return _TraceforgeAgent
 
     def gate_pydantic_ai(self, agent) -> None:
-        """Register traceforge as Pydantic AI tool-execute hooks (before/after).
+        """Gate a Pydantic AI agent's tool calls via a wrapping toolset.
 
-        Blocking: raises SkipToolExecution with denial reason on preflight.
-        Session ID: from ctx.run_id (Pydantic AI's native UUID7 run ID).
-        Idempotent: calling twice on same agent is a no-op.
+        Blocking: preflight DENY raises ``RuntimeError('Denied: ...')``, which
+            propagates out of the agent run so the tool body never executes.
+        Session ID: from ``ctx.run_id`` (Pydantic AI's native per-run UUID).
+        Postflight: SUPPRESS/REDACT rewrite the tool's return value; TERMINATE raises.
+        Idempotent: calling twice on the same agent is a no-op.
+
+        Pydantic AI (>=1) exposes no tool-execution hooks; the supported per-tool
+        interception point is ``AbstractToolset.call_tool``. We wrap each of the
+        agent's leaf toolsets (its function tools plus any user/dynamic toolsets) in a
+        ``WrapperToolset`` subclass, so every tool call routes through the gate. Because
+        preflight and postflight run in the same ``call_tool`` invocation, the trace is
+        a local variable — no cross-hook stash is needed. Apply after tools are
+        registered.
         """
         if getattr(agent, "_traceforge_gated", False):
             return
-        agent._traceforge_gated = True
+
+        from pydantic_ai.toolsets import WrapperToolset
 
         pipeline = self
-        # External trace stash keyed by (run_id, tool_name) — avoids touching frozen ctx
-        _pending: dict[str, "EventTrace"] = {}
-        _MAX_PENDING = 1000
 
-        @agent.tool_hook("before")
-        async def _traceforge_before_tool(ctx, tool_def, args):
-            from pydantic_ai.exceptions import SkipToolExecution
+        class _TraceforgeGateToolset(WrapperToolset):
+            async def call_tool(self, name, tool_args, ctx, tool):
+                from traceforge.sdk.gate_types import PostflightAction
 
-            sid = str(getattr(ctx, "run_id", None) or "pydantic_ai")
-            payload = {
-                "tool_name": tool_def.name,
-                "tool_input": args if isinstance(args, dict) else {"raw": args},
-                "session_id": sid,
-            }
-            trace, verdict = pipeline._score_and_gate_preflight(payload)
-            if verdict.denied:
-                raise SkipToolExecution(f"Denied: {verdict.reason}")
-            stash_key = f"{sid}:{tool_def.name}:{id(args)}"
-            if len(_pending) >= _MAX_PENDING:
-                _pending.pop(next(iter(_pending)), None)
-            _pending[stash_key] = trace
+                sid = str(getattr(ctx, "run_id", None) or "pydantic_ai")
+                payload = {
+                    "tool_name": name,
+                    "tool_input": tool_args if isinstance(tool_args, dict) else {"raw": tool_args},
+                    "session_id": sid,
+                    "tool_call_id": getattr(ctx, "tool_call_id", None),
+                }
+                trace, verdict = pipeline._score_and_gate_preflight(payload)
+                if verdict.denied:
+                    raise RuntimeError(f"Denied: {verdict.reason}")
 
-        @agent.tool_hook("after")
-        async def _traceforge_after_tool(ctx, tool_def, args, result):
-            sid = str(getattr(ctx, "run_id", None) or "pydantic_ai")
-            stash_key = f"{sid}:{tool_def.name}:{id(args)}"
-            trace = _pending.pop(stash_key, None)
-            if trace is None:
-                return
-            pv = pipeline._enforce_postflight(
-                trace,
-                session_id=sid,
-                output={"result": str(result)} if result else None,
-            )
-            from traceforge.sdk.gate_types import PostflightAction
+                result = await super().call_tool(name, tool_args, ctx, tool)
 
-            if pv.action == PostflightAction.TERMINATE:
-                raise RuntimeError(f"Session terminated by policy: {pv.reason}")
-            if pv.action == PostflightAction.SUPPRESS:
-                # Return replacement string — Pydantic AI after hooks can return modified output
-                return "[output suppressed by policy]"
-            if pv.action == PostflightAction.REDACT and isinstance(result, str):
-                return pipeline._apply_postflight_to_output(pv, result)
+                pv = pipeline._enforce_postflight(
+                    trace,
+                    session_id=sid,
+                    output={"result": str(result)} if result is not None else None,
+                )
+                if pv.action == PostflightAction.TERMINATE:
+                    raise RuntimeError(f"Session terminated by policy: {pv.reason}")
+                if pv.action == PostflightAction.SUPPRESS:
+                    return "[output suppressed by policy]"
+                if pv.action == PostflightAction.REDACT and isinstance(result, str):
+                    return pipeline._apply_postflight_to_output(pv, result)
+                return result
+
+        # Wrap every leaf toolset the agent will assemble into its run toolset, then
+        # mark gated only after wrapping succeeds (no half-gated state on failure).
+        agent._function_toolset = _TraceforgeGateToolset(agent._function_toolset)
+        agent._user_toolsets = [_TraceforgeGateToolset(ts) for ts in agent._user_toolsets]
+        agent._dynamic_toolsets = [_TraceforgeGateToolset(ts) for ts in agent._dynamic_toolsets]
+        agent._traceforge_gated = True
 
     def gate_openai_agents(self, agent):
         """Register traceforge as an OpenAI Agents SDK input guardrail.

--- a/tests/e2e/test_gate_frameworks_e2e.py
+++ b/tests/e2e/test_gate_frameworks_e2e.py
@@ -7,10 +7,10 @@ adapters that had no e2e coverage:
     its native ``process(context, call_next)`` protocol. Only the tool body is
     faked; the middleware, ``MiddlewareTermination`` deny, and postflight
     redact/suppress transforms are the real traceforge code paths.
-  * ``pipeline.gate_pydantic_ai()`` — Pydantic AI tool hooks. This adapter is
-    currently BROKEN (it calls ``agent.tool_hook(...)`` which does not exist on
-    pydantic-ai>=1); the single test below is an ``xfail(strict=True)`` pinning
-    the bug so a future fix flips it to XPASS and alerts us.
+  * ``pipeline.gate_pydantic_ai()`` — Pydantic AI tool gating. The adapter wraps the
+    agent's leaf toolsets in a ``WrapperToolset`` whose ``call_tool`` runs the real
+    traceforge preflight (deny) and postflight (redact/suppress) code paths; only the
+    tool body is faked. Driven through a real ``Agent(TestModel())``.
 
 Both frameworks are guarded with ``importorskip`` so a missing optional dep
 skips (rather than errors) that framework's tests independently.
@@ -209,31 +209,135 @@ class TestMAFGating:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-class TestPydanticAIGating:
-    """E2E: pipeline.gate_pydantic_ai() tool-hook registration."""
+def _run_pydantic_agent(agent, prompt: str = "go") -> list:
+    """Run a gated Pydantic AI agent and collect its tool-return contents.
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "bug: gate_pydantic_ai registers hooks via agent.tool_hook('before'/'after'), "
-            "but pydantic-ai>=1 Agent has no tool_hook attribute. "
-            "EXPECTED: hooks register and a dangerous call is denied. "
-            "ACTUAL: AttributeError: 'Agent' object has no attribute 'tool_hook'. "
-            "src/traceforge/governance/pipeline.py:740 and :758."
-        ),
-    )
-    def test_gate_pydantic_ai_registers_hooks(self):
+    ``TestModel(call_tools="all")`` emits exactly one call per registered function
+    tool, so a single registered tool is invoked once and routed through the gate.
+    Output tools are not gated and do not appear here.
+    """
+    from pydantic_ai.messages import ToolReturnPart
+
+    result = agent.run_sync(prompt)
+    returns = []
+    for message in result.all_messages():
+        for part in getattr(message, "parts", []):
+            if isinstance(part, ToolReturnPart):
+                returns.append(part.content)
+    return returns
+
+
+class TestPydanticAIGating:
+    """E2E: pipeline.gate_pydantic_ai() wrapping-toolset enforcement.
+
+    Driven through a real ``Agent(TestModel())``. Only the tool body is faked; the
+    ``WrapperToolset`` gate, preflight deny, and postflight redact/suppress transforms
+    are the real traceforge code paths.
+    """
+
+    def test_gate_registration_is_idempotent(self):
+        """gate_pydantic_ai marks the agent gated and a second call is a no-op."""
+        pytest.importorskip("pydantic_ai")
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        pipeline = make_pipeline(preflight=allow_all_gate)
+        agent = Agent(TestModel())
+
+        assert getattr(agent, "_traceforge_gated", False) is False
+        pipeline.gate_pydantic_ai(agent)
+        assert getattr(agent, "_traceforge_gated", False) is True
+
+        gated_toolset = agent._function_toolset
+        pipeline.gate_pydantic_ai(agent)  # second call must not re-wrap
+        assert agent._function_toolset is gated_toolset
+
+    def test_dangerous_call_denied(self):
+        """A denied tool raises out of the run and its body never executes."""
         pytest.importorskip("pydantic_ai")
         from pydantic_ai import Agent
         from pydantic_ai.models.test import TestModel
 
         pipeline = make_pipeline(preflight=deny_rm_gate)
         agent = Agent(TestModel())
+        called = {"n": 0}
 
-        # Currently raises AttributeError inside gate_pydantic_ai (the bug).
+        @agent.tool_plain(name="rm")
+        def remove(path: str) -> str:
+            called["n"] += 1
+            return f"removed {path}"
+
         pipeline.gate_pydantic_ai(agent)
 
-        # Reached only once the adapter is fixed: registration must be idempotent
-        # and mark the agent as gated.
-        assert getattr(agent, "_traceforge_gated", False) is True
-        pipeline.gate_pydantic_ai(agent)  # idempotent no-op
+        with pytest.raises(RuntimeError, match="Denied: Destructive tool blocked: rm"):
+            agent.run_sync("go")
+
+        assert called["n"] == 0  # tool body never executed
+
+    def test_safe_call_allowed(self):
+        """A safe tool is allowed: it executes and its result passes through."""
+        pytest.importorskip("pydantic_ai")
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        pipeline = make_pipeline(preflight=deny_rm_gate)
+        agent = Agent(TestModel())
+        called = {"n": 0}
+
+        @agent.tool_plain
+        def read_file(path: str) -> str:
+            called["n"] += 1
+            return "contents of the file"
+
+        pipeline.gate_pydantic_ai(agent)
+
+        returns = _run_pydantic_agent(agent)
+
+        assert called["n"] == 1
+        assert "contents of the file" in returns
+
+    def test_postflight_redacts_secret(self):
+        """A successful result containing SECRET is redacted in place."""
+        pytest.importorskip("pydantic_ai")
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        pipeline = make_pipeline(
+            preflight=allow_all_gate,
+            postflight=redact_secret_postflight,
+        )
+        agent = Agent(TestModel())
+
+        @agent.tool_plain
+        def search(query: str) -> str:
+            return "the SECRET api key is 42"
+
+        pipeline.gate_pydantic_ai(agent)
+
+        returns = _run_pydantic_agent(agent)
+
+        assert returns  # the tool was called and returned through the gate
+        assert all("SECRET" not in str(r) for r in returns)
+        assert any("[REDACTED]" in str(r) for r in returns)
+
+    def test_postflight_suppresses_output(self):
+        """A successful result flagged for suppression is replaced wholesale."""
+        pytest.importorskip("pydantic_ai")
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        pipeline = make_pipeline(
+            preflight=allow_all_gate,
+            postflight=suppress_if_output_contains_hide,
+        )
+        agent = Agent(TestModel())
+
+        @agent.tool_plain
+        def dump(what: str) -> str:
+            return "please HIDE this from the caller"
+
+        pipeline.gate_pydantic_ai(agent)
+
+        returns = _run_pydantic_agent(agent)
+
+        assert "[output suppressed by policy]" in returns


### PR DESCRIPTION
## Bug (issue #104, bug 4 of 4 — `pydantic-ai-tool-hook-missing` / story #86)

`GovernancePipeline.gate_pydantic_ai(agent)` registered interception via
`@agent.tool_hook("before")` / `@agent.tool_hook("after")`. On the locked
`pydantic-ai-slim 1.60.0` the `Agent` has **no** `tool_hook` attribute (and
`pydantic_ai.exceptions` has no `SkipToolExecution`), so the call raised
`AttributeError` — after already setting `agent._traceforge_gated = True`, leaving a
half-gated agent with no hooks attached.

Repro: `GovernancePipeline.create().gate_pydantic_ai(Agent(TestModel()))` → `AttributeError`.

## Fix — use the supported toolset interception API

pydantic-ai ≥1 exposes no tool-execution hooks; the supported per-tool interception
point is `AbstractToolset.call_tool(name, args, ctx, tool)` — the same mechanism the
library's own `ApprovalRequiredToolset` uses. The adapter now:

- Defines a `WrapperToolset` subclass whose `call_tool` runs the **same governance
  contract as `gate_maf`**: preflight `DENY` → `raise RuntimeError("Denied: …")` so the
  tool body never executes; postflight `SUPPRESS`/`REDACT` rewrite the tool's return
  value; `TERMINATE` raises.
- Wraps each of the agent's leaf toolsets **in place** — `_function_toolset`,
  `_user_toolsets`, `_dynamic_toolsets` — so every tool call routes through the gate
  (`CombinedToolset` dispatches `call_tool` to the element toolset, and
  `visit_and_replace` preserves the wrapper).
- Derives the session id from `RunContext.run_id`.
- Sets `_traceforge_gated = True` **only after** wrapping succeeds — no half-gated state
  on failure.
- Deletes the old cross-hook `_pending` trace stash (keyed by run_id+tool+`id(args)`,
  with a 1000-entry eviction cap): preflight and postflight now run in the **same**
  `call_tool` invocation, so the trace is just a local variable.

## Un-pinned guard

`tests/e2e/test_gate_frameworks_e2e.py::TestPydanticAIGating` was a single
`xfail(strict=True)` pinning the bug. A now-passing strict-xfail becomes an XPASS → CI
failure, so it had to be un-pinned: it is replaced with real **deny / allow / redact /
suppress + idempotency** assertions driven through a real `Agent(TestModel())`,
mirroring `TestMAFGating`. No other tests were touched.

## Validation

- Full suite: **2803 passed, 6 skipped, 16 xfailed** (the remaining xfails are the other
  still-pinned #104 bug guards).
- Lint: `ruff check` clean; `ruff format --check` clean (pinned `ruff==0.15.20`).

Refs #104 (fixes bug 4 of 4: pydantic-ai-tool-hook-missing)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>