### PR TITLE
Fix preprocessors crashing on null-valued container fields

### DIFF
--- a/src/traceforge/preprocessors/amazonq.py
+++ b/src/traceforge/preprocessors/amazonq.py
@@ -44,12 +44,13 @@ def _expand_amazonq_pair(entry: dict[str, Any], cid: str) -> list[dict[str, Any]
         results = None
         if isinstance(content, dict):
             if "Prompt" in content:
-                prompt = content["Prompt"].get("prompt")
+                prompt = (content["Prompt"] or {}).get("prompt")
             elif "CancelledToolUses" in content:
-                prompt = content["CancelledToolUses"].get("prompt")
-                results = content["CancelledToolUses"].get("tool_use_results")
+                cancelled = content["CancelledToolUses"] or {}
+                prompt = cancelled.get("prompt")
+                results = cancelled.get("tool_use_results")
             elif "ToolUseResults" in content:
-                results = content["ToolUseResults"].get("tool_use_results")
+                results = (content["ToolUseResults"] or {}).get("tool_use_results")
         if prompt:
             out.append({"block_type": "message.user", "conversation_id": cid, "content": prompt})
         for r in results or []:

--- a/src/traceforge/preprocessors/codex.py
+++ b/src/traceforge/preprocessors/codex.py
@@ -239,7 +239,7 @@ def _handle_event_msg(payload: dict[str, Any], base: dict[str, Any]) -> list[dic
         ]
 
     if event_type == "mcp_tool_call_begin":
-        invocation = payload.get("invocation", {})
+        invocation = payload.get("invocation") or {}
         return [
             {
                 **base,
@@ -252,7 +252,7 @@ def _handle_event_msg(payload: dict[str, Any], base: dict[str, Any]) -> list[dic
         ]
 
     if event_type == "mcp_tool_call_end":
-        invocation = payload.get("invocation", {})
+        invocation = payload.get("invocation") or {}
         result = payload.get("result", {})
         # Result is {"Ok": {...}} or {"Err": "..."}
         ok_val = result.get("Ok", {}) if isinstance(result, dict) else {}

--- a/src/traceforge/preprocessors/goose.py
+++ b/src/traceforge/preprocessors/goose.py
@@ -42,7 +42,7 @@ def preprocess_goose(obj: dict[str, Any]) -> list[dict[str, Any]]:
             has_text = True
         elif item_type == "toolRequest":
             tool_call = item.get("toolCall", {})
-            value = tool_call.get("value", {}) if isinstance(tool_call, dict) else {}
+            value = (tool_call.get("value") or {}) if isinstance(tool_call, dict) else {}
             results.append(
                 {
                     "role": "tool_use",
@@ -59,7 +59,7 @@ def preprocess_goose(obj: dict[str, Any]) -> list[dict[str, Any]]:
                     "role": "tool_result",
                     "created_at": ts,
                     "tool_use_id": item.get("id", ""),
-                    "content": tool_result.get("value", {}).get("content", "")
+                    "content": (tool_result.get("value") or {}).get("content", "")
                     if isinstance(tool_result, dict)
                     else "",
                     "is_success": tool_result.get("status") == "success"
@@ -118,7 +118,7 @@ def preprocess_goose(obj: dict[str, Any]) -> list[dict[str, Any]]:
             )
         elif item_type == "frontendToolRequest":
             tool_call = item.get("toolCall", {})
-            value = tool_call.get("value", {}) if isinstance(tool_call, dict) else {}
+            value = (tool_call.get("value") or {}) if isinstance(tool_call, dict) else {}
             results.append(
                 {
                     "role": "frontend_tool_request",

--- a/src/traceforge/preprocessors/pydantic_ai.py
+++ b/src/traceforge/preprocessors/pydantic_ai.py
@@ -26,7 +26,7 @@ def preprocess_pydantic_ai(obj: dict[str, Any]) -> list[dict[str, Any]]:
         elif event_kind == "model_response_stream":
             normalized["type"] = "model_response_chunk"
             if "chunk" not in normalized:
-                normalized["chunk"] = normalized.get("part", {}).get("content", "")
+                normalized["chunk"] = (normalized.get("part") or {}).get("content", "")
         else:
             normalized["type"] = f"stream.{event_kind}"
         return [normalized]
@@ -37,7 +37,7 @@ def preprocess_pydantic_ai(obj: dict[str, Any]) -> list[dict[str, Any]]:
         normalized = dict(obj)
         normalized["type"] = "model_response"
         # Extract text from parts for convenience
-        parts = normalized.get("parts", [])
+        parts = normalized.get("parts") or []
         text_parts = [
             p.get("content", "")
             for p in parts
@@ -49,7 +49,7 @@ def preprocess_pydantic_ai(obj: dict[str, Any]) -> list[dict[str, Any]]:
     elif kind == "request":
         normalized = dict(obj)
         normalized["type"] = "model_request"
-        parts = normalized.get("parts", [])
+        parts = normalized.get("parts") or []
         user_parts = [
             p.get("content", "")
             for p in parts

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -1014,50 +1014,33 @@ class TestAntigravity:
 # where ``key`` is PRESENT but explicitly ``null`` (a plausible schema drift). ``.get``
 # returns the ``None`` value — not the default — and the code then iterates / attributes it.
 #
-# Per the #84 ticket (tests-only, no src changes) these are pinned as strict xfails and
-# reported to the epic coordinator to be triaged as their own issue. When the src is fixed,
-# ``strict=True`` turns the xpass into a failure so this guard is removed deliberately.
+# These were pinned as strict xfails while the fix was deferred to its own issue (#92);
+# the src is now normalized (``d.get(key) or <default>``) so they are ordinary passing
+# regression tests that lock in the fix.
 
 
 class TestKnownProductBugsNullContainers:
-    """Captured crashes on ``null`` where a list/dict container was expected."""
+    """Null where a list/dict container was expected must normalize, not crash."""
 
-    @pytest.mark.xfail(
-        reason="BUG: pydantic_ai crashes on response parts=null (drift); "
-        "reported to #90 coordinator",
-        strict=True,
-        raises=TypeError,
-    )
     def test_pydantic_ai_response_null_parts(self) -> None:
         out = preprocess_pydantic_ai({"kind": "response", "parts": None})
         assert isinstance(out, list)
+        assert len(out) == 1
+        assert out[0]["type"] == "model_response"
 
-    @pytest.mark.xfail(
-        reason="BUG: pydantic_ai crashes on request parts=null (drift); "
-        "reported to #90 coordinator",
-        strict=True,
-        raises=TypeError,
-    )
     def test_pydantic_ai_request_null_parts(self) -> None:
         out = preprocess_pydantic_ai({"kind": "request", "parts": None})
         assert isinstance(out, list)
+        assert len(out) == 1
+        assert out[0]["type"] == "model_request"
 
-    @pytest.mark.xfail(
-        reason="BUG: pydantic_ai crashes on stream chunk part=null (drift); "
-        "reported to #90 coordinator",
-        strict=True,
-        raises=AttributeError,
-    )
     def test_pydantic_ai_stream_null_part(self) -> None:
         out = preprocess_pydantic_ai({"event_kind": "model_response_stream", "part": None})
         assert isinstance(out, list)
+        assert len(out) == 1
+        assert out[0]["type"] == "model_response_chunk"
+        assert out[0]["chunk"] == ""
 
-    @pytest.mark.xfail(
-        reason="BUG: amazonq crashes on history user.content={'Prompt': null} "
-        "(drift); reported to #90 coordinator",
-        strict=True,
-        raises=AttributeError,
-    )
     def test_amazonq_null_prompt_enum(self) -> None:
         out = preprocess_amazonq(
             {
@@ -1068,3 +1051,5 @@ class TestKnownProductBugsNullContainers:
             }
         )
         assert isinstance(out, list)
+        assert len(out) == 1
+        assert out[0]["block_type"] == "raw.empty"


### PR DESCRIPTION
Closes #92

## Problem
"Null where a container is expected." When an optional array/object field is present but explicitly `null`, `d.get(key, default)` returns `None` (not the default), so the next line iterated / attribute-accessed `None` and crashed. A framework emitting an explicit `null` for an optional field took down the preprocessor.

Fix pattern (single source of truth, no compat shims): normalize the null-valued container to its default before use — `d.get(key) or []` for arrays, `d.get(key) or {}` for objects.

## Site fixes (the 3 root causes from #92)
- **pydantic_ai.py** — `parts = normalized.get("parts") or []` in both the `response` and `request` paths (was `TypeError` on `parts: null`); one fix covers both. And `(normalized.get("part") or {}).get("content", "")` for the `model_response_stream` chunk (was `AttributeError` on `part: null`).
- **amazonq.py** — normalize the externally-tagged enum body before `.get()`: `(content["Prompt"] or {}).get("prompt")`, and likewise for the `CancelledToolUses` / `ToolUseResults` branches (was `AttributeError` on `content = {"Prompt": null}`).

## In-scope audit (the other 12 preprocessors)
Checked every remaining preprocessor for the same `.get(key, <container-default>)`-then-iterate/attribute pattern that breaks on an explicit `null`:

| Preprocessor | Verdict |
|---|---|
| codex.py | **Fixed** — `invocation = payload.get("invocation") or {}` in `mcp_tool_call_begin`/`end` (crashed on `invocation: null`) |
| goose.py | **Fixed** — nested `value` in `toolRequest` / `toolResponse` / `frontendToolRequest` via `(tool_call.get("value") or {})` / `(tool_result.get("value") or {})` (crashed on `value: null`) |
| copilot_vscode.py | Already safe (`... or []`, `isinstance()` guards) |
| opencode.py | Already safe (`isinstance(...) else {}`) |
| smolagents.py | Already safe (`if x and isinstance(x, list)`) |
| continue_dev.py | Already safe (`isinstance()` guards) |
| openai_agents.py | Already safe (`... or {}`) |
| cline.py | Already safe (no container iterate/attribute) |
| maf_transcript.py | Already safe (`... or {}`, `isinstance()`) |
| claude.py | Already safe (`isinstance()` guards) |
| antigravity.py | Already safe (`... or []`) |
| openhands.py | Already safe (no container iterate/attribute) |

Behavior for non-null inputs is unchanged — `.get(key, {})` and `.get(key) or {}` differ only when the value is explicitly `null`.

## Un-pinned guards
Removed the 4 `@pytest.mark.xfail(strict=True)` markers in `tests/unit/test_preprocessor_edge_cases.py` (they'd XPASS = CI failure once the src is fixed) and strengthened each assertion from a bare `isinstance(out, list)` to also lock in the normalized output (`type` / `len` / `chunk` / `block_type`).

## Validation
- Full suite: **2811 → 2815 passed**, 6 skipped, **9 → 5 xfailed** — the 4 edge cases now pass, no regressions.
- `ruff check` and `ruff format --check` (0.15.20) clean on the touched files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>