### PR TITLE
docs: trim remaining borderline copy (red-team follow-up)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TraceForge
 
-Thanks for your interest in improving TraceForge! This guide covers local setup, the test and lint
+This guide covers local setup, the test and lint
 workflow, how to add support for a new agent framework, and our commit/PR conventions.
 
 TraceForge is a **docs-and-code** project with a strict scope discipline: by default it

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -8,7 +8,7 @@ description: traceforge.yaml, ~/.traceforge/config.yaml, TRACEFORGE_* environmen
 # Configuration
 
 TraceForge reads a hierarchical configuration from YAML files and environment variables. A
-config file is optional, sensible defaults apply on first use.
+config file is optional, defaults apply on first use.
 
 ## Loading precedence
 
@@ -127,7 +127,7 @@ governance:
 ## Session naming
 
 Sessions are named from the first substantive user message. By default this is a zero-cost,
-offline heuristic. You can opt into an LLM API (via LiteLLM) for polished abstractive titles:
+offline heuristic. You can opt into an LLM API (via LiteLLM) for abstractive titles:
 
 ```yaml
 title:

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -99,6 +99,6 @@ print(trace.risk_score, trace.suggested_action)   # e.g. 66 escalate
 - **[Governance](governance/overview.md)**: the monitor + shield assessment engine.
 - **[Reference](reference/sources.md)**: a stage-by-stage tour of every component.
 
-TraceForge is a standalone, reusable library with no framework lock-in. For the full
+TraceForge is a standalone, reusable library. For the full
 authoritative specification, see
 [`SPEC.md`](https://github.com/dfinson/traceforge/blob/main/SPEC.md).

--- a/website/docs/reference/adapters.md
+++ b/website/docs/reference/adapters.md
@@ -22,7 +22,7 @@ today:
 
 ### MappedJsonAdapter
 
-The workhorse. Construct it from a YAML mapping:
+Construct it from a YAML mapping:
 
 ```python
 adapter = MappedJsonAdapter.from_yaml("mappings/copilot.yaml", session_id="s1")

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -30,7 +30,7 @@ const FEATURES = [
   },
   {
     title: 'Observation-first',
-    body: 'Observes, enriches, and recommends by default. Enforcement is a separate, opt-in gate layer you switch on when you want it.',
+    body: 'Observes, enriches, and recommends by default. Enforcement is a separate, opt-in gate layer.',
   },
 ];
 


### PR DESCRIPTION
Follow-up to the red-team pass (#113). The owner reviewed the 6 borderline calls I surfaced (and intentionally left in place) there and asked to trim all six. This is a small, docs-only, subtractive pass — every technical fact, code block, shell command, config key, and link is preserved; no code/JSX/config-key/URL changes beyond human-readable copy strings.

## The 6 trims (before → after)

**1. Throat-clearing greeting** — `CONTRIBUTING.md:3`
- `Thanks for your interest in improving TraceForge! This guide covers local setup, the test and lint workflow…` → `This guide covers local setup, the test and lint workflow…`
- Cut the pleasantry; the guide now opens directly on substance.

**2. Hollow adjective** — `website/docs/configuration.md:11`
- `A config file is optional, sensible defaults apply on first use.` → `A config file is optional, defaults apply on first use.`
- Dropped "sensible" (unearned self-praise; "defaults apply" says it plainly).

**3. Hollow adjective** — `website/docs/configuration.md:130`
- `You can opt into an LLM API (via LiteLLM) for polished abstractive titles:` → `You can opt into an LLM API (via LiteLLM) for abstractive titles:`
- Dropped "polished" (puffery; "abstractive titles" is the concrete fact).

**4. Redundant tail** — `website/src/pages/index.js:33`
- `Enforcement is a separate, opt-in gate layer you switch on when you want it.` → `Enforcement is a separate, opt-in gate layer.`
- "opt-in" already conveys "you switch on when you want it"; the tail was restatement. Copy string only — JSX/component/props untouched.

**5. Redundant restatement** — `website/docs/intro.md:102`
- `TraceForge is a standalone, reusable library with no framework lock-in.` → `TraceForge is a standalone, reusable library.`
- "with no framework lock-in" restates "standalone, reusable library".

**6. Casual filler** — `website/docs/reference/adapters.md:25`
- `The workhorse. Construct it from a YAML mapping:` → `Construct it from a YAML mapping:`
- Removed the throwaway "The workhorse." fragment; the section now opens cleanly with no dangling text.

## Validation
- **Docusaurus build**: `npm run build` in `website/` → `[SUCCESS] Generated static files in "build"` (`onBrokenLinks: 'throw'`, so broken links/MDX would fail the build).
- **Scope**: docs/copy only. No `.py` touched → no pytest/ruff needed. 5 files changed, +6/−6.

Leaving this **unmerged** for your review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
