### PR TITLE
Make activity/step titles configurable with an opt-in LLM API tier (activity-title-config)

### DIFF
--- a/src/traceforge/config/__init__.py
+++ b/src/traceforge/config/__init__.py
@@ -21,7 +21,10 @@ from traceforge.config.models import (
     SqliteSinkConfig,
     JsonlSinkConfig,
     S3SinkConfig,
+    TitleApiConfig,
     TitleConfig,
+    ActivityTitlingConfig,
+    ActivityTitlingApiConfig,
     TraceforgeConfig,
 )
 from traceforge.config.loader import load_config, get_config, reset_config
@@ -55,9 +58,12 @@ __all__ = [
     "BudgetConfig",
     # Title
     "TitleConfig",
+    "TitleApiConfig",
     "SessionNamingConfig",
     "SessionNamingHeuristicConfig",
     "SessionNamingApiConfig",
+    "ActivityTitlingConfig",
+    "ActivityTitlingApiConfig",
     # Loading
     "load_config",
     "get_config",

--- a/src/traceforge/config/defaults.py
+++ b/src/traceforge/config/defaults.py
@@ -69,11 +69,16 @@ sdk:
   max_queue_size: 10000
 
 # ─── Titling ────────────────────────────────────────────────────────────────
-# Activity/step titles always use the packaged model. Session naming (the title
-# derived from the first substantive user message) defaults to a free, offline
-# heuristic over the user's own words. Opt into an LLM for abstractive titles by
-# setting strategy: api and providing the provider's API key in the environment
-# (e.g. export OPENAI_API_KEY=...). No key => it silently stays on the heuristic.
+# Two title surfaces, each with a free/offline floor and an opt-in LLM API tier
+# that engages only when the provider's API key is present in the environment
+# (e.g. export OPENAI_API_KEY=...). No key => it silently stays on the offline
+# floor. The floor is emitted immediately; the API upgrade (when configured and
+# keyed) is applied later, off the hot path, so live emission is never blocked.
+#
+#   * session_naming  — the title from the first substantive user message; floor
+#                       is a free heuristic over the user's own words.
+#   * activity_titling — the activity/step (span) titles; floor is the packaged,
+#                       offline ONNX model shipped with every install.
 #
 # title:
 #   session_naming:
@@ -89,6 +94,14 @@ sdk:
 #       api_key_env: null     # override which env var holds the key
 #       timeout: 10
 #       max_tokens: 24
+#   activity_titling:
+#     strategy: model         # model | api  (model = packaged offline ONNX titler)
+#     api:
+#       model: gpt-4o-mini    # any LiteLLM model string (as above)
+#       api_base: null        # for azure / ollama / vllm / openai-compatible
+#       api_key_env: null     # override which env var holds the key
+#       timeout: 10
+#       max_tokens: 256       # one call returns the activity + all step titles
 
 # ─── Additional mapping directories ────────────────────────────────────────
 mappings_dirs:

--- a/src/traceforge/config/models.py
+++ b/src/traceforge/config/models.py
@@ -344,15 +344,16 @@ class SessionNamingHeuristicConfig(StrictModel):
     max_chars: int = Field(default=60, ge=8)
 
 
-class SessionNamingApiConfig(StrictModel):
-    """Opt-in LLM API tier for session naming, served via LiteLLM.
+class TitleApiConfig(StrictModel):
+    """Shared opt-in LiteLLM API-tier settings for title generation.
 
-    The API key is **never** stored here. LiteLLM reads it from the provider's
-    conventional environment variable (``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``,
-    ``AZURE_API_KEY`` …). Set ``api_key_env`` only to name a *different* env var
-    to read from. ``model`` is any LiteLLM model string, so OpenAI, Azure,
-    Anthropic, Gemini, and local runtimes (``ollama/…``, ``vllm/…`` via
-    ``api_base``) are all reachable through one code path.
+    Both session naming and activity/step titling reach any LLM provider through
+    this one typed surface. The API key is **never** stored here. LiteLLM reads it
+    from the provider's conventional environment variable (``OPENAI_API_KEY``,
+    ``ANTHROPIC_API_KEY``, ``AZURE_API_KEY`` …). Set ``api_key_env`` only to name
+    a *different* env var to read from. ``model`` is any LiteLLM model string, so
+    OpenAI, Azure, Anthropic, Gemini, and local runtimes (``ollama/…``, ``vllm/…``
+    via ``api_base``) are all reachable through one code path.
     """
 
     model: str = "gpt-4o-mini"
@@ -360,6 +361,14 @@ class SessionNamingApiConfig(StrictModel):
     api_key_env: str | None = None
     timeout: float = Field(default=10.0, gt=0)
     max_tokens: int = Field(default=24, ge=1)
+
+
+class SessionNamingApiConfig(TitleApiConfig):
+    """Opt-in LLM API tier for session naming, served via LiteLLM.
+
+    Inherits the shared :class:`TitleApiConfig` surface unchanged: session titles
+    are short, so the base ``max_tokens`` default is sufficient.
+    """
 
 
 class SessionNamingConfig(StrictModel):
@@ -391,16 +400,68 @@ class SessionNamingConfig(StrictModel):
     api: SessionNamingApiConfig = Field(default_factory=SessionNamingApiConfig)
 
 
+class ActivityTitlingApiConfig(TitleApiConfig):
+    """Opt-in LLM API tier for activity/step (span) titling, served via LiteLLM.
+
+    One call per closed activity returns the activity title **and** all of its
+    step titles together (as JSON), so the default ``max_tokens`` is larger than
+    session naming's to fit a multi-title response.
+    """
+
+    max_tokens: int = Field(default=256, ge=1)
+
+
+class ActivityTitlingConfig(StrictModel):
+    """How activity/step (span) titles are generated for a closed activity.
+
+        # traceforge.yaml
+        title:
+          activity_titling:
+            strategy: model            # model | api  (DEFAULT: model)
+            api:
+              model: gpt-4o-mini       # any LiteLLM model string
+              api_base: null           # azure / ollama / vllm / openai-compatible
+              api_key_env: null        # override env var name (else LiteLLM default)
+              timeout: 10
+              max_tokens: 256
+
+    ``model`` (default) titles each closed activity and its steps with the
+    packaged, offline ONNX ``traceforge-title-model`` — free, no key, no network,
+    byte-for-byte the shipped behavior. ``api`` engages LiteLLM to *refine* those
+    titles and takes effect **only** when the provider's API key is present in the
+    environment; otherwise it silently keeps the packaged-model titles, so a
+    missing key never errors or blocks.
+
+    The packaged title is always emitted the instant an activity closes; when the
+    API tier is configured and keyed the abstractive upgrade arrives **later** as
+    an append-only title update, computed off the hot path so live event emission
+    is never delayed by the network.
+    """
+
+    strategy: Literal["model", "api"] = "model"
+    api: ActivityTitlingApiConfig = Field(default_factory=ActivityTitlingApiConfig)
+
+
 class TitleConfig(StrictModel):
     """Titling configuration.
 
-    Activity/step (span) titles always use the packaged ``traceforge-title-model``
-    (the seq-KD flan-t5-small, proven strong at that task and shipped with every
-    install). Only *session naming* is configurable, because the tiny model was
-    proven weak at it; see :class:`SessionNamingConfig`.
+    Two title surfaces, each a free/offline floor with an opt-in LiteLLM API tier
+    that engages only when a provider key is present in the environment:
+
+    * ``session_naming`` — the session title derived from the first substantive
+      user message. Floor: a zero-cost extractive heuristic over the user's own
+      words; see :class:`SessionNamingConfig`.
+    * ``activity_titling`` — the activity/step (span) titles. Floor: the packaged,
+      offline ONNX ``traceforge-title-model`` (proven strong at that task and
+      shipped with every install); see :class:`ActivityTitlingConfig`.
+
+    In both cases the offline floor is emitted immediately and the API upgrade
+    (when configured and keyed) is applied later, off the hot path, as an
+    append-only title update — never blocking live event emission.
     """
 
     session_naming: SessionNamingConfig = Field(default_factory=SessionNamingConfig)
+    activity_titling: ActivityTitlingConfig = Field(default_factory=ActivityTitlingConfig)
 
 
 # ─── Root Config ─────────────────────────────────────────────────────────────

--- a/src/traceforge/pipeline.py
+++ b/src/traceforge/pipeline.py
@@ -361,6 +361,12 @@ class EventPipeline:
                     updates = []
                 for update in updates:
                     await self._push_title_update(update)
+                # NOTE: eviction does not schedule API refinement for the trailing
+                # activity. It already cancelled this session's in-flight
+                # refinements above; finalizing with packaged titles only keeps a
+                # clean contract (evicted sessions get no API upgrades) and leaves
+                # no API task running after the stream is gone. Normally-completing
+                # sessions refine their trailing activity in _flush_title_streams.
         self._boundary_streams.pop(session_id, None)
 
     async def _push_locked(self, event: SessionEvent) -> None:
@@ -499,6 +505,13 @@ class EventPipeline:
         if refine_text is not None:
             self._schedule_session_refine(event.session_id, refine_text)
 
+        # Likewise upgrade the just-closed activity's packaged titles off the hot
+        # path when an activity API tier is configured: the stream queued each
+        # closed activity (with its distilled context) for an abstractive upgrade.
+        # By default (strategy=model) nothing is queued, so this is a no-op.
+        for closed in stream.take_activity_refinements():
+            self._schedule_activity_refine(event.session_id, closed)
+
     def _schedule_session_refine(self, session_id: str, text: str) -> None:
         """Refine a session title via the API off the hot path (fire-and-forget).
 
@@ -561,6 +574,50 @@ class EventPipeline:
                 title=refined,
             )
         )
+
+    def _schedule_activity_refine(self, session_id: str, closed) -> None:
+        """Refine a closed activity's titles via the API off the hot path.
+
+        Mirrors :meth:`_schedule_session_refine`: spawns a tracked background task
+        indexed in the *same* ``_refine_tasks`` bucket, so eviction cancels it
+        (:meth:`_cancel_session_refinements`) and :meth:`flush` awaits it before
+        teardown. Live event emission is never blocked on the network.
+        """
+        task = asyncio.create_task(self._activity_refine(session_id, closed))
+        self._refine_tasks.setdefault(session_id, set()).add(task)
+        task.add_done_callback(lambda t: self._discard_refine_task(session_id, t))
+
+    async def _activity_refine(self, session_id: str, closed) -> None:
+        """Compute API activity/step titles in a worker thread and emit upgrades.
+
+        Runs off the hot path. Each returned
+        :class:`~traceforge.title.inferencer.TitleRefinement` becomes a later
+        append-only :class:`~traceforge.types.TitleUpdate` on the *same* segment
+        id, upgrading the packaged-model title. On empty output (unconfigured
+        refiner, no extractable signal, timeout, or any provider error) the
+        packaged titles already emitted stand and nothing further is published.
+        Error-isolated so a failing refinement never propagates into the loop.
+        """
+        try:
+            refinements = await asyncio.to_thread(self._title_inferencer.refine_activity, closed)
+        except Exception as exc:
+            logger.error(
+                "Activity-title API refinement failed for session %s: %s — keeping packaged titles",
+                session_id,
+                exc,
+                exc_info=True,
+            )
+            return
+        for ref in refinements:
+            await self._push_title_update(
+                TitleUpdate(
+                    session_id=session_id,
+                    segment_id=ref.segment_id,
+                    kind=ref.kind,
+                    title=ref.title,
+                    parent_id=ref.parent_id,
+                )
+            )
 
     def _boundary_stamp(self, event: SessionEvent) -> SessionEvent:
         """Run one event through its session's live boundary stream."""
@@ -629,6 +686,10 @@ class EventPipeline:
                 updates = []
             for update in updates:
                 await self._push_title_update(update)
+            # Upgrade the trailing activity's packaged titles off the hot path
+            # when configured; flush() below awaits these before closing sinks.
+            for closed in stream.take_activity_refinements():
+                self._schedule_activity_refine(session_id, closed)
 
     async def _fanout(
         self,

--- a/src/traceforge/title/inferencer.py
+++ b/src/traceforge/title/inferencer.py
@@ -24,6 +24,18 @@ The model is loaded lazily on first close and runs CPU-only with a capped thread
 count, so an inactive session costs nothing and an active one runs the heavy
 model once per *segment*, never per event.
 
+Activity/step titles default to that packaged model alone, but are also
+configurable (mirroring session naming): when ``title.activity_titling.strategy``
+is ``api`` *and* a provider key is present, each closed activity's packaged
+titles are additionally queued for an **off-hot-path** LiteLLM refinement
+(:meth:`TitleInferencer.refine_activity`, backed by
+:mod:`traceforge.title.naming`). The pipeline upgrades the activity title and all
+its step titles in one call in a worker thread and emits them as later
+append-only :class:`~traceforge.types.TitleUpdate` records on the *same* segment
+ids. Absent a key, or on any API failure/timeout, the packaged titles stand, so
+the default (``strategy=model``) path is byte-for-byte unchanged and never blocks
+live emission.
+
 The same machinery also titles the **session** itself: fed the first substantive
 user message (:meth:`TitleInferencer.request_title`), it emits a ``kind="session"``
 :class:`~traceforge.types.TitleUpdate` keyed by the session id -- the session label,
@@ -35,6 +47,8 @@ opt-in LiteLLM API tier engaged only when a key is configured.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
 
 from traceforge.phase.event_rows import event_to_feature_row
 from traceforge.types import EventKind, SessionEvent, TitleUpdate
@@ -57,7 +71,12 @@ class TitleInferencer:
     """
 
     def __init__(
-        self, model=None, model_dir=None, session_titler=None, session_refiner=None
+        self,
+        model=None,
+        model_dir=None,
+        session_titler=None,
+        session_refiner=None,
+        activity_refiner=None,
     ) -> None:
         self._model = model
         self._model_dir = model_dir
@@ -70,6 +89,13 @@ class TitleInferencer:
         self._titler_built = False
         self._session_heuristic = None
         self._session_refiner = None
+        # Optional off-hot-path activity/step-title API refiner. ``None`` (the
+        # default) means the packaged ONNX titles are final. Injected directly in
+        # tests; otherwise built lazily from ``title.activity_titling`` on first
+        # use, so a pipeline that never refines a span pays nothing.
+        self._activity_refiner_override = activity_refiner
+        self._activity_titler_built = False
+        self._activity_refiner = None
 
     @property
     def model(self):
@@ -135,6 +161,71 @@ class TitleInferencer:
             return ""
         return self._session_refiner(text)
 
+    def _ensure_activity_titler(self) -> None:
+        if self._activity_titler_built:
+            return
+        if self._activity_refiner_override is not None:
+            self._activity_refiner = self._activity_refiner_override
+        else:
+            from .naming import build_activity_refiner
+
+            self._activity_refiner = build_activity_refiner()
+        self._activity_titler_built = True
+
+    @property
+    def has_activity_refiner(self) -> bool:
+        """Whether an off-hot-path API activity/step-title refiner is configured."""
+        self._ensure_activity_titler()
+        return self._activity_refiner is not None
+
+    def refine_activity(self, closed: "_ClosedActivity") -> list["TitleRefinement"]:
+        """Abstractive activity/step-title upgrades for the opt-in API tier.
+
+        Distils the just-closed activity and each of its steps, asks the
+        configured API refiner for better titles in **one** call, and returns a
+        per-segment :class:`TitleRefinement` for the activity and every step the
+        API usefully covered. Returns ``[]`` when no refiner is configured or the
+        API returns nothing usable (missing key, provider error, timeout, or an
+        unparseable reply), so the packaged-model titles already emitted stand.
+
+        This blocks on the network and MUST run off the hot path (the pipeline
+        runs it in a worker thread and emits each result as a later
+        ``TitleUpdate`` on the same segment id). Step titles are kept distinct
+        from the (effective) activity title and one another via
+        :func:`traceforge.title.hygiene.norm_key`; any API step title that
+        collides is dropped so that step keeps its distinct packaged-model title.
+        """
+        self._ensure_activity_titler()
+        if self._activity_refiner is None:
+            return []
+        from .naming import ActivitySpan
+
+        step_contexts = [distilled_context(rows) for _sid, rows in closed.steps]
+        activity_rows = [r for _sid, rows in closed.steps for r in rows]
+        activity_context = distilled_context(activity_rows)
+        # Nothing extractable anywhere -> no useful API call (parity with the
+        # packaged path, which emits no updates for a signal-less span).
+        if activity_context == "(no signal)" and all(c == "(no signal)" for c in step_contexts):
+            return []
+        titles = self._activity_refiner(ActivitySpan(activity_context, step_contexts))
+
+        refinements: list["TitleRefinement"] = []
+        used: set = set()
+        if titles.activity:
+            refinements.append(TitleRefinement(closed.activity_id, "activity", titles.activity))
+        effective_activity = titles.activity or closed.activity_title
+        if effective_activity:
+            used.add(norm_key(effective_activity))
+        for (step_id, _rows), step_title in zip(closed.steps, titles.steps):
+            if not step_title:
+                continue
+            key = norm_key(step_title)
+            if not key or key in used:
+                continue  # collides with the activity/a sibling -> keep packaged title
+            used.add(key)
+            refinements.append(TitleRefinement(step_id, "step", step_title, closed.activity_id))
+        return refinements
+
     def _title(self, rows: list[dict]) -> str:
         ctx = distilled_context(rows)
         if ctx == "(no signal)":
@@ -151,6 +242,37 @@ class TitleInferencer:
         """Open a live per-session titling stream."""
 
         return SessionTitleStream(self, session_id, source)
+
+
+@dataclass(frozen=True)
+class TitleRefinement:
+    """One off-hot-path title upgrade for a closed activity or one of its steps.
+
+    Produced by :meth:`TitleInferencer.refine_activity` and turned into a later
+    append-only :class:`~traceforge.types.TitleUpdate` (same ``segment_id`` /
+    ``kind``) by the pipeline, superseding the packaged-model title.
+    """
+
+    segment_id: str
+    kind: str  # "activity" | "step"
+    title: str
+    parent_id: str | None = None
+
+
+@dataclass
+class _ClosedActivity:
+    """A just-closed activity queued for off-hot-path API title refinement.
+
+    Carries the segment ids and the raw feature rows (already built on the hot
+    path) so the worker thread can distil + call the API without touching the
+    live stream. ``activity_title`` is the packaged-model activity title (or
+    ``None``); it only seeds step-title distinctness when the API leaves the
+    activity title unchanged.
+    """
+
+    activity_id: str
+    activity_title: str | None
+    steps: list[tuple[str, list[dict]]] = field(default_factory=list)  # (step_id, rows), in order
 
 
 class _Step:
@@ -187,6 +309,12 @@ class SessionTitleStream:
         # pipeline pops it via :meth:`take_session_refinement` and refines in a
         # worker thread, so the network never blocks live emission.
         self._pending_refine_text: str | None = None
+        # Closed activities queued for off-hot-path API activity/step-title
+        # refinement, appended by :meth:`_close_activity` when an activity refiner
+        # is configured. The pipeline pops them via
+        # :meth:`take_activity_refinements` and refines each in a worker thread,
+        # emitting the upgraded titles as later append-only ``TitleUpdate``s.
+        self._pending_activity_refinements: list[_ClosedActivity] = []
 
     def push(self, event: SessionEvent) -> tuple[SessionEvent, list[TitleUpdate]]:
         """Ingest one event; stamp its segment ids and emit it now, returning
@@ -268,7 +396,17 @@ class SessionTitleStream:
         return self._close_activity()
 
     def _close_activity(self) -> list[TitleUpdate]:
-        """Title the just-closed activity + its steps as append-only updates."""
+        """Title the just-closed activity + its steps as append-only updates.
+
+        The packaged-model titles are computed and returned immediately (the
+        pipeline emits them the instant the activity closes). When an API
+        activity refiner is configured *and* this activity produced at least one
+        packaged title, the closed activity (ids + raw rows) is also queued for
+        off-hot-path API refinement via :meth:`take_activity_refinements`; the
+        pipeline upgrades the titles in a worker thread and emits them as later
+        append-only updates. Queueing is skipped entirely by default
+        (``strategy=model``), so the packaged path is unchanged.
+        """
 
         steps = self._steps
         activity_id = self._activity_id
@@ -303,7 +441,30 @@ class SessionTitleStream:
                         parent_id=activity_id,
                     )
                 )
+
+        # Queue this activity for an off-hot-path API upgrade only when a refiner
+        # is configured and there is at least one packaged title to upgrade.
+        if updates and self._inf.has_activity_refiner:
+            self._pending_activity_refinements.append(
+                _ClosedActivity(
+                    activity_id=activity_id,
+                    activity_title=activity_title,
+                    steps=[(s.step_id, s.rows) for s in steps],
+                )
+            )
         return updates
+
+    def take_activity_refinements(self) -> list["_ClosedActivity"]:
+        """Pop the closed activities queued for off-hot-path API refinement.
+
+        Returns them once (then empties the queue). The pipeline calls this right
+        after :meth:`push` / :meth:`flush` and, for each returned activity,
+        refines its titles in a worker thread (:meth:`TitleInferencer.refine_activity`)
+        and emits the upgrades as later append-only :class:`TitleUpdate`s.
+        """
+        out = self._pending_activity_refinements
+        self._pending_activity_refinements = []
+        return out
 
     @staticmethod
     def _stamp(event: SessionEvent, activity_id: str | None, step_id: str | None) -> SessionEvent:
@@ -313,4 +474,4 @@ class SessionTitleStream:
         return event.model_copy(update={"metadata": new_md})
 
 
-__all__ = ["TitleInferencer", "SessionTitleStream"]
+__all__ = ["TitleInferencer", "SessionTitleStream", "TitleRefinement"]

--- a/src/traceforge/title/naming.py
+++ b/src/traceforge/title/naming.py
@@ -1,17 +1,25 @@
-"""Session-title providers: heuristic floor + opt-in LiteLLM API tier.
+"""Title providers: offline floor + opt-in LiteLLM API tier (session and span).
 
-:func:`build_session_titler` reads :class:`~traceforge.config.SessionNamingConfig`
-and returns a plain ``Callable[[str], str]`` -- the session titler used by
-:meth:`traceforge.title.TitleInferencer.request_title`.
+This module owns the LiteLLM plumbing, the opt-in key-presence gate, and the
+graceful-fallback contract shared by both configurable title surfaces:
 
-Resolution:
+* **Session naming.** :func:`build_session_titler_split` reads
+  :class:`~traceforge.config.SessionNamingConfig` and returns a
+  :class:`SessionTitler` (an immediate :class:`HeuristicProvider` floor + an
+  optional :class:`ApiProvider` refiner). The heuristic is a free, offline
+  extractive title over the user's own words; the API tier engages only when a
+  key is present.
+* **Activity/step titling.** :func:`build_activity_refiner` reads
+  :class:`~traceforge.config.ActivityTitlingConfig` and returns an optional
+  :class:`ActivityApiProvider` refiner. Here the offline floor is the *packaged
+  ONNX span model* (owned by :mod:`traceforge.title.inferencer`, emitted the
+  instant an activity closes); the refiner, when configured and keyed, upgrades
+  the activity title and all its step titles in one call, off the hot path.
 
-* ``strategy: heuristic`` (default) -> :class:`HeuristicProvider`, a free, offline
-  extractive title over the user's own words (see :mod:`traceforge.title.heuristics`).
-* ``strategy: api`` -> :class:`ApiProvider` (LiteLLM), **but only if the provider's
-  API key is present in the environment**. When the key is absent -- or any API
-  call fails or times out -- the titler transparently falls back to the heuristic,
-  so a missing key or a flaky network never errors, blocks, or empties a title.
+In both cases the API tier is **strictly opt-in and never load-bearing**: absent
+a key -- or on any API call that fails, times out, or returns nothing usable --
+the offline floor stands, so a missing key or a flaky network never errors,
+blocks, or empties a title.
 
 The API key is never read from config: LiteLLM sources it from the provider's
 conventional env var; ``api.api_key_env`` only overrides *which* var to read.
@@ -19,6 +27,7 @@ conventional env var; ``api.api_key_env`` only overrides *which* var to read.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -29,9 +38,12 @@ from .heuristics import heuristic_title
 
 if TYPE_CHECKING:
     from traceforge.config.models import (
+        ActivityTitlingApiConfig,
+        ActivityTitlingConfig,
         SessionNamingApiConfig,
         SessionNamingConfig,
         SessionNamingHeuristicConfig,
+        TitleApiConfig,
     )
 
 logger = logging.getLogger(__name__)
@@ -118,12 +130,14 @@ class _WithFallback:
     __call__ = title
 
 
-def _api_key_present(cfg: "SessionNamingApiConfig") -> bool:
+def _api_key_present(cfg: "TitleApiConfig") -> bool:
     """True iff the API tier can authenticate right now (opt-in gate).
 
-    Honors an explicit ``api_key_env`` override; otherwise defers to LiteLLM's
+    Shared by both title surfaces (session naming and activity/step titling),
+    since both ``api`` sub-configs derive from :class:`TitleApiConfig`. Honors an
+    explicit ``api_key_env`` override; otherwise defers to LiteLLM's
     provider-aware environment validation so any provider's conventional key var
-    counts. Absent LiteLLM or on any error, reports not-present (-> heuristic).
+    counts. Absent LiteLLM or on any error, reports not-present (-> offline floor).
     """
     if cfg.api_base and not cfg.api_key_env:
         # Local/self-hosted runtimes (ollama/vllm) often need no key.
@@ -202,10 +216,183 @@ def build_session_titler_split(
     return SessionTitler(heuristic, None)
 
 
+# ─── Activity/step (span) title refinement ───────────────────────────────────
+
+#: Terse, instruction-tight span prompt. The model sees each segment's distilled
+#: context and must return ONLY a JSON object titling the activity and its steps.
+_SPAN_SYSTEM = (
+    "You title one activity in a developer's coding session and each of its "
+    "numbered steps, from their distilled contexts. Reply with ONLY a JSON "
+    'object of the form {{"activity": "<title>", "steps": ["<step 1>", '
+    '"<step 2>", ...]}} -- exactly one step title per numbered step, in order. '
+    "Each title is a short, specific phrase in imperative or gerund mood, at most "
+    "{max_words} words, no trailing punctuation, no quotes. Keep every step title "
+    "distinct from the activity title and from the other step titles."
+)
+
+
+@dataclass(frozen=True)
+class ActivitySpan:
+    """The distilled context of a closed activity and its steps, fed to the API.
+
+    ``activity_context`` is the distilled context over the whole activity;
+    ``step_contexts`` holds one distilled context per step, in order. Both are
+    produced by :func:`traceforge.title.context.distilled_context`, so the API
+    tier sees the same source-agnostic slots the packaged model was trained on.
+    """
+
+    activity_context: str
+    step_contexts: list[str]
+
+
+@dataclass(frozen=True)
+class ActivityTitles:
+    """The API's proposed titles for an :class:`ActivitySpan`.
+
+    ``activity`` is the refined activity title (``None`` when the API declined or
+    failed); ``steps`` is aligned index-for-index with the span's ``step_contexts``
+    -- ``None`` in any slot the API did not usefully cover, so the caller keeps
+    that segment's packaged-model title.
+    """
+
+    activity: str | None
+    steps: list[str | None]
+
+
+def _empty_titles(n_steps: int) -> ActivityTitles:
+    return ActivityTitles(None, [None] * n_steps)
+
+
+def _loads_json_object(raw: str):
+    """Best-effort parse of a JSON object from a model reply.
+
+    Tolerates a model that wraps the object in prose or code fences by falling
+    back to the outermost ``{...}`` slice. Returns the parsed object or ``None``.
+    """
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        pass
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start != -1 and end > start:
+        try:
+            return json.loads(raw[start : end + 1])
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+class ActivityApiProvider:
+    """Abstractive activity/step titles via LiteLLM (any provider + local runtimes).
+
+    One :meth:`refine` call per closed activity returns the activity title and all
+    of its step titles together, so the model sees the full activity context and
+    can keep step titles distinct. Returns :class:`ActivityTitles` with ``None``
+    slots on any failure (missing key, provider/network error, timeout, or an
+    unparseable reply) so the caller falls back to the packaged-model titles.
+    """
+
+    def __init__(self, cfg: "ActivityTitlingApiConfig", max_words: int = 8) -> None:
+        self._cfg = cfg
+        self._max_words = max_words
+
+    @staticmethod
+    def _render(span: ActivitySpan) -> str:
+        lines = [f"activity: {span.activity_context}"]
+        for i, ctx in enumerate(span.step_contexts, start=1):
+            lines.append(f"step {i}: {ctx}")
+        return "\n".join(lines)
+
+    def refine(self, span: ActivitySpan) -> ActivityTitles:
+        n = len(span.step_contexts)
+        try:
+            import litellm
+        except ImportError:  # pragma: no cover - litellm ships as a base dep
+            logger.debug("litellm unavailable; activity-titling API tier disabled")
+            return _empty_titles(n)
+        cfg = self._cfg
+        system = _SPAN_SYSTEM.format(max_words=self._max_words)
+        kwargs: dict = {
+            "model": cfg.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": self._render(span)},
+            ],
+            "max_tokens": cfg.max_tokens,
+            "timeout": cfg.timeout,
+            "temperature": 0.0,
+        }
+        if cfg.api_base:
+            kwargs["api_base"] = cfg.api_base
+        if cfg.api_key_env:
+            key = os.environ.get(cfg.api_key_env)
+            if not key:
+                return _empty_titles(n)
+            kwargs["api_key"] = key
+        try:
+            resp = litellm.completion(**kwargs)
+            raw = (resp.choices[0].message.content or "").strip()
+        except Exception as exc:  # noqa: BLE001 - any provider/network error -> fallback
+            logger.warning("activity-titling API call failed (%s); using packaged model", exc)
+            return _empty_titles(n)
+        return self._parse(raw, n)
+
+    @staticmethod
+    def _parse(raw: str, n_steps: int) -> ActivityTitles:
+        data = _loads_json_object(raw)
+        if not isinstance(data, dict):
+            return _empty_titles(n_steps)
+        act = data.get("activity")
+        activity = clean_title(act) if isinstance(act, str) and act.strip() else None
+        steps: list[str | None] = [None] * n_steps
+        raw_steps = data.get("steps")
+        if isinstance(raw_steps, list):
+            for i in range(min(n_steps, len(raw_steps))):
+                s = raw_steps[i]
+                if isinstance(s, str) and s.strip():
+                    cleaned = clean_title(s)
+                    steps[i] = cleaned or None
+        return ActivityTitles(activity or None, steps)
+
+    __call__ = refine
+
+
+def build_activity_refiner(
+    cfg: "ActivityTitlingConfig | None" = None,
+) -> "ActivityApiProvider | None":
+    """Build the optional off-hot-path activity/step title refiner.
+
+    Returns an :class:`ActivityApiProvider` only when ``strategy=api`` *and* a
+    usable API key is present in the environment; otherwise ``None``, in which
+    case the packaged ONNX titles (emitted the instant an activity closes) are
+    final. Mirrors :func:`build_session_titler_split`'s ``api_refiner`` gate --
+    the packaged model itself is the always-present floor, owned by the inferencer.
+    """
+    if cfg is None:
+        from traceforge.config import get_config
+
+        cfg = get_config().title.activity_titling
+
+    if cfg.strategy == "api" and _api_key_present(cfg.api):
+        return ActivityApiProvider(cfg.api)
+    if cfg.strategy == "api":
+        logger.info(
+            "title.activity_titling.strategy=api but no API key for model %r found in "
+            "the environment; using the packaged ONNX titler.",
+            cfg.api.model,
+        )
+    return None
+
+
 __all__ = [
     "HeuristicProvider",
     "ApiProvider",
     "SessionTitler",
+    "ActivitySpan",
+    "ActivityTitles",
+    "ActivityApiProvider",
     "build_session_titler",
     "build_session_titler_split",
+    "build_activity_refiner",
 ]

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -462,6 +462,253 @@ class TestPipelineSessionEviction:
         assert [u.title for u in sess] == ["Heuristic title", "Refined API title"]
 
 
+class TestPipelineActivityTitleRefinement:
+    """The opt-in activity/step-title API tier upgrades the packaged titles.
+
+    Mirrors the session-title refinement tests: the packaged ONNX titles are
+    emitted the instant an activity closes (the default, never blocking), and
+    when an activity refiner is configured each closed activity is refined off
+    the hot path and its upgraded titles arrive as later append-only
+    TitleUpdate records on the same segment ids.
+    """
+
+    @staticmethod
+    def _activity_refiner(activity="API Activity", steps_prefix="API Step"):
+        from traceforge.title.naming import ActivityTitles
+
+        def refine(span):
+            steps = [f"{steps_prefix} {i}" for i in range(len(span.step_contexts))]
+            return ActivityTitles(activity, steps)
+
+        return refine
+
+    async def test_default_model_strategy_makes_no_api_call(self, monkeypatch):
+        # strategy=model (the default): no refiner is wired, so a closed activity
+        # emits only its packaged titles and the API is never touched. Patch
+        # litellm.completion to explode so any accidental call fails loudly.
+        import litellm
+
+        from tests.unit.test_title_inferencer import _FakeTitle, _event
+
+        from traceforge.title import TitleInferencer
+
+        def _boom(**_kw):  # pragma: no cover - must never run on the default path
+            raise AssertionError("the default strategy must not call the API")
+
+        monkeypatch.setattr(litellm, "completion", _boom)
+
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enable_phase=False,
+            enable_boundary=False,
+            title_inferencer=TitleInferencer(model=_FakeTitle()),
+        )
+        await pipeline.push(_event(0, tool="edit"))
+        await pipeline.push(_event(1, tool="shell", boundary="step-boundary"))
+        await pipeline.push(_event(2, tool="grep", boundary="activity-boundary"))
+        await pipeline.flush()
+
+        # Exactly the packaged titles, one update per segment (no later upgrade).
+        acts = [u for u in recorder.title_updates if u.kind == "activity" and u.segment_id == "e0"]
+        assert [u.title for u in acts] == ["Title 0"]
+        steps = [u for u in recorder.title_updates if u.kind == "step" and u.segment_id == "e0"]
+        assert [u.title for u in steps] == ["Title 1"]
+
+    async def test_no_key_falls_back_to_packaged(self, monkeypatch):
+        # strategy=api but no key present -> build_activity_refiner returns None,
+        # so the inferencer wires no refiner and the packaged titles stand.
+        from tests.unit.test_title_inferencer import _FakeTitle, _event
+
+        from traceforge.config.models import ActivityTitlingApiConfig, ActivityTitlingConfig
+        from traceforge.title import TitleInferencer
+        from traceforge.title.naming import build_activity_refiner
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        cfg = ActivityTitlingConfig(
+            strategy="api", api=ActivityTitlingApiConfig(api_key_env="OPENAI_API_KEY")
+        )
+        refiner = build_activity_refiner(cfg)
+        assert refiner is None  # the opt-in gate declined
+
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enable_phase=False,
+            enable_boundary=False,
+            title_inferencer=TitleInferencer(model=_FakeTitle(), activity_refiner=refiner),
+        )
+        await pipeline.push(_event(0, tool="edit"))
+        await pipeline.push(_event(1, boundary="activity-boundary"))
+        await pipeline.flush()
+        acts = [u for u in recorder.title_updates if u.kind == "activity" and u.segment_id == "e0"]
+        assert [u.title for u in acts] == ["Title 0"]  # packaged only
+
+    async def test_api_refines_activity_and_steps_off_hot_path(self):
+        # With a refiner configured the packaged titles are emitted immediately;
+        # the API upgrades for the activity and each step arrive later (same
+        # segment ids), awaited at flush.
+        from tests.unit.test_title_inferencer import _FakeTitle, _event
+
+        from traceforge.title import TitleInferencer
+
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enable_phase=False,
+            enable_boundary=False,
+            title_inferencer=TitleInferencer(
+                model=_FakeTitle(), activity_refiner=self._activity_refiner()
+            ),
+        )
+        await pipeline.push(_event(0, tool="edit"))
+        await pipeline.push(_event(1, tool="shell", boundary="step-boundary"))
+        await pipeline.push(_event(2, tool="grep", boundary="activity-boundary"))
+
+        # The packaged activity title emitted immediately; no API upgrade yet.
+        acts = [u for u in recorder.title_updates if u.kind == "activity" and u.segment_id == "e0"]
+        assert [u.title for u in acts] == ["Title 0"]
+
+        await pipeline.flush()
+        # Flush awaited the background refinement: each segment now has a second,
+        # API update superseding its packaged title.
+        acts = [u for u in recorder.title_updates if u.kind == "activity" and u.segment_id == "e0"]
+        assert [u.title for u in acts] == ["Title 0", "API Activity"]
+        s0 = [u for u in recorder.title_updates if u.kind == "step" and u.segment_id == "e0"]
+        s1 = [u for u in recorder.title_updates if u.kind == "step" and u.segment_id == "e1"]
+        assert [u.title for u in s0] == ["Title 1", "API Step 0"]
+        assert [u.title for u in s1] == ["Title 2", "API Step 1"]
+        # The API step updates stay parented to the activity.
+        assert s0[-1].parent_id == "e0" and s1[-1].parent_id == "e0"
+
+    async def test_api_failure_keeps_packaged_titles(self):
+        # A refiner that raises (provider/network error) must not error or block:
+        # the packaged titles already emitted stand and no upgrade is published.
+        from tests.unit.test_title_inferencer import _FakeTitle, _event
+
+        from traceforge.title import TitleInferencer
+
+        def boom(span):
+            raise RuntimeError("network down")
+
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enable_phase=False,
+            enable_boundary=False,
+            title_inferencer=TitleInferencer(model=_FakeTitle(), activity_refiner=boom),
+        )
+        await pipeline.push(_event(0, tool="edit"))
+        await pipeline.push(_event(1, boundary="activity-boundary"))
+        await pipeline.flush()  # must not raise
+        acts = [u for u in recorder.title_updates if u.kind == "activity" and u.segment_id == "e0"]
+        assert [u.title for u in acts] == ["Title 0"]  # packaged only, no upgrade
+
+    async def test_refinement_does_not_block_later_events(self):
+        # A slow activity refinement must not delay subsequent live events: while
+        # the refiner blocks in its worker thread, further events keep streaming.
+        import threading
+
+        from tests.unit.test_title_inferencer import _FakeTitle, _event
+
+        from traceforge.title import TitleInferencer
+        from traceforge.title.naming import ActivityTitles
+
+        release = threading.Event()
+
+        def refine(span):
+            release.wait(timeout=5)  # block until the test lets it finish
+            return ActivityTitles("API Activity", ["API Step 0"])
+
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enable_phase=False,
+            enable_boundary=False,
+            title_inferencer=TitleInferencer(model=_FakeTitle(), activity_refiner=refine),
+        )
+        await pipeline.push(_event(0, tool="edit"))
+        await pipeline.push(
+            _event(1, boundary="activity-boundary")
+        )  # closes e0 -> schedules refine
+        # The refinement is now blocked in a worker thread; following events
+        # still emit immediately without waiting for it.
+        await pipeline.push(_event(2, tool="edit"))
+        assert [e.id for e in recorder.events] == ["e0", "e1", "e2"]
+        acts = [u for u in recorder.title_updates if u.kind == "activity" and u.segment_id == "e0"]
+        assert [u.title for u in acts] == ["Title 0"]  # only packaged so far
+
+        release.set()  # let the refinement complete
+        await pipeline.flush()
+        acts = [u for u in recorder.title_updates if u.kind == "activity" and u.segment_id == "e0"]
+        assert [u.title for u in acts] == ["Title 0", "API Activity"]
+
+    async def test_eviction_cancels_pending_activity_refinement(self):
+        # A slow activity refinement scheduled before eviction is cancelled with
+        # the session, so the evicted session keeps only its packaged titles while
+        # the survivor's refinement still lands.
+        import threading
+        from datetime import datetime, timezone
+
+        from tests.unit.test_title_inferencer import _FakeTitle
+
+        from traceforge.title import TitleInferencer
+        from traceforge.title.naming import ActivityTitles
+        from traceforge.types import EventMetadata, SessionEvent
+
+        def _sev(session_id: str, boundary=None) -> SessionEvent:
+            return SessionEvent(
+                id=f"{session_id}-0" if boundary is None else f"{session_id}-1",
+                kind="tool.call",
+                session_id=session_id,
+                timestamp=datetime.now(timezone.utc),
+                payload={"tool_name": "edit"},
+                metadata=EventMetadata(source_framework="copilot", boundary=boundary),
+            )
+
+        release = threading.Event()
+
+        def refine(span):
+            release.wait(timeout=5)  # block so the refinement is still in-flight
+            return ActivityTitles(
+                "API Activity", [f"API Step {i}" for i in range(len(span.step_contexts))]
+            )
+
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enable_phase=False,
+            enable_boundary=False,
+            title_inferencer=TitleInferencer(model=_FakeTitle(), activity_refiner=refine),
+            max_sessions=1,
+        )
+        # Session A: open then close an activity so its refinement is scheduled
+        # and blocked in a worker thread.
+        await pipeline.push(_sev("A"))
+        await pipeline.push(_sev("A", boundary="activity-boundary"))
+        # Pushing B is over the cap -> A is finalized/evicted, cancelling A's
+        # in-flight activity refinement before it can emit an upgrade.
+        await pipeline.push(_sev("B"))
+        release.set()
+        await pipeline.flush()
+
+        # The evicted activity A-0 kept only its packaged title: its in-flight
+        # refinement was cancelled, so no API upgrade ever landed on it.
+        a0_acts = [
+            u.title
+            for u in recorder.title_updates
+            if u.session_id == "A" and u.segment_id == "A-0" and u.kind == "activity"
+        ]
+        assert a0_acts == ["Title 0"]
+        # And no activity/step update for session A carries an API upgrade.
+        a_api = [
+            u
+            for u in recorder.title_updates
+            if u.session_id == "A" and u.kind in ("activity", "step") and "API" in u.title
+        ]
+        assert a_api == []
+
+
 class TestPipelineSpanAndUsage:
     async def test_push_span_fanout(self):
         recorders = [RecordingSink() for _ in range(2)]

--- a/tests/unit/test_title_inferencer.py
+++ b/tests/unit/test_title_inferencer.py
@@ -281,6 +281,143 @@ def test_non_substantive_message_queues_no_refinement():
     assert stream.take_session_refinement() is None
 
 
+# ─── activity/step-title API refinement (packaged now, API upgrade later) ────
+
+
+class _RecordingActivityRefiner:
+    """A deterministic activity refiner recording the spans it was asked to title.
+
+    Stands in for :class:`traceforge.title.naming.ActivityApiProvider` so the
+    inferencer/stream can be tested without LiteLLM or a network. Returns an
+    :class:`~traceforge.title.naming.ActivityTitles` upgrading the activity and
+    each step title.
+    """
+
+    def __init__(self, activity="API Activity", steps=None):
+        self._activity = activity
+        self._steps = steps
+        self.spans: list = []
+
+    def __call__(self, span):
+        from traceforge.title.naming import ActivityTitles
+
+        self.spans.append(span)
+        steps = self._steps
+        if steps is None:
+            steps = [f"API Step {i}" for i in range(len(span.step_contexts))]
+        return ActivityTitles(self._activity, steps)
+
+
+def test_no_activity_refiner_queues_nothing():
+    # Default (strategy=model): no refiner is configured, so closing an activity
+    # emits its packaged titles and queues NOTHING for off-hot-path refinement.
+    inf = TitleInferencer(model=_FakeTitle())
+    assert inf.has_activity_refiner is False
+    stream = inf.new_stream("S", "copilot")
+    stream.push(_event(0, tool="edit"))
+    _e, updates = stream.push(_event(1, boundary="activity-boundary"))
+    assert any(u.kind == "activity" for u in updates)  # packaged titles emitted
+    assert stream.take_activity_refinements() == []  # nothing queued
+
+
+def test_activity_refiner_queues_closed_activity_once():
+    # With a refiner configured, closing an activity queues exactly one closed
+    # activity (ids + rows) for refinement, popped once by the pipeline.
+    inf = TitleInferencer(model=_FakeTitle(), activity_refiner=_RecordingActivityRefiner())
+    assert inf.has_activity_refiner is True
+    stream = inf.new_stream("S", "copilot")
+    stream.push(_event(0, tool="edit"))  # activity e0 / step e0
+    stream.push(_event(1, tool="shell", boundary="step-boundary"))  # step e1
+    stream.push(_event(2, tool="grep", boundary="activity-boundary"))  # closes e0
+
+    queued = stream.take_activity_refinements()
+    assert len(queued) == 1
+    closed = queued[0]
+    assert closed.activity_id == "e0"
+    assert [sid for sid, _rows in closed.steps] == ["e0", "e1"]
+    # Popped once, not re-queued.
+    assert stream.take_activity_refinements() == []
+
+
+def test_signal_less_activity_is_not_queued():
+    # A span with no packaged title (no signal) emits no updates, so there is
+    # nothing to upgrade -> it is never queued even with a refiner configured.
+    inf = TitleInferencer(model=_FakeTitle(), activity_refiner=_RecordingActivityRefiner())
+    stream = inf.new_stream("S", "copilot")
+    stream.push(_event(0, tool=None, payload={}))  # no signal
+    _e, updates = stream.push(_event(1, tool=None, payload={}, boundary="activity-boundary"))
+    assert updates == []
+    assert stream.take_activity_refinements() == []
+
+
+def test_refine_activity_maps_api_titles_to_refinements():
+    # refine_activity distils the closed activity + steps, calls the refiner
+    # ONCE, and maps the returned titles to per-segment refinements (activity +
+    # each step, parented to the activity).
+    refiner = _RecordingActivityRefiner()
+    inf = TitleInferencer(model=_FakeTitle(), activity_refiner=refiner)
+    stream = inf.new_stream("S", "copilot")
+    stream.push(_event(0, tool="edit"))
+    stream.push(_event(1, tool="shell", boundary="step-boundary"))
+    stream.push(_event(2, tool="grep", boundary="activity-boundary"))
+    closed = stream.take_activity_refinements()[0]
+
+    refs = inf.refine_activity(closed)
+    assert len(refiner.spans) == 1  # exactly one API call for the whole activity
+    by = {(r.kind, r.segment_id): r for r in refs}
+    assert by[("activity", "e0")].title == "API Activity"
+    assert by[("activity", "e0")].parent_id is None
+    assert by[("step", "e0")].title == "API Step 0" and by[("step", "e0")].parent_id == "e0"
+    assert by[("step", "e1")].title == "API Step 1" and by[("step", "e1")].parent_id == "e0"
+
+
+def test_refine_activity_drops_step_titles_colliding_with_activity():
+    # A step title that collides with the (effective) activity title is dropped
+    # so that step keeps its distinct packaged-model title.
+    refiner = _RecordingActivityRefiner(activity="Add Auth", steps=["Add Auth", "Write Tests"])
+    inf = TitleInferencer(model=_FakeTitle(), activity_refiner=refiner)
+    stream = inf.new_stream("S", "copilot")
+    stream.push(_event(0, tool="edit"))
+    stream.push(_event(1, tool="shell", boundary="step-boundary"))
+    stream.push(_event(2, tool="grep", boundary="activity-boundary"))
+    closed = stream.take_activity_refinements()[0]
+
+    refs = inf.refine_activity(closed)
+    kinds = {(r.kind, r.segment_id): r.title for r in refs}
+    assert kinds[("activity", "e0")] == "Add Auth"
+    assert ("step", "e0") not in kinds  # collided -> dropped
+    assert kinds[("step", "e1")] == "Write Tests"  # distinct -> kept
+
+
+def test_refine_activity_none_activity_keeps_packaged_and_seeds_distinctness():
+    # When the API declines the activity title (None), no activity refinement is
+    # produced (the packaged one stands) and step distinctness is seeded off the
+    # packaged activity title.
+    refiner = _RecordingActivityRefiner(activity=None, steps=["Step One", "Step Two"])
+    inf = TitleInferencer(model=_FakeTitle(), activity_refiner=refiner)
+    stream = inf.new_stream("S", "copilot")
+    stream.push(_event(0, tool="edit"))
+    stream.push(_event(1, tool="shell", boundary="step-boundary"))
+    stream.push(_event(2, tool="grep", boundary="activity-boundary"))
+    closed = stream.take_activity_refinements()[0]
+
+    refs = inf.refine_activity(closed)
+    assert all(r.kind == "step" for r in refs)  # no activity refinement
+    assert {r.title for r in refs} == {"Step One", "Step Two"}
+
+
+def test_refine_activity_without_refiner_returns_empty():
+    inf = TitleInferencer(model=_FakeTitle())  # no refiner
+    stream = inf.new_stream("S", "copilot")
+    stream.push(_event(0, tool="edit"))
+    updates = stream.flush()
+    assert updates  # packaged titles emitted
+    # Nothing queued, but refine_activity is still a safe no-op if called.
+    from traceforge.title.inferencer import _ClosedActivity
+
+    assert inf.refine_activity(_ClosedActivity("e0", "Title 0", [("e0", [])])) == []
+
+
 # ─── real packaged model ─────────────────────────────────────────────────────
 
 _HAS_DEPS = (

--- a/tests/unit/test_title_naming.py
+++ b/tests/unit/test_title_naming.py
@@ -12,14 +12,20 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from traceforge.config.models import (
+    ActivityTitlingApiConfig,
+    ActivityTitlingConfig,
     SessionNamingApiConfig,
     SessionNamingConfig,
     SessionNamingHeuristicConfig,
 )
 from traceforge.title.naming import (
+    ActivityApiProvider,
+    ActivitySpan,
+    ActivityTitles,
     ApiProvider,
     HeuristicProvider,
     _api_key_present,
+    build_activity_refiner,
     build_session_titler,
 )
 
@@ -143,3 +149,136 @@ def test_with_fallback_prefers_api_when_available(monkeypatch):
     )
     titler = build_session_titler(cfg)
     assert titler("some request") == "Wire up the retry backoff"
+
+
+# ─── activity/step (span) title refinement ───────────────────────────────────
+#
+# The span refiner mirrors the session API tier exactly (same LiteLLM plumbing,
+# key-presence gate, and graceful-fallback contract) but titles a whole closed
+# activity and its steps in ONE call, returning JSON. The offline floor here is
+# the packaged ONNX span model (owned by the inferencer), so absent a key -- or
+# on any API failure -- ``build_activity_refiner`` returns ``None`` and the
+# refiner returns all-``None`` titles, leaving the packaged titles standing.
+
+
+def _span(n_steps: int = 2) -> ActivitySpan:
+    return ActivitySpan(
+        activity_context="intent: add retry backoff | files: client.py",
+        step_contexts=[f"step {i} context" for i in range(n_steps)],
+    )
+
+
+# ─── build_activity_refiner resolution ───────────────────────────────────────
+
+
+def test_activity_default_strategy_builds_no_refiner():
+    # strategy=model (the default) -> the packaged ONNX titles are final; no
+    # API refiner is built and the pipeline pays nothing.
+    assert build_activity_refiner(ActivityTitlingConfig()) is None
+
+
+def test_activity_api_without_key_falls_back_to_packaged(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cfg = ActivityTitlingConfig(
+        strategy="api", api=ActivityTitlingApiConfig(api_key_env="OPENAI_API_KEY")
+    )
+    # No key -> the opt-in gate declines, so the packaged model stands (None).
+    assert build_activity_refiner(cfg) is None
+
+
+def test_activity_api_with_key_builds_provider(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = ActivityTitlingConfig(
+        strategy="api", api=ActivityTitlingApiConfig(api_key_env="OPENAI_API_KEY")
+    )
+    refiner = build_activity_refiner(cfg)
+    assert isinstance(refiner, ActivityApiProvider)
+
+
+# ─── _api_key_present opt-in gate (shared, over the activity api config) ──────
+
+
+def test_activity_api_key_present_honors_explicit_env(monkeypatch):
+    cfg = ActivityTitlingApiConfig(api_key_env="MY_KEY")
+    monkeypatch.delenv("MY_KEY", raising=False)
+    assert _api_key_present(cfg) is False
+    monkeypatch.setenv("MY_KEY", "x")
+    assert _api_key_present(cfg) is True
+
+
+def test_activity_api_key_present_local_base_needs_no_key():
+    cfg = ActivityTitlingApiConfig(api_base="http://localhost:11434", api_key_env=None)
+    assert _api_key_present(cfg) is True
+
+
+# ─── ActivityApiProvider behavior (litellm mocked) ───────────────────────────
+
+
+def test_activity_provider_parses_activity_and_step_titles(monkeypatch):
+    import litellm
+
+    reply = '{"activity": "Add retry backoff", "steps": ["Wire client", "Add tests"]}'
+    monkeypatch.setattr(litellm, "completion", _fake_completion(reply))
+    titles = ActivityApiProvider(ActivityTitlingApiConfig())(_span(2))
+    assert titles.activity == "Add retry backoff"
+    assert titles.steps == ["Wire client", "Add tests"]
+
+
+def test_activity_provider_cleans_titles(monkeypatch):
+    import litellm
+
+    reply = '{"activity": "  Add retry backoff.  ", "steps": ["  wire client.  "]}'
+    monkeypatch.setattr(litellm, "completion", _fake_completion(reply))
+    titles = ActivityApiProvider(ActivityTitlingApiConfig())(_span(1))
+    # clean_title trims whitespace + trailing punctuation and caps the first char.
+    assert titles.activity == "Add retry backoff"
+    assert titles.steps == ["Wire client"]
+
+
+def test_activity_provider_tolerates_prose_wrapped_json(monkeypatch):
+    import litellm
+
+    reply = 'Sure! Here you go:\n```json\n{"activity": "Fix bug", "steps": ["Patch it"]}\n```'
+    monkeypatch.setattr(litellm, "completion", _fake_completion(reply))
+    titles = ActivityApiProvider(ActivityTitlingApiConfig())(_span(1))
+    assert titles.activity == "Fix bug"
+    assert titles.steps == ["Patch it"]
+
+
+def test_activity_provider_pads_missing_steps_with_none(monkeypatch):
+    import litellm
+
+    # Reply covers only the first of two steps -> the second stays None so its
+    # packaged-model title is kept.
+    reply = '{"activity": "Add retry backoff", "steps": ["Wire client"]}'
+    monkeypatch.setattr(litellm, "completion", _fake_completion(reply))
+    titles = ActivityApiProvider(ActivityTitlingApiConfig())(_span(2))
+    assert titles.steps == ["Wire client", None]
+
+
+def test_activity_provider_returns_empty_on_exception(monkeypatch):
+    import litellm
+
+    def _boom(**_kw):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(litellm, "completion", _boom)
+    titles = ActivityApiProvider(ActivityTitlingApiConfig())(_span(2))
+    # Any provider/network error -> all-None so the caller keeps packaged titles.
+    assert titles == ActivityTitles(None, [None, None])
+
+
+def test_activity_provider_unparseable_reply_returns_empty(monkeypatch):
+    import litellm
+
+    monkeypatch.setattr(litellm, "completion", _fake_completion("not json at all"))
+    titles = ActivityApiProvider(ActivityTitlingApiConfig())(_span(2))
+    assert titles == ActivityTitles(None, [None, None])
+
+
+def test_activity_provider_missing_key_env_returns_empty(monkeypatch):
+    # api_key_env names an absent var -> decline (all-None) rather than call the
+    # API keyless; the caller falls back to packaged titles.
+    monkeypatch.delenv("MY_KEY", raising=False)
+    titles = ActivityApiProvider(ActivityTitlingApiConfig(api_key_env="MY_KEY"))(_span(2))
+    assert titles == ActivityTitles(None, [None, None])


### PR DESCRIPTION
## What & why

Activity/step (span) titles were always produced by the packaged offline ONNX titler, with no way to opt into an LLM — unlike **session naming**, which already ships an offline floor + opt-in LiteLLM API tier. This PR closes that gap by mirroring the session-naming machinery for span titles.

The packaged ONNX titler remains the **default, immediate floor**. A new `title.activity_titling.strategy = api` opt-in additionally refines each closed activity's titles **off the hot path** via LiteLLM when a provider key is present, emitting the upgrades as later append-only `TitleUpdate`s on the same segment ids.

`strategy = "model"` (the default) reproduces today's behavior **byte-for-byte**: packaged ONNX, offline, free, no key, no network, no new task scheduled.

## Design

- **Config** (`config/models.py`): factored a shared `TitleApiConfig` base (model/api_base/api_key_env/timeout/max_tokens); `SessionNamingApiConfig` now inherits it unchanged (max_tokens stays 24). Added `ActivityTitlingApiConfig` (max_tokens 256, to fit a multi-title JSON reply) and `ActivityTitlingConfig` (`strategy: model|api`, default `model`), wired into `TitleConfig.activity_titling`. Docstrings + `defaults.py` YAML comment document the new block. The API key is never stored in config — LiteLLM reads it from the provider env var; `api_key_env` only names a different var (identical contract to session naming).
- **Engine** (`title/naming.py`, `title/inferencer.py`): reused the existing LiteLLM plumbing, `_api_key_present` opt-in gate, and graceful-fallback contract. Added an `ActivityApiProvider` (span-oriented JSON prompt), `build_activity_refiner()`, and `TitleInferencer.refine_activity()`. The packaged titles are still emitted the instant an activity closes; when a refiner is configured the closed activity is queued for refinement.
- **Pipeline** (`pipeline.py`): after emitting the packaged titles, drains queued closed activities and refines each in a **worker thread** (`asyncio.to_thread`), emitting the upgrades as later `TitleUpdate`s. Reuses the same `_refine_tasks` bucket as session refinement, so eviction cancels in-flight tasks and `flush()` awaits pending ones. Eviction finalizes with packaged titles only (no new API work).

### Granularity decision

**One API call per closed activity** returns the activity title **and** all its step titles together (JSON `{"activity": ..., "steps": [...]}`). This lets the model see full activity context and keep step titles distinct from each other and the parent (preserving the `pick_distinct` invariant, re-enforced on the API path via `norm_key`). It is O(activities), not O(events/steps). Fallback stays per-segment: any segment the API doesn't usefully cover keeps its packaged-model title.

### Preserved invariants

Fully causal/streaming emission (events never held for a title), packaged model loaded once per segment, activity-vs-step distinctness, append-only `TitleUpdate`s keyed by segment id, lazy load so an untitled/default pipeline pays nothing. No back-compat/dual-path shims. Session naming, `preprocessors/**`, and `website/**` untouched.

## Validation

- **Full suite** (`uv run --no-progress python -m pytest -q -p no:cacheprovider`): **2836 passed, 6 skipped, 9 xfailed** — baseline was 2811/6/9, so **+25 new tests**, identical skip/xfail.
- **New tests** mirror the session-naming tests: (a) default `strategy=model` makes **no** API call and produces identical packaged titles; (b) `strategy=api` with a key refines off the hot path and emits later upgrades for activity + steps; (c) `strategy=api` without a key silently falls back; (d) API failure keeps packaged titles with no error/no block; (e) live emission is never blocked; plus eviction-cancels-refinement and `ActivityApiProvider`/`build_activity_refiner`/`refine_activity` unit tests. LiteLLM is mocked — no network.
- **Lint**: `ruff==0.15.20 ruff check` → *All checks passed!*; `ruff format --check` → *403 files already formatted*.

Left **unmerged** for coordinator review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>