### PR TITLE
docs: cut defensive/marketing cruft (red-team pass)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ---
 
 TraceForge is a framework-agnostic Python library that turns the raw session logs of
-AI coding agents into a clean, strongly-typed event stream, classified, risk-scored, and
+AI coding agents into a strongly-typed event stream, classified, risk-scored, and
 governance-assessed in real time. Adding support for a new agent framework requires only a **YAML
 mapping file**: no code.
 
@@ -45,7 +45,7 @@ mapping file**: no code.
 pip install traceforge      # or: uv add traceforge
 ```
 
-Everything ships in a single install, with no extras and no GPU required. Describe a pipeline in
+Everything ships in a single install, with no extras. Describe a pipeline in
 `traceforge.yaml`:
 
 ```yaml
@@ -90,8 +90,8 @@ for the full CLI (`watch`, `replay`, `score`, `gate`, `init`, `detect`, `status`
 | | |
 | --- | --- |
 | 🧩 **Framework-agnostic** | 22 bundled YAML mappings covering Copilot, Claude Code, Cline, Aider, CrewAI, LangGraph, OpenHands, PydanticAI, smolagents, Goose, and more. |
-| 🖥️ **Runs anywhere** | Installs and runs anywhere Python does, from a laptop to CI, with no GPU or heavyweight ML stack. |
-| 🏷️ **Rich classification** | 7-dimension taxonomy, tree-sitter shell AST, MCP profiles, 0–100 risk scoring with MITRE ATT&CK mappings. |
+| 🖥️ **Runs anywhere** | Runs from a laptop to CI. CPU-only, no heavyweight ML stack. |
+| 🏷️ **Classification & risk** | 7-dimension taxonomy, tree-sitter shell AST, MCP profiles, 0–100 risk scoring with MITRE ATT&CK mappings. |
 | 🧠 **Live structure** | Phase, activity/step boundaries, and human-readable titles stamped as events arrive. |
 | 🛡️ **Governance** | Data labeling, information-flow control, drift & budget tracking, and `allow/warn/escalate/deny/transform` recommendations. |
 | 🔌 **Pluggable sinks** | JSONL, SQLite, S3, Parquet, OpenTelemetry, webhook, console, and custom callbacks, all YAML-configurable. |

--- a/website/docs/getting-started/first-run.md
+++ b/website/docs/getting-started/first-run.md
@@ -53,7 +53,7 @@ traceforge watch --frameworks claude,copilot
 
 ## 3. Or replay recorded traces
 
-To re-run the full pipeline over captured session files (great for testing and batch
+To re-run the full pipeline over captured session files (for testing and batch
 reprocessing), use `replay` with an explicit adapter mapping:
 
 ```bash

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -2,12 +2,12 @@
 id: installation
 title: Installation
 sidebar_label: Installation
-description: "Install TraceForge with pip or uv: one install, no extras, no GPU required."
+description: "Install TraceForge with pip or uv: one install, no extras."
 ---
 
 # Installation
 
-TraceForge installs anywhere Python does, with no GPU required. It runs on **Python 3.11, 3.12, and 3.13**.
+TraceForge runs on **Python 3.11, 3.12, and 3.13**.
 
 ```bash
 pip install traceforge      # or: uv add traceforge

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -60,7 +60,7 @@ Raw records flow left to right, gaining structure at every stage:
 
 - **Observation-first**: observes, enriches, and recommends by default; enforcement is strictly opt-in (a registered gate policy).
 - **Framework-agnostic**: new framework support = new YAML file.
-- **Runs anywhere**: no GPU or heavyweight ML stack; structuring runs live as events arrive.
+- **Runs anywhere**: CPU-only, no heavyweight ML stack; structuring runs live as events arrive.
 - **Defensive parsing**: malformed input is logged and skipped, never crashes.
 - **Immutable domain objects**: all events are frozen Pydantic models.
 - **Error isolation**: one failing sink cannot block others.

--- a/website/docs/reference/live-structuring.md
+++ b/website/docs/reference/live-structuring.md
@@ -2,7 +2,7 @@
 id: live-structuring
 title: Live Structuring
 sidebar_label: Live Structuring
-description: Torch-free phase, boundary, and title models that turn a flat event stream into navigable structure live, with no GPU.
+description: Torch-free phase, boundary, and title models that turn a flat event stream into navigable structure live.
 ---
 
 # Live Structuring

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -14,7 +14,7 @@ const FEATURES = [
   },
   {
     title: 'Runs anywhere',
-    body: 'Installs and runs anywhere Python does, from a laptop to CI, with no GPU or heavyweight ML stack.',
+    body: 'Runs from a laptop to CI. CPU-only, no heavyweight ML stack.',
   },
   {
     title: 'Classification & risk',


### PR DESCRIPTION
## Red-team pass: defensive/marketing cruft removed from user-facing docs

Went through every user-facing sentence — README, CONTRIBUTING, the full Docusaurus set (`website/docs/**`), the landing copy (`index.js`), and `docusaurus.config.js` — sentence by sentence. The docset was already in good shape: **none** of the `powerful` / `seamless` / `robust` / `blazing` / `elegant` / `world of AI`-class hype exists. The dominant anti-pattern was exactly the one you named — the **"no GPU required" / "installs anywhere Python does"** archetype, metastasized across 7 spots.

**10 cuts across 6 files.** Every change subtracts editorializing; **zero** technical facts, code blocks, shell commands, YAML, API signatures, or links were altered.

### The archetype — "no GPU required" (its fate)
You called out `TraceForge installs anywhere Python does, with no GPU required.` — that **exact sentence** was live at `installation.md:10`. **Killed.** Replaced with only the real fact it was smothering: `TraceForge runs on Python 3.11, 3.12, and 3.13.`

I did **not** blanket-delete the CPU/torch footprint — it's a genuine differentiator for an ML-classification tool that's deliberately torch-free. Per your rule it now survives in exactly **two plain technical spots**, never as a hero boast:
- `installation.md:39` — `:::note Lightweight runtime` → "No GPU, no `torch`, and no `transformers` at runtime…" (requirements context)
- `CONTRIBUTING.md:140` — design principle `**CPU-only**: no torch, no GPU dependencies.`

Everywhere it was a defensive boast, it's gone or reframed to the positive fact `CPU-only`.

### Category 1 — Defensive cruft (the "no GPU / installs anywhere Python does" family)
- `installation.md:10` — "TraceForge **installs anywhere Python does, with no GPU required.**" → **deleted**; kept "TraceForge runs on Python 3.11, 3.12, and 3.13."
- `installation.md:5` (frontmatter desc) — "…one install, no extras, **no GPU required**." → dropped ", no GPU required".
- `README.md:48` — "Everything ships in a single install, with no extras **and no GPU required**." → dropped "and no GPU required".
- `README.md:93` (features table) — "**Installs and runs anywhere Python does**, from a laptop to CI, with **no GPU** or heavyweight ML stack." → "Runs from a laptop to CI. CPU-only, no heavyweight ML stack."
- `index.js:17` (feature card) — same archetype → "Runs from a laptop to CI. CPU-only, no heavyweight ML stack."
- `intro.md:63` (design principle) — "**Runs anywhere**: **no GPU** or heavyweight ML stack; …" → "CPU-only, no heavyweight ML stack; …" (defensive "no GPU" → positive "CPU-only")
- `live-structuring.md:5` (frontmatter desc) — "…navigable structure live, **with no GPU**." → dropped ", with no GPU" ("Torch-free" already leads the sentence).

### Category 3 — Hollow adjectives
- `README.md:21` — "into a **clean**, strongly-typed event stream" → dropped "clean," ("strongly-typed" carries it; "clean" was unearned).
- `README.md:94` (features label) — "🏷️ **Rich classification**" → "🏷️ **Classification & risk**" (dropped hollow "Rich"; aligns with the landing card's own label — the concrete 7-dimension / AST / MITRE detail is already in the cell).

### Category 2 — Mild puffery
- `first-run.md:56` — "(**great for** testing and batch reprocessing)" → "(for testing and batch reprocessing)" (kept the real use cases, dropped "great for").

### BORDERLINE — your call (left in place)
Debatable voice calls where cutting risks losing information or is subjective:
- `CONTRIBUTING.md:3` — "Thanks for your interest in improving TraceForge!" — standard contributor courtesy, not marketing. **Rec: keep.**
- `configuration.md:11` — "**sensible** defaults apply on first use" — idiomatic and roughly factual. **Rec: keep** (cutting risks over-bleaching).
- `configuration.md:130` — "for **polished** abstractive titles" — mild puffery, but conveys *why* you'd opt into the API tier. **Rec: keep, or trim "polished".**
- `index.js:33` (feature card) — "…a separate, opt-in gate layer **you switch on when you want it**." — tail is redundant with "opt-in." **Rec: optional trim** to "…opt-in gate layer."
- `intro.md:102` — "a standalone, reusable library **with no framework lock-in**" — restates "framework-agnostic." **Rec: keep** (genuine property, closing summary).
- `reference/adapters.md:25` — "The workhorse." (for `MappedJsonAdapter`) — casual but accurate (it is the primary adapter). **Rec: keep.**

### Not touched (verified clean)
`docusaurus.config.js` (standard tagline/footer), all governance + architecture docs, and the remaining reference docs (`sources`, `adapters`, `classification`, `enrichment`, `pipeline`, `sdk`, `sinks`, `cli`) are dense, concrete, fact-first writing. Two `out of the box` usages (`index.js:13` "22 mappings ship out of the box"; `installation.md:53` "works out of the box") convey real facts (bundled / no extra install) and stay.

### Validation
- `website/`: `npm ci` ✓ then `npm run build` ✓ — **`[SUCCESS] Generated static files`**. With `onBrokenLinks: 'throw'`, this proves no edit broke a link or MDX.
- Kill-list grep across all edited docs: the only surviving `GPU` hits are the two intentional technical statements above; **zero** `installs anywhere` / `runs anywhere Python` / `seamless` / `powerful` / `blazing` / `effortless` / `world of AI`.
- Doc-only change — no `.py` touched, so no pytest/ruff needed.

Left **unmerged** for your review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>