### PR TITLE
Publish core distribution as traceforge-toolkit (#121)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -38,5 +38,5 @@ jobs:
       # via --find-links so the base-wheel install works pre-publish (litellm,
       # onnxruntime, etc. still come from PyPI).
       - run: python -m build packages/traceforge-title-model --outdir dist
-      - run: pip install --find-links dist traceforge
+      - run: pip install --find-links dist traceforge-toolkit
       - run: python -c "import traceforge; print(traceforge.__name__)"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ mapping file**: no code.
 ## Quickstart
 
 ```bash
-pip install traceforge      # or: uv add traceforge
+pip install traceforge-toolkit   # or: uv add traceforge-toolkit
 ```
 
 Everything ships in a single install, with no extras. Describe a pipeline in

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,14 +12,19 @@ the operational runbook and go/no-go checklist for cutting a release.
 
 | Distribution | Source | Contents | Publish workflow | Tag |
 |---|---|---|---|---|
-| `traceforge` | root `pyproject.toml` | code + small data (classify/mappings/gates YAML, phase/boundary/title heads, `potion-base-8M` `.safetensors`) | `.github/workflows/publish.yml` | `v*` |
+| `traceforge-toolkit` | root `pyproject.toml` | code + small data (classify/mappings/gates YAML, phase/boundary/title heads, `potion-base-8M` `.safetensors`) | `.github/workflows/publish.yml` | `v*` |
 | `traceforge-title-model` | `packages/traceforge-title-model` | pure-data ONNX span titler (`encoder.onnx`, `decoder.onnx`, `tokenizer.json`) | `.github/workflows/publish-title-model.yml` | `title-model-v*` |
 
-`traceforge` depends on `traceforge-title-model>=0.2`. The titler weights are a
+> **Note:** the core distribution is published to PyPI as **`traceforge-toolkit`** because
+> the bare name `traceforge` was already taken by an unrelated project. The import package
+> (`import traceforge`), the `traceforge` CLI command, and the brand stay `traceforge` — the
+> `scikit-learn` → `import sklearn` pattern.
+
+`traceforge-toolkit` depends on `traceforge-title-model>=0.2`. The titler weights are a
 separate distribution so the core wheel stays code-first and the ~95 MB model
 only re-releases when it is retrained (rarely), on its own tag.
 
-Both weight classes (`.safetensors` in `traceforge`, `.onnx` in
+Both weight classes (`.safetensors` in `traceforge-toolkit`, `.onnx` in
 `traceforge-title-model`) are tracked with **Git LFS** — see [§4](#4-git-lfs--weight-integrity).
 
 ## 2. Versioning strategy
@@ -29,17 +34,17 @@ Both weight classes (`.safetensors` in `traceforge`, `.onnx` in
   a **PATCH** bump is reserved for backwards-compatible fixes. Cut `1.0.0` once the
   public API (SDK `Pipeline`/`GatePolicy`/`Verdict`, the `traceforge` CLI surface,
   and the YAML config schema) is committed to stability.
-- **Initial versions:** `traceforge` `0.1.0`; `traceforge-title-model` `0.2.0`
+- **Initial versions:** `traceforge-toolkit` `0.1.0`; `traceforge-title-model` `0.2.0`
   (already ahead — it iterated during model development).
 - **Independent lifecycles:** the two versions move independently. A code-only
-  release bumps `traceforge` and reuses the existing model. A retrain bumps
+  release bumps `traceforge-toolkit` and reuses the existing model. A retrain bumps
   `traceforge-title-model` and, if the new weights require it, widens the
-  `traceforge` dependency floor.
+  `traceforge-toolkit` dependency floor.
 - **Single source of truth:** each version lives only in its own
   `pyproject.toml`. The CLI reports it via `importlib.metadata`
-  (`click.version_option(package_name="traceforge")`) — never hard-code a version
+  (`click.version_option(package_name="traceforge-toolkit")`) — never hard-code a version
   string elsewhere.
-- **Model dependency pin:** `traceforge` requires `traceforge-title-model>=0.2`.
+- **Model dependency pin:** `traceforge-toolkit` requires `traceforge-title-model>=0.2`.
   The model is a pure-data package with a stable three-file head contract
   (`encoder.onnx`/`decoder.onnx`/`tokenizer.json`), so a compatible retrain is
   drop-in. If a future retrain changes that on-disk contract, raise the floor
@@ -47,14 +52,14 @@ Both weight classes (`.safetensors` in `traceforge`, `.onnx` in
 
 ## 3. Release order (critical)
 
-Because `traceforge` depends on `traceforge-title-model`, a fresh model release
+Because `traceforge-toolkit` depends on `traceforge-title-model`, a fresh model release
 must land on PyPI **before** the code release that requires it:
 
 1. (Only if the model changed) tag `title-model-vX.Y.Z` → wait for
    `Publish title model` to finish and the version to be visible on PyPI.
-2. Tag `vA.B.C` → `Publish` builds and uploads `traceforge`.
+2. Tag `vA.B.C` → `Publish` builds and uploads `traceforge-toolkit`.
 
-If the model is unchanged, step 1 is skipped and `traceforge` resolves the
+If the model is unchanged, step 1 is skipped and `traceforge-toolkit` resolves the
 already-published model.
 
 ## 4. Git LFS & weight integrity
@@ -90,7 +95,7 @@ One-time PyPI setup (per distribution, done in the PyPI project's
 |---|---|
 | Owner | `dfinson` |
 | Repository | `traceforge` |
-| Workflow (traceforge) | `publish.yml` |
+| Workflow (traceforge-toolkit) | `publish.yml` |
 | Workflow (title-model) | `publish-title-model.yml` |
 | Environment | `pypi` |
 
@@ -115,9 +120,9 @@ uv run --no-project python scripts/verify_no_lfs_pointers.py dist \
 uv run --no-project --with twine twine check dist/*
 ```
 
-Expected: the traceforge wheel carries the classify/mappings/gates YAML, the
+Expected: the traceforge-toolkit wheel carries the classify/mappings/gates YAML, the
 phase/boundary/title heads, `py.typed`, and the `potion-base-8M` `.safetensors`;
-the title-model wheel carries the ONNX triad; the traceforge **sdist** stays lean
+the title-model wheel carries the ONNX triad; the traceforge-toolkit **sdist** stays lean
 (~29 MB — it deliberately excludes `packages/`, `tests/`, and `research/`, so it
 never bundles the titler weights and never approaches PyPI's 100 MiB per-file cap).
 
@@ -133,7 +138,7 @@ never bundles the titler weights and never approaches PyPI's 100 MiB per-file ca
 
 **Packaging readiness (verified by this PR):**
 
-- [x] `traceforge` metadata complete: name, version, description, readme, license
+- [x] `traceforge-toolkit` metadata complete: name, version, description, readme, license
       (SPDX `MIT` → `License-Expression`), authors, requires-python
       (`>=3.11,<3.14`), classifiers (Dev Status 4-Beta, Python 3.11/3.12/3.13,
       Typing :: Typed), keywords, `project.urls`.
@@ -156,9 +161,9 @@ never bundles the titler weights and never approaches PyPI's 100 MiB per-file ca
 1. [ ] Final `main` is green (Test on 3.11/3.12/3.13, Lint).
 2. [ ] Bump versions if needed; update this checklist.
 3. [ ] (If model changed) push `title-model-vX.Y.Z`; confirm on PyPI + GH release mirror.
-4. [ ] Push `vA.B.C`; confirm `Publish` succeeds and `pip install traceforge` pulls
+4. [ ] Push `vA.B.C`; confirm `Publish` succeeds and `pip install traceforge-toolkit` pulls
        the model automatically.
-5. [ ] Smoke test in a clean env: `pip install traceforge && traceforge --version`.
+5. [ ] Smoke test in a clean env: `pip install traceforge-toolkit && traceforge --version`.
 
 ## 8. Fallback: GitHub-release model mirror
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1365,7 +1365,7 @@ traceforge/
 
 | Item | Priority | Dependencies | Notes |
 |------|----------|--------------|-------|
-| **PyPI release** | Medium | None | Publish `traceforge` + `traceforge-title-model` to PyPI. Packaging and CI publish workflow are already in place. |
+| **PyPI release** | Medium | None | Publish `traceforge-toolkit` + `traceforge-title-model` to PyPI. Packaging and CI publish workflow are already in place. |
 
 > **Delivered since this table was first written:** the live structuring subsystem
 > (`phase/` + `boundary/` + `title/`, formerly PR #35, now specified in §23) and the
@@ -1376,7 +1376,7 @@ traceforge/
 ### Implementation Order (Recommended)
 
 `
-1. PyPI release → publish traceforge + traceforge-title-model
+1. PyPI release → publish traceforge-toolkit + traceforge-title-model
 `
 
 ---
@@ -2078,5 +2078,5 @@ The library is "done" when:
 6. **Risk scoring** produces meaningful differentiation (not all-50s)
 7. **End-to-end latency** from event ingestion to sink write is < 10ms p99 for in-memory sinks
 8. **Zero-crash guarantee**: malformed input, failed sinks, and unexpected data never crash the pipeline
-9. **Config bootstrap**: first `pip install traceforge` + any config access creates `~/.traceforge/` with working defaults
+9. **Config bootstrap**: first `pip install traceforge-toolkit` + any config access creates `~/.traceforge/` with working defaults
 10. **CI green**: lint + tests pass on Python 3.11, 3.12, 3.13

--- a/packages/traceforge-title-model/README.md
+++ b/packages/traceforge-title-model/README.md
@@ -19,8 +19,8 @@ The core `traceforge` wheel is code-only and small. The model weights live here 
 are pulled in automatically as a hard dependency of `traceforge`:
 
 ```bash
-pip install traceforge      # pulls traceforge-title-model from PyPI
-uv add traceforge
+pip install traceforge-toolkit  # pulls traceforge-title-model from PyPI
+uv add traceforge-toolkit
 ```
 
 You almost never depend on this package directly — `traceforge.title` resolves the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "traceforge"
+name = "traceforge-toolkit"
 version = "0.1.0"
 description = "Framework-agnostic, CPU-only pipeline that forges AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"

--- a/research/pyproject.toml
+++ b/research/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "datasets>=3.0",
     "huggingface-hub>=0.25",
     # Traceforge itself (editable, from parent repo)
-    "traceforge",
+    "traceforge-toolkit",
     # Misc
     "pydantic>=2",
     "pyyaml",
@@ -34,7 +34,7 @@ embeddings = [
 notebook = ["jupyterlab", "matplotlib", "seaborn"]
 
 [tool.uv.sources]
-traceforge = { path = "..", editable = true }
+traceforge-toolkit = { path = "..", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/research/uv.lock
+++ b/research/uv.lock
@@ -4624,7 +4624,76 @@ wheels = [
 ]
 
 [[package]]
-name = "traceforge"
+name = "traceforge-research"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "datasets" },
+    { name = "github-copilot-sdk" },
+    { name = "huggingface-hub" },
+    { name = "mlflow" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "scikit-learn" },
+    { name = "tqdm" },
+    { name = "traceforge-toolkit" },
+]
+
+[package.optional-dependencies]
+embeddings = [
+    { name = "model2vec" },
+    { name = "sentence-transformers" },
+]
+notebook = [
+    { name = "jupyterlab" },
+    { name = "matplotlib" },
+    { name = "seaborn" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets", specifier = ">=3.0" },
+    { name = "github-copilot-sdk", specifier = ">=0.3.0,<0.4" },
+    { name = "huggingface-hub", specifier = ">=0.25" },
+    { name = "jupyterlab", marker = "extra == 'notebook'" },
+    { name = "matplotlib", marker = "extra == 'notebook'" },
+    { name = "mlflow", specifier = ">=2.16" },
+    { name = "model2vec", marker = "extra == 'embeddings'", specifier = ">=0.8.2" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "pandas", specifier = ">=2.2" },
+    { name = "pyarrow", specifier = ">=15" },
+    { name = "pydantic", specifier = ">=2" },
+    { name = "pyyaml" },
+    { name = "scikit-learn", specifier = ">=1.5" },
+    { name = "seaborn", marker = "extra == 'notebook'" },
+    { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=3.0" },
+    { name = "tqdm" },
+    { name = "traceforge-toolkit", editable = "../" },
+]
+provides-extras = ["embeddings", "notebook"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.1.0" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+]
+
+[[package]]
+name = "traceforge-title-model"
+version = "0.2.0"
+source = { editable = "../packages/traceforge-title-model" }
+
+[[package]]
+name = "traceforge-toolkit"
 version = "0.1.0"
 source = { editable = "../" }
 dependencies = [
@@ -4685,85 +4754,21 @@ provides-extras = ["dev", "s3"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "agent-framework-core", specifier = ">=1.0" },
+    { name = "boto3", specifier = ">=1.28" },
     { name = "crewai", specifier = ">=0.80" },
     { name = "datamodel-code-generator", specifier = ">=0.63.0" },
     { name = "langchain-core", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=0.2" },
+    { name = "moto", extras = ["s3"], specifier = ">=5.0" },
     { name = "openai-agents", specifier = ">=0.1" },
+    { name = "pydantic-ai-slim", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
     { name = "semantic-kernel", specifier = ">=1.20" },
     { name = "smolagents", specifier = ">=1.0" },
 ]
-
-[[package]]
-name = "traceforge-research"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "datasets" },
-    { name = "github-copilot-sdk" },
-    { name = "huggingface-hub" },
-    { name = "mlflow" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "scikit-learn" },
-    { name = "tqdm" },
-    { name = "traceforge" },
-]
-
-[package.optional-dependencies]
-embeddings = [
-    { name = "model2vec" },
-    { name = "sentence-transformers" },
-]
-notebook = [
-    { name = "jupyterlab" },
-    { name = "matplotlib" },
-    { name = "seaborn" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "datasets", specifier = ">=3.0" },
-    { name = "github-copilot-sdk", specifier = ">=0.3.0,<0.4" },
-    { name = "huggingface-hub", specifier = ">=0.25" },
-    { name = "jupyterlab", marker = "extra == 'notebook'" },
-    { name = "matplotlib", marker = "extra == 'notebook'" },
-    { name = "mlflow", specifier = ">=2.16" },
-    { name = "model2vec", marker = "extra == 'embeddings'", specifier = ">=0.8.2" },
-    { name = "numpy", specifier = ">=1.26" },
-    { name = "pandas", specifier = ">=2.2" },
-    { name = "pyarrow", specifier = ">=15" },
-    { name = "pydantic", specifier = ">=2" },
-    { name = "pyyaml" },
-    { name = "scikit-learn", specifier = ">=1.5" },
-    { name = "seaborn", marker = "extra == 'notebook'" },
-    { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=3.0" },
-    { name = "tqdm" },
-    { name = "traceforge", editable = "../" },
-]
-provides-extras = ["embeddings", "notebook"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.1.0" },
-    { name = "pytest-asyncio", specifier = ">=1.4.0" },
-]
-
-[[package]]
-name = "traceforge-title-model"
-version = "0.2.0"
-source = { editable = "../packages/traceforge-title-model" }
 
 [[package]]
 name = "traitlets"

--- a/src/traceforge/cli/__init__.py
+++ b/src/traceforge/cli/__init__.py
@@ -18,7 +18,7 @@ from traceforge.cli.download_cmd import download_model
 
 
 @click.group()
-@click.version_option(package_name="traceforge")
+@click.version_option(package_name="traceforge-toolkit")
 def main() -> None:
     """Traceforge — governance pipeline for AI coding agents."""
     # Force UTF-8 on stdout/stderr so the CLI's Unicode glyphs (box rules,

--- a/src/traceforge/sinks/s3.py
+++ b/src/traceforge/sinks/s3.py
@@ -28,7 +28,7 @@ def _require_boto3():
         return boto3
     except ImportError:
         raise ImportError(
-            "boto3 is required for S3Sink. Install it with: pip install traceforge[s3]"
+            "boto3 is required for S3Sink. Install it with: pip install traceforge-toolkit[s3]"
         ) from None
 
 
@@ -37,7 +37,7 @@ class S3Sink(StorageSink):
 
     Object key format: {prefix}{session_id}/{date}/{timestamp}-{uuid_short}.jsonl
 
-    Requires boto3 (optional dependency). Install via ``pip install traceforge[s3]``.
+    Requires boto3 (optional dependency). Install via ``pip install traceforge-toolkit[s3]``.
     """
 
     def __init__(

--- a/uv.lock
+++ b/uv.lock
@@ -4133,7 +4133,12 @@ wheels = [
 ]
 
 [[package]]
-name = "traceforge"
+name = "traceforge-title-model"
+version = "0.2.0"
+source = { editable = "packages/traceforge-title-model" }
+
+[[package]]
+name = "traceforge-toolkit"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
@@ -4237,11 +4242,6 @@ dev = [
     { name = "semantic-kernel", specifier = ">=1.20" },
     { name = "smolagents", specifier = ">=1.0" },
 ]
-
-[[package]]
-name = "traceforge-title-model"
-version = "0.2.0"
-source = { editable = "packages/traceforge-title-model" }
 
 [[package]]
 name = "tree-sitter"

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -10,7 +10,7 @@ description: "Install TraceForge with pip or uv: one install, no extras."
 TraceForge runs on **Python 3.11, 3.12, and 3.13**.
 
 ```bash
-pip install traceforge      # or: uv add traceforge
+pip install traceforge-toolkit   # or: uv add traceforge-toolkit
 ```
 
 Everything ships with a single install, **no extras to choose**. The pipeline, enricher,
@@ -21,7 +21,7 @@ included.
 ## The titler model weights
 
 The activity/step titler model weights (~90 MB) live in a separate
-`traceforge-title-model` package that `traceforge` depends on, so `pip install traceforge`
+`traceforge-title-model` package that `traceforge` depends on, so `pip install traceforge-toolkit`
 pulls them automatically. The weights are hosted on PyPI (primary) and mirrored on this
 repo's `title-model-v*` GitHub releases.
 
@@ -48,7 +48,7 @@ that sink:
 
 | Sink | Extra | Install |
 | --- | --- | --- |
-| `S3Sink` | `boto3` | `pip install traceforge[s3]` |
+| `S3Sink` | `boto3` | `pip install traceforge-toolkit[s3]` |
 
 Every other sink works out of the box. `ParquetSink` is built on `pyarrow`, which ships with the
 base package, so no separate install is needed.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -72,7 +72,7 @@ Raw records flow left to right, gaining structure at every stage:
 Point TraceForge at your agent's logs and stream structured events to storage:
 
 ```bash
-pip install traceforge
+pip install traceforge-toolkit
 traceforge init claude-code      # write a starter traceforge.yaml
 traceforge watch                 # observe, enrich, classify, and store live
 ```
@@ -93,7 +93,7 @@ print(trace.risk_score, trace.suggested_action)   # e.g. 66 escalate
 
 ## Where to go next
 
-- **[Installation](getting-started/installation.md)**: `pip install traceforge` and your
+- **[Installation](getting-started/installation.md)**: `pip install traceforge-toolkit` and your
   first run.
 - **[Architecture](architecture/overview.md)**: how the pipeline stages fit together.
 - **[Governance](governance/overview.md)**: the monitor + shield assessment engine.


### PR DESCRIPTION
Closes #121

Renames **only** the PyPI distribution name of the core package from `traceforge` to `traceforge-toolkit`. The bare name `traceforge` is already taken on PyPI by an unrelated dormant project, so we adopt the scikit-learn → `import sklearn` pattern: the only thing that changes is the string users type at `pip install`. The brand, import package, CLI command, config dir, and env vars are all untouched.

## Guardrails honored (unchanged)
- `import traceforge` / `from traceforge ...` and the `src/traceforge/` package
- the `traceforge` CLI command and its `[project.scripts]` entry point
- `~/.traceforge` config dir, all `TRACEFORGE_*` env vars, the `traceforge.profiles` entry-point group
- the `traceforge-title-model` distribution name and its `>=0.2` dependency pin
- version `0.1.0`, and research's own `traceforge-research` name

## Changes
- **pyproject.toml** — `name = "traceforge-toolkit"` (nothing else)
- **src/traceforge/cli/__init__.py** — `version_option(package_name="traceforge-toolkit")` so `traceforge --version` resolves the installed **distribution** metadata after a real install (otherwise `PackageNotFoundError`)
- **src/traceforge/sinks/s3.py** — the two user-facing `pip install traceforge-toolkit[s3]` hints
- **research/pyproject.toml** — the root dependency and the matching `[tool.uv.sources]` override key (uv requires the source key to match the dependency name)
- **README.md, RELEASING.md, SPEC.md, packages/traceforge-title-model/README.md** — `pip install` / `uv add` strings and core-dist references; RELEASING.md gains a short note explaining the name collision
- **.github/workflows/ci-test.yml** — the build job installs the core dist by name (`pip install --find-links dist traceforge-toolkit`); the old `traceforge` string would fail post-rename. The `import traceforge` smoke check beside it is unchanged.
- Regenerated **uv.lock** and **research/uv.lock**

## Verification (Windows / uv)
- `uv build` → `dist/traceforge_toolkit-0.1.0-py3-none-any.whl` + `dist/traceforge_toolkit-0.1.0.tar.gz`
- `uv run traceforge --version` → `traceforge, version 0.1.0`
- `uv run traceforge --help` → works, command name unchanged
- Full suite: **2909 passed, 6 skipped, 5 xfailed** (no failures; equals main's baseline since no test or importable code changed)
- `ruff check` clean; `ruff format --check` → 411 files already formatted

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>