### PR TITLE
Fix weekly compat audit probes to eliminate false failures (compat-probes)

### DIFF
--- a/.github/workflows/weekly-compat-audit.yml
+++ b/.github/workflows/weekly-compat-audit.yml
@@ -22,10 +22,8 @@ jobs:
             package: pydantic-ai-slim
           - name: smolagents
             package: smolagents
-          - name: autogen
-            package: autogen-agentchat
           - name: maf
-            package: microsoft-agents-hosting-core
+            package: agent-framework-core
           - name: aider
             package: aider-chat
 
@@ -54,9 +52,25 @@ jobs:
         id: test
         continue-on-error: true
         run: |
-          uv run --no-sync pytest tests/ -q --tb=short \
-            -k "${{ matrix.framework.name }}" \
-            2>&1 | tee test-output.txt
+          # pytest test names use underscores (e.g. pydantic_ai) but the matrix name is
+          # hyphenated (pydantic-ai); a hyphen in -k collects zero tests (pytest exit 5),
+          # so normalize '-' -> '_' before selecting.
+          kfilter="${{ matrix.framework.name }}"
+          kfilter="${kfilter//-/_}"
+          # Disable errexit so the pipeline failure doesn't abort the step before we read
+          # pytest's real exit code (PIPESTATUS[0]) — tee would otherwise mask it.
+          set +e
+          uv run --no-sync pytest tests/ -q --tb=short -k "$kfilter" 2>&1 | tee test-output.txt
+          status=${PIPESTATUS[0]}
+          set -e
+          # Exit 5 = "no tests collected": a framework may have a valid YAML mapping
+          # (still audited by the compat check step below) but no adapter pytest tests.
+          # That is a legitimate skip, not a failure. A real test failure (exit 1) still fails.
+          if [ "$status" -eq 5 ]; then
+            echo "No adapter pytest tests collected for '$kfilter' (pytest exit 5) — treated as pass/skip."
+            status=0
+          fi
+          exit "$status"
 
       - name: Check for breaking SDK changes
         id: check

--- a/scripts/check_framework_compat.py
+++ b/scripts/check_framework_compat.py
@@ -85,7 +85,7 @@ def check_pydantic_ai() -> list[str]:
         _validate_mapping_with_sample(
             "pydantic_ai",
             {
-                "event_type": "agent_run_start",
+                "type": "agent_run_start",
                 "timestamp": "2024-01-01T00:00:00Z",
                 "agent_name": "test_agent",
                 "model_name": "gpt-4o",
@@ -108,23 +108,13 @@ def check_smolagents() -> list[str]:
         _validate_mapping_with_sample(
             "smolagents",
             {
-                "step_type": "AgentStep",
+                "step_type": "ActionStep",
                 "timestamp": "2024-01-01T00:00:00Z",
                 "agent_name": "ToolCallingAgent",
                 "thought": "I should search for this",
             },
         )
     )
-    return errors
-
-
-def check_autogen() -> list[str]:
-    """Verify AutoGen is importable."""
-    errors: list[str] = []
-    try:
-        import autogen_agentchat  # noqa: F401
-    except ImportError as e:
-        errors.append(f"autogen_agentchat not importable: {e}")
     return errors
 
 
@@ -265,7 +255,6 @@ _CHECKERS = {
     "langgraph": check_langgraph,
     "pydantic-ai": check_pydantic_ai,
     "smolagents": check_smolagents,
-    "autogen": check_autogen,
     "maf": check_maf,
     "aider": check_aider,
 }


### PR DESCRIPTION
## Summary

Follow-up to #109. That PR wired the Weekly Framework Compatibility Audit to **actually file issues on failure** (test/check steps are `continue-on-error`, an `if: always()` gate reds the job, and an `if: failure()` step files/dedupes a `compat-failure` issue). This exposed three pre-existing correctness bugs in the audit's **probes** that would make it file **false** issues for its own stale probe code rather than for genuine framework-compat breakage. This PR fixes those so the audit only fires on real breakage.

Two files touched — `scripts/check_framework_compat.py` and `.github/workflows/weekly-compat-audit.yml`. The YAML mappings under `src/traceforge/mappings/` are healthy (adapter tests pass) and are intentionally left untouched; only the probe code had drifted.

## Finding 1 — stale hardcoded sample events in the compat probes

Two probe functions sent sample events whose discriminator did not match the framework mapping's `type_field`, so the probe falsely reported the mapping as broken:

- **pydantic_ai**: probe sent `{"event_type": "agent_run_start"}`, but `pydantic_ai.yaml` declares `type_field: type`. The sample was being read against the wrong discriminator key and mapped to `raw`. Fixed the key to `"type"` (kept the value `agent_run_start`, which is a real event key in the mapping).
- **smolagents**: probe sent `{"step_type": "AgentStep"}`, but `AgentStep` is not a key in `smolagents.yaml` (valid keys are `ActionStep`, `PlanningStep`, `TaskStep`, `SystemPromptStep`, `FinalAnswer`, `ToolCall`). The discriminator key `step_type` was already correct; changed the value to the real `"ActionStep"`.

Only the drifted discriminator values were changed; each probe now exercises a real mapping path.

## Finding 2 — `-k` test selection and the "no tests collected" case

- The matrix framework name is hyphenated (e.g. `pydantic-ai`) but pytest test names use underscores (`pydantic_ai`), so `-k "pydantic-ai"` collected **0 tests** (pytest exit code 5) even though ~50 real pydantic_ai adapter tests exist. The test step now normalizes `-` → `_` in the `-k` expression, so real tests are actually found. (`langgraph`/`smolagents`/`maf`/`aider` have no hyphen and are unaffected.)
- A genuine "no tests collected" (pytest exit 5) is now treated as a pass/skip rather than a failure, so a framework with a valid mapping but no dedicated adapter pytest tests won't file a false `compat-failure` issue. A real test failure (exit 1) is still treated as a failure. Implemented by reading pytest's real exit code via `PIPESTATUS[0]` (past the `tee`) and only swallowing exit 5. The compat **check** step still runs regardless, so such a framework is still meaningfully audited.

## Finding 3 — maf matrix leg upgraded the wrong package

The maf leg upgraded `microsoft-agents-hosting-core`, but that package is **not** what the maf adapter/mapping targets:

- The project's dev dependency group installs **`agent-framework-core`** (import `agent_framework`), and `src/traceforge/governance/pipeline.py` imports `from agent_framework import ...`.
- `microsoft-agents-hosting-core` is not in the dev group, not in `uv.lock`, and is never imported anywhere in `src/` — it appears only in two YAML header comments and (until now) this matrix. It is a different Microsoft SDK (the M365 Agents SDK).
- "MAF" = Microsoft Agent Framework = `agent-framework-core`.

The matrix's purpose is to upgrade the SDK the adapter actually targets to its latest release and re-run the audit against it. Upgrading `microsoft-agents-hosting-core` installed an unrelated package and never tested the real MAF path. **Decision: align the maf leg to upgrade `agent-framework-core`.** (This was clear-cut, not ambiguous, so no need to escalate.) The stale `microsoft-agents-hosting-core` comment in `maf.yaml`/`maf_transcript.yaml` is out of scope for this probe-only PR and left as-is.

## Autogen decision — removed from the matrix

Investigation found **no real autogen support** in the repo:

- No autogen adapter anywhere in `src/traceforge/`.
- No `autogen.yaml` mapping.
- No autogen adapter tests (`-k autogen` collects nothing).
- `check_autogen` only did `import autogen_agentchat` — a package that isn't even a project dependency — and validated nothing about traceforge (there is no mapping to audit).

Because the "keep it" path requires a real mapping + a meaningful check (so the check step actually audits something) and none of that exists, the honest call is to **remove the autogen matrix leg** and its dead `check_autogen` probe (and its `_CHECKERS` entry). Leaving a hollow import-only probe would either false-red on an empty `-k` run or pass without auditing anything. If/when a real autogen adapter + mapping land, the leg can be reintroduced alongside a meaningful probe.

## Validation

- Compat probe run the workflow's way (`uv run --no-sync python scripts/check_framework_compat.py`) passes cleanly for all matrix frameworks: langgraph, pydantic-ai, smolagents, maf (`agent-framework-core`), aider.
- Normalized `-k` adapter tests collect + pass: pydantic_ai 49p/3xf, langgraph 59p/1s, smolagents 53p, maf 45p/1s, aider 108p/1s. The old `-k "pydantic-ai"` reproduces the bug (0 collected, exit 5).
- Full suite: **2810 passed, 6 skipped, 9 xfailed** — no regressions.
- Ruff 0.15.20 `check` and `format --check` clean (changed file and repo-wide).
- Dispatched `weekly-compat-audit.yml` on this branch: all matrix legs + the `audit-yaml-mappings` job green, zero `compat-failure` issues filed. (Run details in the PR thread.)

Left unmerged for review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>