### PR TITLE
Hydrate SDK sinks from config for CLI/SDK parity (#116)

### DIFF
--- a/src/traceforge/cli/watch.py
+++ b/src/traceforge/cli/watch.py
@@ -226,28 +226,15 @@ async def _process_pipeline_once(
 
 
 def _build_sinks(pipeline: ResolvedPipeline) -> list:
-    """Instantiate the configured sink objects for a resolved pipeline (once)."""
-    from traceforge.sinks.console import ConsoleSink
-    from traceforge.sinks.jsonl import JsonlSink
-    from traceforge.sinks.sqlite_output import SqliteOutputSink
+    """Instantiate the configured sink objects for a resolved pipeline (once).
 
-    sinks: list = []
-    for sink_config in pipeline.sinks:
-        sink_type = getattr(sink_config, "type", None)
-        if sink_type == "console":
-            sinks.append(
-                ConsoleSink(
-                    filter_actions=getattr(sink_config, "filter", None),
-                    color=getattr(sink_config, "color", True),
-                )
-            )
-        elif sink_type == "sqlite":
-            sinks.append(SqliteOutputSink(path=sink_config.path))
-        elif sink_type == "jsonl":
-            sinks.append(JsonlSink(path=sink_config.path))
-        else:
-            logger.warning("Unknown sink type %r in pipeline %s", sink_type, pipeline.name)
-    return sinks
+    Delegates to the shared :func:`traceforge.sinks.factory.build_sinks` so the
+    daemon and the SDK build sinks from one mapping of the full ``SinkConfig``
+    union.
+    """
+    from traceforge.sinks.factory import build_sinks
+
+    return build_sinks(pipeline.sinks)
 
 
 def _build_pipeline_runtime(pipeline: ResolvedPipeline, governance: "GovernancePipeline"):

--- a/src/traceforge/config/loader.py
+++ b/src/traceforge/config/loader.py
@@ -197,6 +197,33 @@ def load_config(**overrides: Any) -> TraceforgeConfig:
     return _config
 
 
+def load_config_from_path(path: Any = None) -> TraceforgeConfig:
+    """Resolve a full ``TraceforgeConfig``, optionally forcing a specific file.
+
+    When ``path`` is given it becomes the sole config source (applied via the
+    ``TRACEFORGE_CONFIG`` override, then restored); when ``None`` the standard
+    discovery chain runs (``TRACEFORGE_CONFIG`` env, ``./traceforge.yaml``,
+    ``~/.traceforge/config.yaml``).
+
+    This is the single ``path -> config`` resolution shared by the SDK
+    (:meth:`traceforge.sdk.Pipeline.from_config`) and governance
+    (:meth:`traceforge.governance.pipeline.GovernancePipeline.from_config`)
+    entry points, so both hydrate from the same resolved config.
+    """
+    if path is None:
+        return load_config()
+
+    old_env = os.environ.get("TRACEFORGE_CONFIG")
+    os.environ["TRACEFORGE_CONFIG"] = str(path)
+    try:
+        return load_config()
+    finally:
+        if old_env is None:
+            os.environ.pop("TRACEFORGE_CONFIG", None)
+        else:
+            os.environ["TRACEFORGE_CONFIG"] = old_env
+
+
 def get_config() -> TraceforgeConfig:
     """Get the current config singleton, loading defaults if needed."""
     global _config

--- a/src/traceforge/governance/pipeline.py
+++ b/src/traceforge/governance/pipeline.py
@@ -202,21 +202,9 @@ class GovernancePipeline:
             pipeline = Pipeline.from_config()
             pipeline = Pipeline.from_config(policy=my_policy)
         """
-        import os
+        from traceforge.config.loader import load_config_from_path
 
-        from traceforge.config.loader import load_config
-
-        old_env = os.environ.get("TRACEFORGE_CONFIG")
-        if path is not None:
-            os.environ["TRACEFORGE_CONFIG"] = str(path)
-        try:
-            config = load_config()
-        finally:
-            if path is not None:
-                if old_env is None:
-                    os.environ.pop("TRACEFORGE_CONFIG", None)
-                else:
-                    os.environ["TRACEFORGE_CONFIG"] = old_env
+        config = load_config_from_path(path)
 
         instance = cls.create(config.governance)
 

--- a/src/traceforge/sdk/pipeline.py
+++ b/src/traceforge/sdk/pipeline.py
@@ -129,8 +129,31 @@ class Pipeline:
 
         Same knobs as :meth:`create`, but the governance engine is loaded from the
         given config file (see :meth:`GovernancePipeline.from_config`).
+
+        Sink hydration (SDK/CLI parity, issue #116): when ``sinks`` is **omitted**
+        (left as ``None``), the standard sinks declared in the config's pipelines
+        (``pipelines[].sinks``) are auto-built from their ``SinkConfig`` entries via
+        the shared :func:`traceforge.sinks.factory.build_sinks` — the same factory the
+        ``traceforge watch`` daemon uses. Sinks declared across multiple named
+        pipelines are flattened into one list, since the SDK backbone is a single
+        source/adapter-agnostic event stream and every declared sink is a live
+        destination.
+
+        Programmatic sinks always win: passing ``sinks=[...]`` — **including an
+        explicit empty list ``[]``** — is honored exactly and disables
+        auto-hydration. ``None`` is the sole "omitted" sentinel.
         """
         gov_engine = GovernancePipeline.from_config(path, policy=policy)
+
+        if sinks is None:
+            from traceforge.config.loader import load_config_from_path
+            from traceforge.sinks.factory import build_sinks
+
+            config = load_config_from_path(path)
+            sinks = build_sinks(
+                [sink_config for pipeline in config.pipelines for sink_config in pipeline.sinks]
+            )
+
         return cls._assemble(
             gov_engine,
             sinks=sinks,

--- a/src/traceforge/sinks/factory.py
+++ b/src/traceforge/sinks/factory.py
@@ -1,0 +1,94 @@
+"""Single factory mapping declarative ``SinkConfig`` unions to sink instances.
+
+One place builds standard sinks from config so the CLI daemon
+(:func:`traceforge.cli.watch._build_sinks`) and the SDK
+(:meth:`traceforge.sdk.Pipeline.from_config`) stay in parity — the exact
+asymmetry issue #116 closes.
+
+Optional-dependency sinks import lazily *per branch* (e.g. ``boto3`` for S3),
+so a config that never mentions S3 never imports boto3.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from traceforge.config.models import SinkConfig
+    from traceforge.sinks.base import StorageSink
+
+logger = logging.getLogger(__name__)
+
+
+def build_sinks(sink_configs: "list[SinkConfig]") -> "list[StorageSink]":
+    """Instantiate the standard sinks declared by a ``SinkConfig`` list.
+
+    Covers the full serializable union (``sqlite``, ``jsonl``, ``console``,
+    ``webhook``, ``otel``, ``s3``); each config field maps onto its sink
+    constructor faithfully. Callback / custom :class:`StorageSink` subclasses are
+    code-only and intentionally have no ``SinkConfig`` variant, so they are not
+    built here.
+
+    Unknown ``type`` discriminators are logged and skipped. This cannot happen
+    for a validated :data:`~traceforge.config.models.SinkConfig` (the union is
+    exhaustive), but keeping the branch total means a malformed duck-typed config
+    degrades gracefully instead of raising.
+    """
+    sinks: list = []
+    for sink_config in sink_configs:
+        sink_type = getattr(sink_config, "type", None)
+
+        if sink_type == "console":
+            from traceforge.sinks.console import ConsoleSink
+
+            sinks.append(ConsoleSink(filter_actions=sink_config.filter, color=sink_config.color))
+        elif sink_type == "sqlite":
+            from traceforge.sinks.sqlite_output import SqliteOutputSink
+
+            sinks.append(
+                SqliteOutputSink(path=sink_config.path, journal_mode=sink_config.journal_mode)
+            )
+        elif sink_type == "jsonl":
+            from traceforge.sinks.jsonl import JsonlSink
+
+            sinks.append(
+                JsonlSink(path=sink_config.path, rotate_size_mb=sink_config.rotate_size_mb)
+            )
+        elif sink_type == "webhook":
+            from traceforge.sinks.webhook import WebhookSink
+
+            sinks.append(
+                WebhookSink(
+                    url=sink_config.url,
+                    filter_actions=sink_config.filter,
+                    timeout=sink_config.timeout,
+                    max_retries=sink_config.max_retries,
+                    headers=sink_config.headers,
+                )
+            )
+        elif sink_type == "otel":
+            from traceforge.sinks.otel_exporter import OtelExporterSink
+
+            sinks.append(
+                OtelExporterSink(
+                    endpoint=sink_config.endpoint,
+                    service_name=sink_config.service_name,
+                    headers=sink_config.headers,
+                )
+            )
+        elif sink_type == "s3":
+            from traceforge.sinks.s3 import S3Sink
+
+            sinks.append(
+                S3Sink(
+                    bucket=sink_config.bucket,
+                    prefix=sink_config.prefix,
+                    region=sink_config.region,
+                    endpoint_url=sink_config.endpoint_url,
+                )
+            )
+        else:
+            logger.warning("Unknown sink type %r; skipping", sink_type)
+
+    return sinks

--- a/tests/e2e/test_sdk_from_config_sinks_e2e.py
+++ b/tests/e2e/test_sdk_from_config_sinks_e2e.py
@@ -1,0 +1,92 @@
+"""End-to-end tests for SDK sink hydration in ``Pipeline.from_config`` (issue #116).
+
+Closes the SDK/CLI asymmetry: a declarative ``traceforge.yaml`` that lists sinks now
+hydrates them onto the SDK backbone when ``sinks=`` is **omitted**, while a
+programmatic ``sinks=`` — including an explicit empty list ``[]`` — still wins verbatim
+with no auto-hydration.
+
+Isolation mirrors ``test_config_precedence_e2e``: the config layer is a module
+singleton whose ``~/.traceforge`` paths are import-time constants, so the fixture
+redirects those into a throwaway home, scrubs every ``TRACEFORGE_*`` var, and resets
+the singleton before and after each test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from traceforge.config import loader
+from traceforge.config.loader import reset_config
+from traceforge.sdk import Pipeline
+from traceforge.sinks.console import ConsoleSink
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.fixture
+def config_env(tmp_traceforge_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fully isolate the config-singleton surface for one test (see module docstring)."""
+    tf_dir = tmp_traceforge_home / ".traceforge"
+    monkeypatch.setattr(loader, "_USER_CONFIG_DIR", tf_dir)
+    monkeypatch.setattr(loader, "_USER_MAPPINGS_DIR", tf_dir / "mappings")
+    monkeypatch.setattr(loader, "_USER_CONFIG_FILE", tf_dir / "config.yaml")
+    monkeypatch.setattr(loader, "_PROJECT_CONFIG_FILE", tmp_traceforge_home / "traceforge.yaml")
+
+    for key in [k for k in os.environ if k.startswith("TRACEFORGE_")]:
+        monkeypatch.delenv(key, raising=False)
+
+    reset_config()
+    yield tmp_traceforge_home
+    reset_config()
+
+
+def _write_config(home: Path) -> Path:
+    """Write a config declaring one pipeline whose sinks are console + sqlite."""
+    cfg = {
+        "pipelines": [
+            {
+                "name": "declared",
+                "source": {"type": "replay", "path": (home / "session.jsonl").as_posix()},
+                "adapter": {"type": "otel_span"},
+                "sinks": [
+                    {"type": "console"},
+                    {"type": "sqlite", "path": (home / "out.db").as_posix()},
+                ],
+            }
+        ]
+    }
+    cfg_file = home / "traceforge.yaml"
+    cfg_file.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return cfg_file
+
+
+def test_from_config_omitted_sinks_hydrates_from_yaml(config_env: Path):
+    cfg_file = _write_config(config_env)
+
+    pipe = Pipeline.from_config(path=cfg_file)
+
+    assert [type(s) for s in pipe.backbone._sinks] == [ConsoleSink, SqliteOutputSink]
+
+
+def test_from_config_explicit_sinks_override_yaml(config_env: Path):
+    cfg_file = _write_config(config_env)
+    override = ConsoleSink()
+
+    pipe = Pipeline.from_config(path=cfg_file, sinks=[override])
+
+    # Programmatic sinks win: exactly the passed instance, no YAML hydration.
+    assert pipe.backbone._sinks == [override]
+
+
+def test_from_config_explicit_empty_sinks_honored(config_env: Path):
+    cfg_file = _write_config(config_env)
+
+    pipe = Pipeline.from_config(path=cfg_file, sinks=[])
+
+    # Explicit empty list is honored as "no sinks" — distinct from omitted (None).
+    assert pipe.backbone._sinks == []

--- a/tests/unit/test_cli_build_sinks.py
+++ b/tests/unit/test_cli_build_sinks.py
@@ -1,0 +1,67 @@
+"""Parity tests for the CLI daemon's ``_build_sinks`` (issue #116).
+
+The daemon now delegates to the shared :func:`traceforge.sinks.factory.build_sinks`,
+so console/sqlite/jsonl build exactly as before and webhook/otel/s3 build instead of
+logging ``Unknown sink type``. Each test constructs a ``ResolvedPipeline`` (the
+daemon's unit of work) and asserts the built sink types — ``_build_sinks`` only ever
+reads ``pipeline.sinks``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from traceforge.cli.runner import ResolvedPipeline
+from traceforge.cli.watch import _build_sinks
+from traceforge.config.models import (
+    ConsoleSinkConfig,
+    JsonlSinkConfig,
+    MappedJsonAdapterConfig,
+    OtelSinkConfig,
+    S3SinkConfig,
+    SqliteSinkConfig,
+    WebhookSinkConfig,
+)
+from traceforge.sinks.console import ConsoleSink
+from traceforge.sinks.jsonl import JsonlSink
+from traceforge.sinks.otel_exporter import OtelExporterSink
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+from traceforge.sinks.webhook import WebhookSink
+
+
+def _resolved(sinks: list) -> ResolvedPipeline:
+    return ResolvedPipeline(
+        name="p",
+        source_path=Path("session.jsonl"),
+        ingestion_mode="replay",
+        adapter=MappedJsonAdapterConfig(mapping="claude_code"),
+        sinks=sinks,
+    )
+
+
+def test_build_sinks_standard_trio_unchanged():
+    pipeline = _resolved(
+        [
+            ConsoleSinkConfig(),
+            SqliteSinkConfig(path="out.db"),
+            JsonlSinkConfig(path="out.jsonl"),
+        ]
+    )
+    sinks = _build_sinks(pipeline)
+    assert [type(s) for s in sinks] == [ConsoleSink, SqliteOutputSink, JsonlSink]
+
+
+def test_build_sinks_now_builds_webhook_otel_s3():
+    pipeline = _resolved(
+        [
+            WebhookSinkConfig(url="https://x.test/h"),
+            OtelSinkConfig(),
+            S3SinkConfig(bucket="b"),
+        ]
+    )
+    with patch("traceforge.sinks.s3._require_boto3", return_value=MagicMock()):
+        sinks = _build_sinks(pipeline)
+    from traceforge.sinks.s3 import S3Sink
+
+    assert [type(s) for s in sinks] == [WebhookSink, OtelExporterSink, S3Sink]

--- a/tests/unit/test_sinks_factory.py
+++ b/tests/unit/test_sinks_factory.py
@@ -1,0 +1,142 @@
+"""Unit tests for the shared sink factory (issue #116).
+
+``build_sinks`` is the single mapping from the declarative ``SinkConfig`` union to
+concrete sink instances, shared by the CLI daemon (``cli.watch._build_sinks``) and
+the SDK (``Pipeline.from_config``) so both hydrate sinks identically. These tests
+pin the per-branch construction for all six union members, confirm each config
+field maps onto its constructor faithfully, and cover the graceful skip of an
+unknown discriminator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from traceforge.config.models import (
+    ConsoleSinkConfig,
+    JsonlSinkConfig,
+    OtelSinkConfig,
+    S3SinkConfig,
+    SqliteSinkConfig,
+    WebhookSinkConfig,
+)
+from traceforge.sinks.console import ConsoleSink
+from traceforge.sinks.factory import build_sinks
+from traceforge.sinks.jsonl import JsonlSink
+from traceforge.sinks.otel_exporter import OtelExporterSink
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+from traceforge.sinks.webhook import WebhookSink
+
+
+def test_build_console_sink_maps_filter():
+    (sink,) = build_sinks([ConsoleSinkConfig(filter=["warn", "deny"], color=False)])
+    assert isinstance(sink, ConsoleSink)
+    assert sink._filter == {"warn", "deny"}
+
+
+def test_build_sqlite_sink_maps_path_and_journal_mode():
+    (sink,) = build_sinks([SqliteSinkConfig(path="out/events.db", journal_mode="delete")])
+    assert isinstance(sink, SqliteOutputSink)
+    assert sink._journal_mode == "delete"
+    assert str(sink._path).endswith("events.db")
+
+
+def test_build_jsonl_sink_maps_path_and_rotate():
+    (sink,) = build_sinks([JsonlSinkConfig(path="out/events.jsonl", rotate_size_mb=5.0)])
+    assert isinstance(sink, JsonlSink)
+    assert sink._path_template == str(Path("out/events.jsonl"))
+    assert sink._rotate_size_mb == 5.0
+
+
+def test_build_webhook_sink_maps_all_fields():
+    (sink,) = build_sinks(
+        [
+            WebhookSinkConfig(
+                url="https://example.test/hook",
+                filter=["deny"],
+                timeout=2.5,
+                max_retries=7,
+                headers={"X-Token": "abc"},
+            )
+        ]
+    )
+    assert isinstance(sink, WebhookSink)
+    assert sink._url == "https://example.test/hook"
+    assert sink._filter == {"deny"}
+    assert sink._timeout == 2.5
+    assert sink._max_retries == 7
+    assert sink._headers == {"X-Token": "abc"}
+
+
+def test_build_otel_sink_maps_endpoint_service_headers():
+    (sink,) = build_sinks(
+        [
+            OtelSinkConfig(
+                endpoint="https://collector.test/v1/traces",
+                service_name="svc",
+                headers={"A": "B"},
+            )
+        ]
+    )
+    assert isinstance(sink, OtelExporterSink)
+    assert sink._endpoint == "https://collector.test/v1/traces"
+    assert sink._service_name == "svc"
+    assert sink._headers == {"A": "B"}
+
+
+def test_build_s3_sink_maps_fields_and_defers_boto3():
+    with patch("traceforge.sinks.s3._require_boto3", return_value=MagicMock()) as require:
+        (sink,) = build_sinks(
+            [
+                S3SinkConfig(
+                    bucket="b",
+                    prefix="p/",
+                    region="us-east-1",
+                    endpoint_url="http://minio.test:9000",
+                )
+            ]
+        )
+    from traceforge.sinks.s3 import S3Sink
+
+    assert isinstance(sink, S3Sink)
+    assert sink._bucket == "b"
+    assert sink._prefix == "p/"
+    assert sink._region == "us-east-1"
+    assert sink._endpoint_url == "http://minio.test:9000"
+    require.assert_called_once()
+
+
+def test_build_sinks_covers_full_union_in_declared_order():
+    with patch("traceforge.sinks.s3._require_boto3", return_value=MagicMock()):
+        sinks = build_sinks(
+            [
+                SqliteSinkConfig(path="a.db"),
+                JsonlSinkConfig(path="a.jsonl"),
+                ConsoleSinkConfig(),
+                WebhookSinkConfig(url="https://x.test/h"),
+                OtelSinkConfig(),
+                S3SinkConfig(bucket="b"),
+            ]
+        )
+    from traceforge.sinks.s3 import S3Sink
+
+    assert [type(s) for s in sinks] == [
+        SqliteOutputSink,
+        JsonlSink,
+        ConsoleSink,
+        WebhookSink,
+        OtelExporterSink,
+        S3Sink,
+    ]
+
+
+def test_build_sinks_empty_input_yields_empty_list():
+    assert build_sinks([]) == []
+
+
+def test_build_sinks_skips_unknown_type():
+    # A validated SinkConfig can never carry an unknown discriminator, but a
+    # duck-typed/malformed entry must degrade gracefully rather than raise.
+    assert build_sinks([SimpleNamespace(type="bogus")]) == []


### PR DESCRIPTION
Closes #116

## Problem

CLI `traceforge watch` hydrated sinks from `traceforge.yaml` via `_build_sinks`, but only handled `console`/`sqlite`/`jsonl` (logging `Unknown sink type` for the rest). Meanwhile the SDK `Pipeline.from_config(path)` never hydrated sinks at all — an omitted `sinks=` defaulted to `[]`, so a declarative pipeline that lists sinks in YAML silently emitted to **nothing** when driven from the SDK.

## Changes

- **New shared factory** `src/traceforge/sinks/factory.py`: `build_sinks(sink_configs) -> list[StorageSink]` maps the full `SinkConfig` union (`console`/`sqlite`/`jsonl`/`webhook`/`otel`/`s3`) to sink instances, using lazy per-branch imports so optional deps (e.g. `boto3` for s3) only import when that sink is configured.
- **CLI** `cli/watch.py::_build_sinks` now delegates to the factory — console/sqlite/jsonl behavior is identical, and webhook/otel/s3 now build instead of warning.
- **SDK** `Pipeline.from_config` auto-hydrates sinks when `sinks=` is **omitted** (`None`), flattening the sinks declared across all `pipelines[].sinks`. **Programmatic sinks always win**: an explicit `sinks=[...]` — including an empty list `[]` — is honored verbatim with no hydration (`None` is the sole "omitted" sentinel).
- **Loader** `config/loader.py::load_config_from_path` dedupes the `TRACEFORGE_CONFIG` path→config resolution, shared by the SDK and governance `from_config` entry points.

## Design decision — how `from_config` resolves the sink list

Sinks are only expressible under `config.pipelines[].sinks` (the config models use `extra="forbid"`, so there is no top-level `sinks:`). `from_config` therefore **flattens all** `pipelines[].sinks` rather than selecting one named pipeline: the SDK backbone is a single source/adapter-agnostic event stream, and picking one pipeline would silently drop the other pipelines' declared sinks — reintroducing the exact "emits to nothing" bug for those. Every declared sink is a live destination.

## Tests (+14, all green)

- Factory constructs each of the 6 union members with faithful field mapping (s3 mocks `boto3`).
- CLI `_build_sinks` stays identical for console/sqlite/jsonl and now builds webhook/otel/s3.
- `from_config` with omitted `sinks=` hydrates from YAML; explicit `sinks=[...]` overrides; explicit `sinks=[]` yields no sinks.

Full suite: **2815 → 2829 passed** (6 skipped, 5 xfailed, 0 failed). `ruff check` + `ruff format --check` clean (pinned `0.15.20`).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
