### PR TITLE
External (out-of-process) preflight gates: HttpGate + SubprocessGate

### DIFF
--- a/src/traceforge/config/__init__.py
+++ b/src/traceforge/config/__init__.py
@@ -6,6 +6,7 @@ from traceforge.config.models import (
     FileWatchSourceConfig,
     FilePollSourceConfig,
     GovernanceConfig,
+    HttpGateConfig,
     HttpPollSourceConfig,
     MappedJsonAdapterConfig,
     OtelSpanAdapterConfig,
@@ -19,8 +20,10 @@ from traceforge.config.models import (
     SourceConfig,
     SSESourceConfig,
     SqliteSinkConfig,
+    SubprocessGateConfig,
     JsonlSinkConfig,
     S3SinkConfig,
+    ExternalGateConfig,
     TitleApiConfig,
     TitleConfig,
     ActivityTitlingConfig,
@@ -56,6 +59,9 @@ __all__ = [
     # Governance
     "GovernanceConfig",
     "BudgetConfig",
+    "ExternalGateConfig",
+    "SubprocessGateConfig",
+    "HttpGateConfig",
     # Title
     "TitleConfig",
     "TitleApiConfig",

--- a/src/traceforge/config/defaults.py
+++ b/src/traceforge/config/defaults.py
@@ -51,6 +51,30 @@ governance:
   #   max_tool_calls: 200
   #   max_by_effect:
   #     destructive: 10
+  #
+  # ── External preflight gate (out-of-process tool-call decider) ──────────────
+  # Delegate the ALLOW/DENY decision to an external Policy Decision Point instead
+  # of an in-process Python callback. Fail-CLOSED by default (any error/timeout/
+  # non-2xx/bad output => DENY). Mutually exclusive with `tool_preflight_gate`.
+  # Choose ONE of the two forms below.
+  #
+  # HTTP PDP (recommended — e.g. an OPA REST server):
+  # preflight_gate:
+  #   type: http
+  #   endpoint: http://localhost:8181/v1/data/traceforge/verdict
+  #   timeout: 2.0
+  #   fail_open: false        # false = fail-closed (DENY on error). Keep false.
+  #   headers:                # optional, e.g. auth tokens
+  #     Authorization: "Bearer ${PDP_TOKEN}"
+  #   max_input_bytes: 65536  # per-string cap on tool input sent to the decider
+  #
+  # Subprocess decider (portable / air-gapped — e.g. `opa eval`):
+  # preflight_gate:
+  #   type: subprocess
+  #   command: "opa eval -I -f raw data.traceforge.verdict"
+  #   timeout: 10.0
+  #   fail_open: false
+  #   max_input_bytes: 65536
 
 # ─── Phase tracker (session-level phase segmentation) ───────────────────────
 # Smooths per-event activity labels into stable workflow phases via a debounced

--- a/src/traceforge/config/models.py
+++ b/src/traceforge/config/models.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from traceforge.models import StrictModel
 
@@ -234,6 +234,42 @@ class BudgetConfig(StrictModel):
     max_by_scope: dict[str, int] | None = None
 
 
+class SubprocessGateConfig(StrictModel):
+    """External preflight gate that shells out to a decider command per call.
+
+    The JSON request is written to the process's stdin; the JSON verdict is read
+    from stdout. Fail-closed by default (any error/timeout/bad output -> DENY).
+    """
+
+    type: Literal["subprocess"] = "subprocess"
+    command: str
+    timeout: float = Field(default=10.0, gt=0)
+    fail_open: bool = False
+    max_input_bytes: int = Field(default=65536, gt=0)
+
+
+class HttpGateConfig(StrictModel):
+    """External preflight gate that POSTs the request to a persistent HTTP PDP.
+
+    Recommended mode (e.g. an OPA REST server). Fail-closed by default (any
+    error/timeout/non-2xx -> DENY). ``headers`` carries auth tokens.
+    """
+
+    type: Literal["http"] = "http"
+    endpoint: str
+    timeout: float = Field(default=2.0, gt=0)
+    fail_open: bool = False
+    headers: dict[str, str] = Field(default_factory=dict)
+    max_input_bytes: int = Field(default=65536, gt=0)
+
+
+# Discriminated union of external (out-of-process) preflight gate types
+ExternalGateConfig = Annotated[
+    SubprocessGateConfig | HttpGateConfig,
+    Field(discriminator="type"),
+]
+
+
 class GovernanceConfig(StrictModel):
     """Governance pipeline configuration.
 
@@ -258,6 +294,15 @@ class GovernanceConfig(StrictModel):
             integrity_verification=True,
             budget=BudgetConfig(max_tool_calls=200, max_by_effect={"destructive": 10}),
         )
+
+    Preflight gating is configured one of two mutually-exclusive ways:
+
+      * ``tool_preflight_gate`` — a dotted import path to an in-process Python
+        ``PreflightGate`` callable (SDK / code-defined policy).
+      * ``preflight_gate`` — an out-of-process, YAML-native external decider
+        (``http`` or ``subprocess``); see :data:`ExternalGateConfig`.
+
+    Setting both is a configuration error (raised by the validator below).
     """
 
     db_path: str | None = None  # None = in-memory
@@ -267,6 +312,24 @@ class GovernanceConfig(StrictModel):
     integrity_verification: bool = True  # content-hash tamper detection (baseline + drift)
     budget: BudgetConfig = Field(default_factory=BudgetConfig)
     tool_preflight_gate: str | None = None  # dotted import path (e.g. "myapp.policies.my_policy")
+    preflight_gate: ExternalGateConfig | None = (
+        None  # out-of-process external decider (http/subprocess)
+    )
+
+    @model_validator(mode="after")
+    def _preflight_gate_exclusivity(self) -> "GovernanceConfig":
+        """``tool_preflight_gate`` and ``preflight_gate`` are mutually exclusive.
+
+        They configure the same slot (the preflight gate chain) via two different
+        mechanisms; allowing both would make precedence ambiguous. Fail loudly.
+        """
+        if self.tool_preflight_gate is not None and self.preflight_gate is not None:
+            raise ValueError(
+                "governance.tool_preflight_gate (dotted import path) and "
+                "governance.preflight_gate (external gate config) are mutually "
+                "exclusive — set only one."
+            )
+        return self
 
 
 # ─── Score API Config ────────────────────────────────────────────────────────

--- a/src/traceforge/gate/external.py
+++ b/src/traceforge/gate/external.py
@@ -1,0 +1,305 @@
+"""External preflight gates — call an out-of-process decider (PDP) for a verdict.
+
+Where the in-process ``GatePolicy`` runs Python callbacks, these two gates delegate
+the ALLOW/DENY decision to an *external* Policy Decision Point so gating can be
+configured entirely from YAML with zero Python:
+
+  * :class:`HttpGate` — POSTs a JSON request to a persistent HTTP PDP (e.g. an OPA
+    REST server) and reads a verdict. Primary / recommended mode.
+  * :class:`SubprocessGate` — spawns a command per call, writes the JSON request to
+    its stdin and reads the JSON verdict from its stdout. For portability, OPA
+    ``eval``, or air-gapped use.
+
+Both satisfy the sync :class:`~traceforge.sdk.verdict.PreflightGate` protocol
+(``(ToolCallRequest, GateContext) -> Verdict``) so they plug straight into a
+:class:`~traceforge.sdk.gate_policy.GatePolicy` with no framework-adapter changes.
+
+Security posture — FAIL CLOSED BY DEFAULT
+-----------------------------------------
+``fail_open`` defaults to ``False`` on both gates: any error, timeout, non-2xx
+response, non-zero exit, or unparseable output DENIES the call. A gate that fails
+open on error silently disables enforcement exactly when something is wrong, which
+is a security anti-pattern — so the safe default is non-negotiable. Set
+``fail_open=True`` only for availability-over-safety deployments where you have
+consciously accepted that a broken decider means unfiltered tool calls.
+
+Dependency-light & thread-safe
+------------------------------
+No third-party dependencies: HTTP uses stdlib ``urllib.request`` and subprocess uses
+stdlib ``subprocess``. Both gates are stateless callables over thread-safe stdlib,
+so LangGraph/CrewAI may invoke them from multiple threads concurrently.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from traceforge.sdk.verdict import Verdict
+
+if TYPE_CHECKING:
+    from traceforge.sdk.gate_types import GateContext, ToolCallRequest
+
+__all__ = ["HttpGate", "SubprocessGate"]
+
+
+# ─── Wire serialization ───────────────────────────────────────────────────────
+
+
+def _stringify(value: Any) -> Any:
+    """Render an enum (or plain value) as its wire string.
+
+    StrEnum members are already ``str`` subclasses, but we normalize to a plain
+    ``str`` so the emitted payload never carries enum instances.
+    """
+    if isinstance(value, Enum):
+        return str(value.value)
+    return str(value)
+
+
+def _cap_str(text: str, max_input_bytes: int) -> str:
+    """Cap a string to ``max_input_bytes`` UTF-8 bytes with a truncation marker.
+
+    Redaction cap: tool inputs may be large and may contain secrets. Capping bounds
+    the payload sent to an external decider (which the operator must trust).
+    """
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_input_bytes:
+        return text
+    truncated = encoded[:max_input_bytes].decode("utf-8", errors="ignore")
+    return f"{truncated}...[truncated {len(encoded)} bytes]"
+
+
+def _json_safe(value: Any, max_input_bytes: int) -> Any:
+    """Recursively coerce ``value`` into a JSON-serializable form.
+
+    Enums are stringified (checked before ``str`` because StrEnum IS a str), string
+    leaves are byte-capped, containers are converted to dict/list, and anything else
+    falls back to a capped ``str(...)`` — so a stray non-serializable object can never
+    reach the wire or crash :func:`json.dumps`.
+    """
+    if isinstance(value, Enum):
+        return _stringify(value)
+    if isinstance(value, str):
+        return _cap_str(value, max_input_bytes)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) or value is None:
+        return value
+    if isinstance(value, (MappingProxyType, dict)):
+        return {str(k): _json_safe(v, max_input_bytes) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_safe(v, max_input_bytes) for v in value]
+    return _cap_str(str(value), max_input_bytes)
+
+
+def _serialize_request(
+    request: "ToolCallRequest", ctx: "GateContext", max_input_bytes: int
+) -> dict[str, Any]:
+    """Build a JSON-safe dict describing the tool call for an external decider.
+
+    Includes the rich policy surface (tool, capped input, target, classification,
+    risk, identity) plus a nested ``context`` block. Enums are stringified.
+
+    CRITICAL: ``event_trace`` (and any other non-JSON-serializable object) is NEVER
+    included — the escape-hatch EventTrace stays in-process. Only the flat, redacted
+    projection crosses the wire.
+    """
+    return {
+        "tool": _stringify(request.tool),
+        "input": _json_safe(request.input, max_input_bytes),
+        "target": request.target,
+        "mechanism": _stringify(request.mechanism),
+        "effect": _stringify(request.effect),
+        "capabilities": [_stringify(c) for c in request.capabilities],
+        "scope": [_stringify(s) for s in request.scope],
+        "role": [_stringify(r) for r in request.role],
+        "action": [_stringify(a) for a in request.action],
+        "risk_score": request.risk_score,
+        "risk_band": _stringify(request.risk_band),
+        "suggested_action": _stringify(request.suggested_action),
+        "reason": request.reason,
+        "session_id": request.session_id,
+        "tool_call_id": request.tool_call_id,
+        "context": {
+            "session_id": ctx.session_id,
+            "tool_call_count": ctx.tool_call_count,
+            "denied_count": ctx.denied_count,
+            "agent_id": ctx.agent_id,
+            "user_id": ctx.user_id,
+        },
+    }
+
+
+def _parse_response(data: Any) -> Verdict:
+    """Map a decoded decider response into a Verdict.
+
+    Contract: ``{"decision": "deny", "reason": "..."}`` -> DENY; anything else -> ALLOW.
+    Liberal in what it accepts: the decision match is case-insensitive, extra fields
+    (e.g. ``score``/``level`` that the built-in gate server also returns) are ignored,
+    and an OPA-style ``{"result": {...}}`` envelope is unwrapped automatically.
+
+    NOTE: this only interprets a *successful* response body. Transport-level failures
+    (timeout, non-2xx, unparseable output) are handled by the gate's fail-open policy,
+    never here.
+    """
+    if not isinstance(data, dict):
+        return Verdict.allow()
+    # Unwrap OPA-style {"result": {...}} envelopes for turnkey integration.
+    if "decision" not in data and isinstance(data.get("result"), dict):
+        data = data["result"]
+    decision = data.get("decision")
+    if isinstance(decision, str) and decision.strip().lower() == "deny":
+        reason = data.get("reason")
+        return Verdict.deny(str(reason) if reason else "denied by external policy")
+    return Verdict.allow()
+
+
+def _fail(fail_open: bool, reason: str) -> Verdict:
+    """Resolve an error/timeout according to the fail-open policy.
+
+    Fail-CLOSED (the default) turns any error into a DENY; fail-open turns it into an
+    ALLOW. See the module docstring for why closed is the safe default.
+    """
+    if fail_open:
+        return Verdict.allow()
+    return Verdict.deny(f"external gate error (fail-closed): {reason}")
+
+
+# ─── Gates ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SubprocessGate:
+    """Preflight gate that shells out to a decider command, once per call.
+
+    The JSON request is written to the process's stdin; the JSON verdict is read from
+    its stdout. Suitable for OPA ``eval``, custom scripts, or air-gapped setups where
+    a persistent HTTP server is undesirable.
+
+    Args:
+        command: The decider command line. Split with :func:`shlex.split` using
+            ``posix=(os.name != 'nt')`` so quoted arguments survive; on Windows this
+            is best-effort (native cmd quoting differs from POSIX).
+        timeout: Per-call wall-clock timeout in seconds.
+        fail_open: If True, ALLOW on any error/timeout/bad output. DEFAULT FALSE
+            (fail-closed = DENY) — a security-critical default; do not flip lightly.
+        max_input_bytes: Per-string cap applied to tool input values before sending.
+    """
+
+    command: str
+    timeout: float = 10.0
+    fail_open: bool = False
+    max_input_bytes: int = 65536
+
+    def __call__(self, request: "ToolCallRequest", ctx: "GateContext") -> Verdict:
+        try:
+            payload = json.dumps(_serialize_request(request, ctx, self.max_input_bytes))
+        except Exception as exc:  # serialization must never crash the caller
+            return _fail(
+                self.fail_open, f"request serialization failed: {type(exc).__name__}: {exc}"
+            )
+
+        try:
+            argv = shlex.split(self.command, posix=(os.name != "nt"))
+        except ValueError as exc:
+            return _fail(self.fail_open, f"invalid command: {exc}")
+        if not argv:
+            return _fail(self.fail_open, "empty command")
+
+        try:
+            proc = subprocess.run(
+                argv,
+                input=payload,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return _fail(self.fail_open, f"decider timed out after {self.timeout}s")
+        except (OSError, ValueError) as exc:
+            return _fail(self.fail_open, f"decider failed to launch: {type(exc).__name__}: {exc}")
+        except Exception as exc:  # airtight: never propagate to the framework
+            return _fail(self.fail_open, f"decider error: {type(exc).__name__}: {exc}")
+
+        if proc.returncode != 0:
+            stderr = (proc.stderr or "").strip()[:200]
+            return _fail(self.fail_open, f"decider exited {proc.returncode}: {stderr}")
+
+        try:
+            data = json.loads(proc.stdout)
+        except (ValueError, TypeError) as exc:
+            return _fail(self.fail_open, f"unparseable decider stdout: {type(exc).__name__}")
+
+        return _parse_response(data)
+
+
+@dataclass
+class HttpGate:
+    """Preflight gate that POSTs the request to a persistent HTTP PDP.
+
+    Recommended mode: a long-lived server (e.g. OPA REST) avoids per-call process
+    spawn cost. Uses stdlib ``urllib.request`` only — no new dependencies.
+
+    Args:
+        endpoint: Absolute URL of the decision endpoint.
+        timeout: Per-request timeout in seconds.
+        fail_open: If True, ALLOW on any error/timeout/non-2xx. DEFAULT FALSE
+            (fail-closed = DENY) — a security-critical default; do not flip lightly.
+        headers: Extra headers merged over ``Content-Type: application/json`` (e.g.
+            an ``Authorization`` bearer token for the PDP).
+        max_input_bytes: Per-string cap applied to tool input values before sending.
+    """
+
+    endpoint: str
+    timeout: float = 2.0
+    fail_open: bool = False
+    headers: dict[str, str] | None = None
+    max_input_bytes: int = 65536
+
+    def __call__(self, request: "ToolCallRequest", ctx: "GateContext") -> Verdict:
+        try:
+            body = json.dumps(_serialize_request(request, ctx, self.max_input_bytes)).encode(
+                "utf-8"
+            )
+        except Exception as exc:  # serialization must never crash the caller
+            return _fail(
+                self.fail_open, f"request serialization failed: {type(exc).__name__}: {exc}"
+            )
+
+        headers = {"Content-Type": "application/json"}
+        if self.headers:
+            headers.update(self.headers)
+        req = urllib.request.Request(self.endpoint, data=body, headers=headers, method="POST")
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                status = getattr(resp, "status", None)
+                if status is None:
+                    status = resp.getcode()
+                raw = resp.read()
+        except urllib.error.HTTPError as exc:
+            return _fail(self.fail_open, f"policy endpoint returned HTTP {exc.code}")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            reason = getattr(exc, "reason", exc)
+            return _fail(self.fail_open, f"policy endpoint unreachable: {reason}")
+        except Exception as exc:  # airtight: never propagate to the framework
+            return _fail(self.fail_open, f"policy call failed: {type(exc).__name__}: {exc}")
+
+        if status is not None and not (200 <= int(status) < 300):
+            return _fail(self.fail_open, f"policy endpoint returned HTTP {status}")
+
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (ValueError, TypeError, UnicodeDecodeError) as exc:
+            return _fail(self.fail_open, f"invalid JSON from policy endpoint: {type(exc).__name__}")
+
+        return _parse_response(data)

--- a/src/traceforge/governance/pipeline.py
+++ b/src/traceforge/governance/pipeline.py
@@ -6,6 +6,7 @@ Wires the governance collaborator graph and forwards the public API to them
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from traceforge.governance.assessor import DefaultAssessor
@@ -208,7 +209,7 @@ class GovernancePipeline:
 
         instance = cls.create(config.governance)
 
-        # Resolve policy: explicit arg > config dotted path > None
+        # Resolve policy: explicit arg > config dotted path > config external gate > None
         if policy is not None:
             instance.policy = policy
         elif config.governance.tool_preflight_gate:
@@ -217,6 +218,27 @@ class GovernancePipeline:
             gate_fn = _import_dotted(config.governance.tool_preflight_gate)
             auto_policy = GatePolicy().preflight(gate_fn)
             instance.policy = auto_policy
+        elif config.governance.preflight_gate is not None:
+            from traceforge.gate.external import HttpGate, SubprocessGate
+            from traceforge.sdk.gate_policy import GatePolicy
+
+            gate_cfg = config.governance.preflight_gate
+            if gate_cfg.type == "http":
+                gate_fn = HttpGate(
+                    endpoint=gate_cfg.endpoint,
+                    timeout=gate_cfg.timeout,
+                    fail_open=gate_cfg.fail_open,
+                    headers=dict(gate_cfg.headers) if gate_cfg.headers else None,
+                    max_input_bytes=gate_cfg.max_input_bytes,
+                )
+            else:  # gate_cfg.type == "subprocess"
+                gate_fn = SubprocessGate(
+                    command=gate_cfg.command,
+                    timeout=gate_cfg.timeout,
+                    fail_open=gate_cfg.fail_open,
+                    max_input_bytes=gate_cfg.max_input_bytes,
+                )
+            instance.policy = GatePolicy().preflight(gate_fn)
 
         return instance
 
@@ -559,7 +581,7 @@ class GovernancePipeline:
                 "tool_input": dict(context.arguments) if context.arguments else {},
                 "session_id": sid,
             }
-            trace, verdict = pipeline._score_and_gate_preflight(payload)
+            trace, verdict = await asyncio.to_thread(pipeline._score_and_gate_preflight, payload)
             if verdict.denied:
                 from semantic_kernel.functions import FunctionResult
 
@@ -618,7 +640,9 @@ class GovernancePipeline:
                     "session_id": sid,
                     "tool_call_id": getattr(context, "call_id", None),
                 }
-                trace, verdict = pipeline._score_and_gate_preflight(payload)
+                trace, verdict = await asyncio.to_thread(
+                    pipeline._score_and_gate_preflight, payload
+                )
                 if verdict.denied:
                     raise MiddlewareTermination(f"Denied: {verdict.reason}")
 
@@ -744,7 +768,9 @@ class GovernancePipeline:
                     "session_id": sid,
                     "tool_call_id": getattr(ctx, "tool_call_id", None),
                 }
-                trace, verdict = pipeline._score_and_gate_preflight(payload)
+                trace, verdict = await asyncio.to_thread(
+                    pipeline._score_and_gate_preflight, payload
+                )
                 if verdict.denied:
                     raise RuntimeError(f"Denied: {verdict.reason}")
 
@@ -797,7 +823,7 @@ class GovernancePipeline:
                 "tool_input": getattr(input_data, "tool_input", {}),
                 "session_id": sid,
             }
-            trace, verdict = pipeline._score_and_gate_preflight(payload)
+            trace, verdict = await asyncio.to_thread(pipeline._score_and_gate_preflight, payload)
             if verdict.denied:
                 return GuardrailFunctionOutput(
                     output_info=verdict.reason,

--- a/tests/unit/test_external_gate_config.py
+++ b/tests/unit/test_external_gate_config.py
@@ -1,0 +1,282 @@
+"""Config-surface + wiring tests for external preflight gates.
+
+Covers:
+
+* the discriminated ``preflight_gate`` union parses ``http`` / ``subprocess`` into
+  the right config class;
+* the mutually-exclusive validator fires when both ``tool_preflight_gate`` and
+  ``preflight_gate`` are set;
+* :meth:`GovernancePipeline.from_config` builds a ``GatePolicy`` whose single
+  preflight gate is the right gate class with fields propagated;
+* the async correctness fix: a DENY from a gate still blocks an ``async`` adapter
+  (Semantic Kernel) the same way as before, now routed through
+  ``asyncio.to_thread``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+import traceforge.config as config_pkg
+from traceforge.config import (
+    ExternalGateConfig,
+    GovernanceConfig,
+    HttpGateConfig,
+    SubprocessGateConfig,
+)
+from traceforge.gate.external import HttpGate, SubprocessGate
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.verdict import Verdict
+
+
+# ─── Package re-export ────────────────────────────────────────────────────────
+
+
+def test_config_classes_reexported_from_package():
+    for name in ("ExternalGateConfig", "HttpGateConfig", "SubprocessGateConfig"):
+        assert name in config_pkg.__all__
+    assert ExternalGateConfig is not None
+
+
+# ─── Discriminated union parsing ──────────────────────────────────────────────
+
+
+class TestExternalGateConfigParsing:
+    def test_http_variant(self):
+        gov = GovernanceConfig.model_validate(
+            {
+                "preflight_gate": {
+                    "type": "http",
+                    "endpoint": "http://localhost:8181/v1/data/tf/allow",
+                    "headers": {"Authorization": "Bearer x"},
+                    "timeout": 1.5,
+                }
+            }
+        )
+        assert isinstance(gov.preflight_gate, HttpGateConfig)
+        assert gov.preflight_gate.endpoint.endswith("/allow")
+        assert gov.preflight_gate.fail_open is False  # fail-closed default
+        assert gov.preflight_gate.headers == {"Authorization": "Bearer x"}
+
+    def test_subprocess_variant(self):
+        gov = GovernanceConfig.model_validate(
+            {"preflight_gate": {"type": "subprocess", "command": "opa eval"}}
+        )
+        assert isinstance(gov.preflight_gate, SubprocessGateConfig)
+        assert gov.preflight_gate.command == "opa eval"
+        assert gov.preflight_gate.fail_open is False
+        assert gov.preflight_gate.timeout == 10.0
+
+    def test_unknown_type_rejected(self):
+        with pytest.raises(ValidationError):
+            GovernanceConfig.model_validate(
+                {"preflight_gate": {"type": "carrier-pigeon", "endpoint": "x"}}
+            )
+
+    def test_extra_field_forbidden(self):
+        with pytest.raises(ValidationError):
+            GovernanceConfig.model_validate(
+                {"preflight_gate": {"type": "http", "endpoint": "x", "bogus": 1}}
+            )
+
+    def test_nonpositive_timeout_rejected(self):
+        with pytest.raises(ValidationError):
+            GovernanceConfig.model_validate(
+                {"preflight_gate": {"type": "http", "endpoint": "x", "timeout": 0}}
+            )
+
+
+# ─── Mutual-exclusion validator ───────────────────────────────────────────────
+
+
+class TestPreflightGateExclusivity:
+    def test_both_set_raises(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            GovernanceConfig.model_validate(
+                {
+                    "tool_preflight_gate": "myapp.policies.gate",
+                    "preflight_gate": {"type": "http", "endpoint": "http://pdp"},
+                }
+            )
+
+    def test_only_dotted_path_ok(self):
+        gov = GovernanceConfig.model_validate({"tool_preflight_gate": "myapp.policies.gate"})
+        assert gov.preflight_gate is None
+        assert gov.tool_preflight_gate == "myapp.policies.gate"
+
+    def test_only_external_ok(self):
+        gov = GovernanceConfig.model_validate(
+            {"preflight_gate": {"type": "subprocess", "command": "decider"}}
+        )
+        assert gov.tool_preflight_gate is None
+        assert isinstance(gov.preflight_gate, SubprocessGateConfig)
+
+    def test_neither_set_ok(self):
+        gov = GovernanceConfig()
+        assert gov.preflight_gate is None
+        assert gov.tool_preflight_gate is None
+
+
+# ─── from_config wiring (builds a real gate instance) ─────────────────────────
+
+
+class TestFromConfigWiring:
+    def _write(self, tmp_path, governance: dict) -> str:
+        cfg = tmp_path / "traceforge.yaml"
+        cfg.write_text(yaml.safe_dump({"governance": governance}))
+        return str(cfg)
+
+    def test_http_gate_built(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            {
+                "preflight_gate": {
+                    "type": "http",
+                    "endpoint": "http://localhost:8181/decide",
+                    "fail_open": True,
+                    "timeout": 3.0,
+                    "headers": {"Authorization": "Bearer tok"},
+                }
+            },
+        )
+        pipeline = GovernancePipeline.from_config(path=path)
+        gates = pipeline.policy.preflight_gates
+        assert len(gates) == 1
+        gate = gates[0]
+        assert isinstance(gate, HttpGate)
+        assert gate.endpoint == "http://localhost:8181/decide"
+        assert gate.fail_open is True
+        assert gate.timeout == 3.0
+        assert gate.headers == {"Authorization": "Bearer tok"}
+
+    def test_subprocess_gate_built(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            {
+                "preflight_gate": {
+                    "type": "subprocess",
+                    "command": 'decider --mode "two words"',
+                    "max_input_bytes": 1024,
+                }
+            },
+        )
+        pipeline = GovernancePipeline.from_config(path=path)
+        gates = pipeline.policy.preflight_gates
+        assert len(gates) == 1
+        gate = gates[0]
+        assert isinstance(gate, SubprocessGate)
+        assert gate.command == 'decider --mode "two words"'
+        assert gate.max_input_bytes == 1024
+        assert gate.fail_open is False  # fail-closed default survives round-trip
+
+    def test_explicit_policy_overrides_config(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            {"preflight_gate": {"type": "subprocess", "command": "decider"}},
+        )
+        override = GatePolicy().preflight(lambda request, ctx: Verdict.allow())
+        pipeline = GovernancePipeline.from_config(path=path, policy=override)
+        assert pipeline.policy is override
+        assert not isinstance(pipeline.policy.preflight_gates[0], SubprocessGate)
+
+    def test_both_set_in_yaml_raises(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            {
+                "tool_preflight_gate": "myapp.policies.gate",
+                "preflight_gate": {"type": "http", "endpoint": "http://pdp"},
+            },
+        )
+        with pytest.raises(ValidationError):
+            GovernancePipeline.from_config(path=path)
+
+
+# ─── Async correctness fix (behavior preserved through asyncio.to_thread) ─────
+
+
+class TestAsyncAdapterOffload:
+    """The async fix wraps the sync preflight call in ``asyncio.to_thread``.
+
+    SK's ``auto_function_invocation`` filter only fires during LLM auto-calling,
+    not on a direct ``kernel.invoke()`` (that is why the e2e suite's DENY test only
+    checks filter registration). So we retrieve the registered async filter and
+    drive its coroutine directly, inside a real event loop, against a fake context.
+    This exercises the exact code path that now offloads via ``asyncio.to_thread``.
+    """
+
+    def _register_and_get_filter(self, pipeline):
+        from semantic_kernel import Kernel
+        from semantic_kernel.functions import kernel_function
+
+        kernel = Kernel()
+
+        @kernel_function(name="rm", description="Remove a file")
+        def rm(path: str) -> str:
+            return f"removed {path}"
+
+        kernel.add_function("tools", rm)
+        pipeline.gate_semantic_kernel(kernel)
+        _priority, filt = kernel.auto_function_invocation_filters[0]
+        func = kernel.get_function("tools", "rm")
+        return filt, func
+
+    def test_semantic_kernel_deny_blocks_and_preserves_reason(self):
+        pytest.importorskip("semantic_kernel")
+        from types import SimpleNamespace
+
+        def deny_rm(request, ctx) -> Verdict:
+            if request.tool == "rm":
+                return Verdict.deny("blocked rm")
+            return Verdict.allow()
+
+        pipeline = GovernancePipeline.create()
+        pipeline.policy = GatePolicy().preflight(deny_rm)
+        filt, func = self._register_and_get_filter(pipeline)
+
+        next_called = {"v": False}
+
+        async def next_handler(ctx):
+            next_called["v"] = True
+
+        ctx = SimpleNamespace(
+            function=func,
+            arguments={"path": "/tmp/x"},
+            function_result=None,
+            terminate=False,
+        )
+        asyncio.run(filt(ctx, next_handler))
+
+        assert next_called["v"] is False  # denied → next_handler never awaited
+        assert ctx.terminate is True
+        assert "Tool blocked by policy" in str(ctx.function_result.value)
+        assert "blocked rm" in str(ctx.function_result.value)
+
+    def test_semantic_kernel_allow_runs_next_handler(self):
+        pytest.importorskip("semantic_kernel")
+        from types import SimpleNamespace
+
+        pipeline = GovernancePipeline.create()
+        pipeline.policy = GatePolicy().preflight(lambda request, ctx: Verdict.allow())
+        filt, func = self._register_and_get_filter(pipeline)
+
+        next_called = {"v": False}
+
+        async def next_handler(ctx):
+            next_called["v"] = True
+            ctx.function_result = SimpleNamespace(value="removed /tmp/x")
+
+        ctx = SimpleNamespace(
+            function=func,
+            arguments={"path": "/tmp/x"},
+            function_result=None,
+            terminate=False,
+        )
+        asyncio.run(filt(ctx, next_handler))
+
+        assert next_called["v"] is True  # allowed → next_handler awaited
+        assert ctx.terminate is False

--- a/tests/unit/test_external_gates.py
+++ b/tests/unit/test_external_gates.py
@@ -1,0 +1,382 @@
+"""Unit tests for external preflight gates (HttpGate, SubprocessGate).
+
+All I/O is mocked — no real network or subprocess is ever touched. Focus areas:
+
+* serialization safety: ``event_trace`` (and other non-JSON objects) never reach
+  the wire, tool-input strings are byte-capped, enums become plain strings;
+* response parsing: liberal/case-insensitive decision handling, OPA envelope
+  unwrapping, extra fields ignored;
+* fail-CLOSED-by-default error handling for timeouts, non-2xx, non-zero exit,
+  and unparseable output.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import urllib.error
+import urllib.request
+from types import MappingProxyType
+
+from traceforge._generated import (
+    Action,
+    Capability,
+    Effect,
+    Mechanism,
+    Recommendation,
+    RiskBand,
+    Role,
+    Scope,
+)
+from traceforge.gate.external import (
+    HttpGate,
+    SubprocessGate,
+    _parse_response,
+    _serialize_request,
+)
+from traceforge.sdk.gate_types import GateContext, ToolCallRequest
+
+
+# ─── Builders ─────────────────────────────────────────────────────────────────
+
+
+class _Unserializable:
+    """Stand-in for EventTrace: NOT json-serializable and carries a unique marker.
+
+    If this ever leaked onto the wire (directly or via a ``str(...)`` fallback) the
+    marker would appear in the serialized payload, failing the exclusion tests.
+    """
+
+    MARKER = "SENTINEL_EVENT_TRACE_9d1f7a"
+
+    def __repr__(self) -> str:  # pragma: no cover - only hit if leaked
+        return self.MARKER
+
+
+def make_request(*, tool: str = "shell", tool_input=None, **overrides) -> ToolCallRequest:
+    data = {"cmd": "rm -rf /tmp/x", "flag": True} if tool_input is None else tool_input
+    fields = dict(
+        tool=tool,
+        input=MappingProxyType(dict(data)),
+        target="/tmp/x",
+        mechanism=Mechanism.process_shell,
+        effect=Effect.destructive,
+        capabilities=(Capability.subprocess, Capability.filesystem_write),
+        scope=(Scope.system_os,),
+        role=(Role.executor_script_runner,),
+        action=(Action.remove_delete,),
+        risk_score=87,
+        risk_band=RiskBand.danger,
+        suggested_action=Recommendation.deny,
+        reason="destructive shell command",
+        session_id="sess-1",
+        tool_call_id="call-1",
+        event_trace=_Unserializable(),
+    )
+    fields.update(overrides)
+    return ToolCallRequest(**fields)
+
+
+def make_ctx(**overrides) -> GateContext:
+    fields = dict(
+        session_id="sess-1",
+        tool_call_count=2,
+        denied_count=1,
+        agent_id="agent-A",
+        user_id="user-Z",
+    )
+    fields.update(overrides)
+    return GateContext(**fields)
+
+
+# ─── _serialize_request ───────────────────────────────────────────────────────
+
+
+class TestSerializeRequest:
+    def test_event_trace_never_on_the_wire(self):
+        payload = _serialize_request(make_request(), make_ctx(), 65536)
+        assert "event_trace" not in payload
+        blob = json.dumps(payload)  # must not raise
+        assert _Unserializable.MARKER not in blob
+
+    def test_payload_is_json_dumpable_and_round_trips(self):
+        payload = _serialize_request(make_request(), make_ctx(), 65536)
+        assert json.loads(json.dumps(payload))["tool"] == "shell"
+
+    def test_enums_are_stringified_to_plain_str(self):
+        payload = _serialize_request(make_request(), make_ctx(), 65536)
+        assert payload["mechanism"] == Mechanism.process_shell.value
+        assert type(payload["mechanism"]) is str
+        assert payload["effect"] == Effect.destructive.value
+        assert payload["risk_band"] == RiskBand.danger.value
+        assert payload["suggested_action"] == Recommendation.deny.value
+        assert payload["capabilities"] == [
+            Capability.subprocess.value,
+            Capability.filesystem_write.value,
+        ]
+        assert all(type(c) is str for c in payload["capabilities"])
+
+    def test_long_input_string_capped_with_marker(self):
+        big = "A" * 100_000
+        payload = _serialize_request(make_request(tool_input={"blob": big}), make_ctx(), 64)
+        capped = payload["input"]["blob"]
+        assert "[truncated 100000 bytes]" in capped
+        # capped body is bounded by the cap plus a short marker
+        assert len(capped.encode("utf-8")) < 200
+
+    def test_nonserializable_input_value_does_not_crash(self):
+        payload = _serialize_request(
+            make_request(tool_input={"weird": object()}), make_ctx(), 65536
+        )
+        json.dumps(payload)  # must not raise
+        assert isinstance(payload["input"]["weird"], str)
+
+    def test_context_block_projection_only(self):
+        payload = _serialize_request(make_request(), make_ctx(), 65536)
+        assert payload["context"] == {
+            "session_id": "sess-1",
+            "tool_call_count": 2,
+            "denied_count": 1,
+            "agent_id": "agent-A",
+            "user_id": "user-Z",
+        }
+        # prior_verdicts / policy / event_trace must not leak into context
+        assert "prior_verdicts" not in payload["context"]
+        assert "policy" not in payload["context"]
+
+
+# ─── _parse_response ──────────────────────────────────────────────────────────
+
+
+class TestParseResponse:
+    def test_deny_with_reason(self):
+        v = _parse_response({"decision": "deny", "reason": "blocked by OPA"})
+        assert v.denied
+        assert v.reason == "blocked by OPA"
+
+    def test_deny_case_insensitive_ignores_extra_fields(self):
+        v = _parse_response({"decision": "DENY", "score": 91, "level": "danger"})
+        assert v.denied
+
+    def test_deny_without_reason_has_default(self):
+        v = _parse_response({"decision": "deny"})
+        assert v.denied
+        assert v.reason  # non-empty default
+
+    def test_allow_explicit(self):
+        assert not _parse_response({"decision": "allow"}).denied
+
+    def test_allow_on_garbage_or_missing_decision(self):
+        assert not _parse_response("nonsense").denied
+        assert not _parse_response({}).denied
+        assert not _parse_response({"foo": "bar"}).denied
+
+    def test_opa_result_envelope_unwrapped(self):
+        v = _parse_response({"result": {"decision": "deny", "reason": "opa said no"}})
+        assert v.denied
+        assert v.reason == "opa said no"
+
+
+# ─── HttpGate ─────────────────────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, body, status: int = 200):
+        self._body = body.encode("utf-8") if isinstance(body, str) else body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+    def getcode(self):
+        return self.status
+
+
+class TestHttpGate:
+    def _patch_urlopen(self, monkeypatch, fn):
+        monkeypatch.setattr(urllib.request, "urlopen", fn)
+
+    def test_allow(self, monkeypatch):
+        self._patch_urlopen(
+            monkeypatch, lambda req, timeout=None: _FakeResp('{"decision": "allow"}')
+        )
+        gate = HttpGate(endpoint="http://pdp/decide")
+        assert not gate(make_request(), make_ctx()).denied
+
+    def test_deny_reason_propagates(self, monkeypatch):
+        self._patch_urlopen(
+            monkeypatch,
+            lambda req, timeout=None: _FakeResp('{"decision": "deny", "reason": "policy X"}'),
+        )
+        v = HttpGate(endpoint="http://pdp/decide")(make_request(), make_ctx())
+        assert v.denied
+        assert v.reason == "policy X"
+
+    def test_non_2xx_fail_closed_denies(self, monkeypatch):
+        def boom(req, timeout=None):
+            raise urllib.error.HTTPError("http://pdp/decide", 500, "err", None, io.BytesIO(b""))
+
+        self._patch_urlopen(monkeypatch, boom)
+        assert HttpGate(endpoint="http://pdp/decide")(make_request(), make_ctx()).denied
+
+    def test_non_2xx_fail_open_allows(self, monkeypatch):
+        def boom(req, timeout=None):
+            raise urllib.error.HTTPError("http://pdp/decide", 503, "err", None, io.BytesIO(b""))
+
+        self._patch_urlopen(monkeypatch, boom)
+        gate = HttpGate(endpoint="http://pdp/decide", fail_open=True)
+        assert not gate(make_request(), make_ctx()).denied
+
+    def test_timeout_fail_closed_denies(self, monkeypatch):
+        def boom(req, timeout=None):
+            raise TimeoutError("timed out")
+
+        self._patch_urlopen(monkeypatch, boom)
+        assert HttpGate(endpoint="http://pdp/decide")(make_request(), make_ctx()).denied
+
+    def test_timeout_fail_open_allows(self, monkeypatch):
+        def boom(req, timeout=None):
+            raise TimeoutError("timed out")
+
+        self._patch_urlopen(monkeypatch, boom)
+        gate = HttpGate(endpoint="http://pdp/decide", fail_open=True)
+        assert not gate(make_request(), make_ctx()).denied
+
+    def test_bad_json_fail_closed_denies(self, monkeypatch):
+        self._patch_urlopen(monkeypatch, lambda req, timeout=None: _FakeResp("not-json{"))
+        assert HttpGate(endpoint="http://pdp/decide")(make_request(), make_ctx()).denied
+
+    def test_bad_json_fail_open_allows(self, monkeypatch):
+        self._patch_urlopen(monkeypatch, lambda req, timeout=None: _FakeResp("not-json{"))
+        gate = HttpGate(endpoint="http://pdp/decide", fail_open=True)
+        assert not gate(make_request(), make_ctx()).denied
+
+    def test_custom_headers_and_body_sent(self, monkeypatch):
+        captured = {}
+
+        def capture(req, timeout=None):
+            captured["req"] = req
+            return _FakeResp('{"decision": "allow"}')
+
+        self._patch_urlopen(monkeypatch, capture)
+        gate = HttpGate(
+            endpoint="http://pdp/decide",
+            headers={"Authorization": "Bearer tok-123"},
+        )
+        gate(make_request(), make_ctx())
+        req = captured["req"]
+        # get_header normalizes case, so this is robust to urllib capitalization
+        assert req.get_header("Authorization") == "Bearer tok-123"
+        assert req.get_header("Content-type") == "application/json"
+        assert req.get_method() == "POST"
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["tool"] == "shell"
+        assert "event_trace" not in body
+
+
+# ─── SubprocessGate ───────────────────────────────────────────────────────────
+
+
+class TestSubprocessGate:
+    def test_allow_and_payload_piped_to_stdin(self, monkeypatch):
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            captured["input"] = kwargs.get("input")
+            return subprocess.CompletedProcess(argv, 0, '{"decision": "allow"}', "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        gate = SubprocessGate(command="decider")
+        assert not gate(make_request(), make_ctx()).denied
+        piped = json.loads(captured["input"])
+        assert piped["tool"] == "shell"
+        assert "event_trace" not in piped
+
+    def test_deny_reason_from_stdout(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda argv, **kw: subprocess.CompletedProcess(
+                argv, 0, '{"decision": "deny", "reason": "nope"}', ""
+            ),
+        )
+        v = SubprocessGate(command="decider")(make_request(), make_ctx())
+        assert v.denied
+        assert v.reason == "nope"
+
+    def test_nonzero_exit_fail_closed_denies(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda argv, **kw: subprocess.CompletedProcess(argv, 3, "", "boom"),
+        )
+        assert SubprocessGate(command="decider")(make_request(), make_ctx()).denied
+
+    def test_nonzero_exit_fail_open_allows(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda argv, **kw: subprocess.CompletedProcess(argv, 3, "", "boom"),
+        )
+        gate = SubprocessGate(command="decider", fail_open=True)
+        assert not gate(make_request(), make_ctx()).denied
+
+    def test_timeout_fail_closed_denies(self, monkeypatch):
+        def boom(argv, **kw):
+            raise subprocess.TimeoutExpired(argv, 10.0)
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        assert SubprocessGate(command="decider")(make_request(), make_ctx()).denied
+
+    def test_timeout_fail_open_allows(self, monkeypatch):
+        def boom(argv, **kw):
+            raise subprocess.TimeoutExpired(argv, 10.0)
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        gate = SubprocessGate(command="decider", fail_open=True)
+        assert not gate(make_request(), make_ctx()).denied
+
+    def test_unparseable_stdout_fail_closed_denies(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda argv, **kw: subprocess.CompletedProcess(argv, 0, "not-json{", ""),
+        )
+        assert SubprocessGate(command="decider")(make_request(), make_ctx()).denied
+
+    def test_unparseable_stdout_fail_open_allows(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda argv, **kw: subprocess.CompletedProcess(argv, 0, "not-json{", ""),
+        )
+        gate = SubprocessGate(command="decider", fail_open=True)
+        assert not gate(make_request(), make_ctx()).denied
+
+    def test_shlex_preserves_quoted_argument(self, monkeypatch):
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return subprocess.CompletedProcess(argv, 0, '{"decision": "allow"}', "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        gate = SubprocessGate(command='decider --mode "two words"')
+        gate(make_request(), make_ctx())
+        argv = captured["argv"]
+        # naive str.split() would yield 4 tokens (splitting the quoted phrase);
+        # shlex keeps it as ONE token. Quote-stripping itself differs by platform
+        # (posix strips, Windows non-posix is best-effort and keeps them), so we
+        # assert structurally rather than on the exact quote characters.
+        assert len(argv) == 3
+        assert argv[0] == "decider"
+        assert argv[1] == "--mode"
+        assert "two words" in argv[2]

--- a/website/docs/reference/external-gating.md
+++ b/website/docs/reference/external-gating.md
@@ -1,0 +1,185 @@
+---
+id: external-gating
+title: External Preflight Gating
+sidebar_label: External Gating
+description: Delegate tool-call ALLOW/DENY decisions to an out-of-process HTTP or subprocess Policy Decision Point, configured entirely from YAML.
+---
+
+# External Preflight Gating
+
+In-process gating registers a Python `GatePolicy` (see
+[The Gate](../governance/gate.md)). **External** preflight gating moves the ALLOW/DENY
+decision *out of process* to a Policy Decision Point (PDP) you run — so gating can be
+configured entirely from YAML, with no Python.
+
+Two gate types are available, both selected under `governance.preflight_gate`:
+
+| `type` | Transport | Use when |
+| --- | --- | --- |
+| `http` | POST JSON to a persistent HTTP PDP (e.g. an [OPA](https://www.openpolicyagent.org/) REST server) | **Recommended.** A long-lived server avoids per-call process spawn cost. |
+| `subprocess` | Spawn a command per call; JSON request on **stdin**, JSON verdict on **stdout** | Portable / air-gapped, or driving `opa eval` without a server. |
+
+Both implement the same synchronous `PreflightGate` contract as in-process gates, so
+they slot into the existing preflight chain with no framework-adapter changes.
+
+## Configuration
+
+`governance.preflight_gate` is a discriminated union keyed on `type`. It is **mutually
+exclusive** with `governance.tool_preflight_gate` (the dotted-path, in-process form):
+setting both raises a configuration error at load time.
+
+### HTTP PDP
+
+```yaml
+governance:
+  preflight_gate:
+    type: http
+    endpoint: http://localhost:8181/v1/data/traceforge/verdict
+    timeout: 2.0            # seconds
+    fail_open: false        # false = fail-closed (DENY on any error). Keep false.
+    headers:                # optional — merged over Content-Type: application/json
+      Authorization: "Bearer ${PDP_TOKEN}"
+    max_input_bytes: 65536  # per-string cap on tool input before it is sent
+```
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `endpoint` | string | — (required) | Absolute URL of the decision endpoint. |
+| `timeout` | float | `2.0` | Per-request timeout, seconds (`> 0`). |
+| `fail_open` | bool | `false` | `false` = DENY on error/timeout/non-2xx. See [Fail-closed](#fail-closed-by-default). |
+| `headers` | map | `{}` | Extra request headers (e.g. auth tokens). |
+| `max_input_bytes` | int | `65536` | Per-string redaction cap (`> 0`). |
+
+The request is sent with `Content-Type: application/json`; any configured `headers` are
+merged on top. A non-2xx response, timeout, connection error, or unparseable body is an
+error and is resolved by `fail_open`.
+
+### Subprocess decider
+
+```yaml
+governance:
+  preflight_gate:
+    type: subprocess
+    command: "opa eval -I -f raw data.traceforge.verdict"
+    timeout: 10.0
+    fail_open: false
+    max_input_bytes: 65536
+```
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `command` | string | — (required) | Command line for the decider. |
+| `timeout` | float | `10.0` | Per-call timeout, seconds (`> 0`). |
+| `fail_open` | bool | `false` | `false` = DENY on error/timeout/non-zero exit/bad output. |
+| `max_input_bytes` | int | `65536` | Per-string redaction cap (`> 0`). |
+
+The JSON request is written to the process's **stdin**; the JSON verdict is read from
+its **stdout**. A non-zero exit, timeout, or unparseable stdout is an error resolved by
+`fail_open`.
+
+`command` is split with `shlex` (POSIX rules on Unix, so quoted arguments survive). On
+Windows, quoting is best-effort because native command quoting differs from POSIX — pass
+a simple, unquoted command line there where possible.
+
+## Wire contract
+
+### Request (traceforge → decider)
+
+A JSON object describing the assessed tool call. Enums are stringified; the full
+`EventTrace` escape hatch is **never** serialized. Example:
+
+```json
+{
+  "tool": "shell",
+  "input": { "command": "rm -rf /tmp/build" },
+  "target": "/tmp/build",
+  "mechanism": "process.shell",
+  "effect": "destructive",
+  "capabilities": ["subprocess", "filesystem_write"],
+  "scope": ["system.os"],
+  "role": ["executor.script_runner"],
+  "action": ["remove.delete"],
+  "risk_score": 78,
+  "risk_band": "danger",
+  "suggested_action": "deny",
+  "reason": "destructive shell command",
+  "session_id": "sess-123",
+  "tool_call_id": "call-456",
+  "context": {
+    "session_id": "sess-123",
+    "tool_call_count": 12,
+    "denied_count": 1,
+    "agent_id": null,
+    "user_id": null
+  }
+}
+```
+
+### Response (decider → traceforge)
+
+```json
+{ "decision": "deny", "reason": "destructive command blocked" }
+```
+
+- `decision` is matched **case-insensitively**. `"deny"` → DENY (with `reason`
+  propagated to the model); **anything else → ALLOW**.
+- Extra fields (e.g. `score`, `level`) are ignored, so traceforge's own score-server
+  response shape works as-is.
+- An OPA-style envelope `{ "result": { "decision": "deny", "reason": "..." } }` is
+  unwrapped automatically.
+
+## Fail-closed by default
+
+`fail_open` defaults to **`false`** on both gate types. When the decider errors, times
+out, returns a non-2xx status / non-zero exit, or emits unparseable output, the call is
+**DENIED**. This is deliberate: a gate that fails *open* silently disables enforcement
+at exactly the moment something is wrong, which is a security anti-pattern.
+
+Set `fail_open: true` only when availability outranks safety for your deployment and you
+have consciously accepted that a broken decider means unfiltered tool calls.
+
+## Input redaction cap
+
+Each string value in `input` is capped to `max_input_bytes` UTF-8 bytes (with a
+truncation marker) before being sent. This bounds payload size and limits how much raw
+tool input leaves the process.
+
+:::warning Trust the decider
+`input` can contain secrets (arguments, file contents, tokens). It crosses the wire to
+your PDP, so run the decider on a **trusted** endpoint/host and secure the transport
+(TLS, network policy, auth headers). The `max_input_bytes` cap reduces but does not
+eliminate exposure.
+:::
+
+## Worked example: OPA
+
+Run [OPA](https://www.openpolicyagent.org/) as an HTTP PDP with a rule whose document is
+the verdict:
+
+```rego
+package traceforge
+
+import rego.v1
+
+# Default allow; deny destructive shell calls.
+verdict := {"decision": "deny", "reason": "destructive shell blocked"} if {
+    input.mechanism == "process.shell"
+    input.effect == "destructive"
+} else := {"decision": "allow"}
+```
+
+```bash
+opa run --server ./traceforge.rego
+```
+
+```yaml
+governance:
+  preflight_gate:
+    type: http
+    endpoint: http://localhost:8181/v1/data/traceforge/verdict
+    fail_open: false
+```
+
+OPA wraps the document as `{ "result": { "decision": ... } }`; traceforge unwraps the
+`result` envelope, so no glue code is needed. For an air-gapped setup, swap the HTTP gate
+for a `subprocess` gate driving `opa eval` against the same policy.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -42,6 +42,7 @@ const sidebars = {
         'reference/pipeline',
         'reference/sinks',
         'reference/live-structuring',
+        'reference/external-gating',
         'reference/sdk',
       ],
     },


### PR DESCRIPTION
## Summary

Makes PREFLIGHT tool-call gating configurable **out-of-process and YAML-native**. Two new gates delegate the ALLOW/DENY decision to an external Policy Decision Point (PDP) instead of an in-process Python callback. Both satisfy the existing sync `PreflightGate` protocol, so they plug into `GatePolicy` with **zero framework-adapter changes**:

- **`HttpGate`** (recommended) — POSTs a JSON request to a persistent HTTP PDP (e.g. an OPA REST server) via stdlib `urllib` and reads a verdict.
- **`SubprocessGate`** — spawns a decider command per call, writing the JSON request to stdin and reading the JSON verdict from stdout (OPA `eval` / air-gapped friendly).

Plus a correctness fix so the 4 async framework adapters don't block the event loop when a gate does I/O.

### Security posture (airtight)
- **Fail-CLOSED by default** (`fail_open=False`): any error, timeout, non-2xx, non-zero exit, or unparseable output → **DENY**. Failing open on error is a security anti-pattern; the safe default is non-negotiable and documented.
- **`event_trace` (and any non-JSON object) is NEVER serialized onto the wire** — only a flat, redacted projection crosses the boundary. Tool-input strings are byte-capped via `max_input_bytes`.
- No new dependencies (stdlib `urllib` / `subprocess` only); both gates are stateless and thread-safe.

### What's included
- `src/traceforge/gate/external.py` — `HttpGate`, `SubprocessGate`, `_serialize_request`, `_parse_response`.
- Config: additive discriminated union `governance.preflight_gate` (`http` | `subprocess`) mirroring the `SinkConfig` pattern; re-exported from `traceforge.config`. The existing dotted-path `tool_preflight_gate` is kept for backward compat.
- `GovernancePipeline.from_config` extended with a sibling branch that builds the gate from config.
- Async fix: Semantic Kernel / MAF / Pydantic AI / OpenAI Agents adapters now `await asyncio.to_thread(pipeline._score_and_gate_preflight, payload)`. The 4 sync adapters (CrewAI, LangChain, LangGraph, smolagents) are untouched.
- `config/defaults.py` commented example block; new docs page `website/docs/reference/external-gating.md` (wired into the sidebar).
- Tests: `tests/unit/test_external_gates.py`, `tests/unit/test_external_gate_config.py` (all I/O mocked — no real network/subprocess).

### Design forks resolved
1. **Gate file location** → `src/traceforge/gate/external.py`, keeping all cross-process gating in the `gate/` package alongside the existing Unix-socket server/client.
2. **Both `tool_preflight_gate` and `preflight_gate` set** → a pydantic `model_validator(mode="after")` raises a clear `ValueError` (mutually exclusive), rather than silent precedence.
3. **Command splitting** → `shlex.split(command, posix=(os.name != 'nt'))`; POSIX strips quotes, Windows is best-effort (documented). Beats naive `str.split()`, which would break quoted args.
4. **OPA ergonomics** → `_parse_response` also unwraps an OPA-style `{"result": {...}}` envelope and ignores extra fields (`score` / `level`) that the built-in gate server already returns.

### Wire contract
- **Request** (POST body / stdin): `{tool, input, target, mechanism, effect, capabilities, scope, role, action, risk_score, risk_band, suggested_action, reason, session_id, tool_call_id, context: {session_id, tool_call_count, denied_count, agent_id, user_id}}` — enums stringified, `input` string values byte-capped.
- **Response**: `{"decision": "deny", "reason": "..."}` → DENY; anything else → ALLOW (case-insensitive, extra fields ignored).

### Out of scope (deliberate)
- No `UnixSocketGate` / `unix_socket` config type — the discriminated union makes it a trivial additive follow-up.
- No server-side `/gate` HTTP endpoint on `traceforge score` — this PR is the **client** side (gates that call out). A server endpoint is possible future work.

### Verification
- Full suite: **2909 passed, 6 skipped, 5 xfailed** (+46 new tests vs the post-#116 base; 0 regressions).
- `ruff check .` clean; `ruff format --check .` clean (pinned `0.15.20`).
- `cd website && npm run build` → `[SUCCESS] Generated static files`.

Rebased onto latest `main` (which includes #116/#119 sink hydration); the change surface is disjoint from that PR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
