### PR TITLE
Part C follow-up: delegate enum-dimension audit to maintained tests

### DIFF
--- a/.github/workflows/tool-surface-audit.yml
+++ b/.github/workflows/tool-surface-audit.yml
@@ -59,46 +59,14 @@ jobs:
               print('\n✅ All YAML files valid')
           " 2>&1 | tee -a audit-output.txt
 
+      # Delegates to the maintained unit tests (single source of truth) instead
+      # of re-deriving enum rules inline — that inline copy drifted from the
+      # typed config API and rotted silently for a month. These tests validate
+      # tool_classifications + binary_info + mcp_profiles enum values against the
+      # registry.validate() API. See tests/unit/test_classification.py.
       - name: Validate enum dimensions in YAML
         run: |
-          uv run python -c "
-          import sys
-          from traceforge.classify.coding import CodingRole, CodingScope, CodingAction
-          from traceforge.classify.config import load_config
-
-          config = load_config()
-          errors = []
-
-          # load_config() returns a typed ClassifyConfig: binary_info values are
-          # BinaryInfoConfig models (attribute access) and mcp_profiles is a list
-          # of McpProfileConfig — NOT the raw dicts this check once assumed.
-
-          # Validate binary_info roles
-          valid_role_prefixes = {r.value.split('.')[0] for r in CodingRole}
-          for name, info in config.binary_info.items():
-              role = info.role or ''
-              if '.' in role:
-                  prefix = role.split('.')[0]
-                  if prefix not in valid_role_prefixes:
-                      errors.append(f'binary_info[{name}].role={role} — invalid prefix')
-
-          # Validate MCP profile dimensions
-          for profile in config.mcp_profiles:
-              profile_name = profile.id or ','.join(profile.namespace_aliases)
-              for v in profile.role:
-                  if '.' in str(v):
-                      prefix = str(v).split('.')[0]
-                      if prefix not in valid_role_prefixes:
-                          errors.append(f'mcp_profiles[{profile_name}].role={v} — invalid')
-
-          if errors:
-              print(f'❌ {len(errors)} dimension validation errors:')
-              for err in errors[:20]:
-                  print(f'  • {err}')
-              sys.exit(1)
-          else:
-              print('✅ All dimensions valid')
-          " 2>&1 | tee -a audit-output.txt
+          uv run pytest tests/unit/test_classification.py -k "enum_values" -q 2>&1 | tee -a audit-output.txt
 
       - name: Run classification engine smoke test
         run: |

--- a/tests/unit/test_classification.py
+++ b/tests/unit/test_classification.py
@@ -469,6 +469,47 @@ class TestRedTeamRegressions:
             for a in cls.action:
                 assert reg.validate("action", a), f"{name}: action '{a}' not registered"
 
+    def test_enum_values_in_binary_info_and_mcp_profiles_are_registered(self):
+        """binary_info + mcp_profiles enum values must be registered dimension values.
+
+        This is the maintained home for the check the weekly Tool Surface Audit
+        used to run with inline YAML-parsing code in the workflow. That inline
+        copy drifted from the typed config API and only checked role *prefixes*;
+        keeping the check here (against the same registry.validate() API the
+        sibling tool_classifications test uses) means it can never silently rot
+        out-of-sync with the config models again.
+        """
+        from traceforge.classify.config import load_config
+        from traceforge.classify.registry import get_default_registry
+
+        config = load_config()
+        reg = get_default_registry()
+
+        # Teeth: the loops below must run over real data (not pass vacuously),
+        # and the registry must actually reject an unregistered value.
+        assert config.binary_info, "no binary_info loaded — check would pass vacuously"
+        assert config.mcp_profiles, "no mcp_profiles loaded — check would pass vacuously"
+        assert not reg.validate("role", "bogus.not_a_real_role")
+
+        for name, info in config.binary_info.items():
+            assert reg.validate("role", info.role), (
+                f"binary_info[{name}]: role '{info.role}' not registered"
+            )
+
+        for profile in config.mcp_profiles:
+            pid = profile.id or ",".join(profile.namespace_aliases)
+            assert reg.validate("mechanism", profile.mechanism), (
+                f"mcp_profiles[{pid}]: mechanism '{profile.mechanism}' not registered"
+            )
+            for r in profile.role:
+                assert reg.validate("role", r), f"mcp_profiles[{pid}]: role '{r}' not registered"
+            for s in profile.scope:
+                assert reg.validate("scope", s), f"mcp_profiles[{pid}]: scope '{s}' not registered"
+            for a in profile.action:
+                assert reg.validate("action", a), (
+                    f"mcp_profiles[{pid}]: action '{a}' not registered"
+                )
+
     def test_rule_effects_override_binary_info_defaults(self):
         """Shell rules with explicit effect must override binary_info defaults."""
         # find -delete rule has effect=destructive, binary_info has read_only default


### PR DESCRIPTION
## Context

Small follow-up to #109 (merged). #109 fixed the two weekly audit workflows — Part A (uv install plumbing so the local-only `traceforge-title-model` resolves via `[tool.uv.sources]`, which plain `pip` ignores) and Part B (issue-filing so failures stop going red silently) — and fixed the masked **enum-dimensions** finding by porting the audit's stale inline validator to the typed config API, **inline in the workflow YAML**.

Per the coordinator's ruling on Part C — _single source of truth / no resurrected inline validators_ — that inline YAML Python is exactly the kind of duplicated logic that drifted from the code and rotted silently for a month. #109 was merged (by the coordinator) before this refinement landed, so `main` currently carries the inline version. This PR replaces it with the ruling-compliant approach. **No functional regression** — the tool-surface audit was already green with the inline version; this is a source-of-truth/hygiene change.

## What changed

- **`.github/workflows/tool-surface-audit.yml`** — the `Validate enum dimensions in YAML` step no longer runs a hand-rolled inline `python -c` validator. It now runs the maintained unit tests directly:
  ```
  uv run pytest tests/unit/test_classification.py -k "enum_values"
  ```
  so the enum-dimension rules can never drift from the code again (and the job's full `uv run pytest` step already covers them too).

- **`tests/unit/test_classification.py`** — added `test_enum_values_in_binary_info_and_mcp_profiles_are_registered`. The existing `test_enum_values_in_tool_classifications_are_registered` only validated `tool_classifications`; **no existing test covered `binary_info` or `mcp_profiles`**, which is the exact surface the inline check owned. The new test mirrors the sibling and validates every `binary_info[*].role` and every `mcp_profiles[*].{role, scope, action, mechanism}` value against the same `registry.validate()` API the other registry tests use.
  - Data verified clean: **0 violations** across 309 `binary_info` + 50 `mcp_profiles` under the strict `registry.validate()` (exact membership — stronger than the old prefix-only check).
  - Teeth: non-empty assertions + a negative `registry.validate("role", "bogus.not_a_real_role")` self-check so it can't pass vacuously.

No data changes — the YAML was clean; the check itself was the bug.

## Validation

- `uv run pytest tests/unit/test_classification.py -k "enum_values"` → **2 passed**
- `ruff check` + `ruff format --check` on the changed test → clean
- End-to-end on real CI via `workflow_dispatch` on this branch — tool-surface audit fully green, delegated enum step ✓, full suite ✓, `File issue on failure` correctly skipped.

Leaving **UNMERGED** for coordinator review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
