### PR TITLE
docs: clear stale release-block, document external gates, add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-07-07
+
+Initial release of `traceforge` (published to PyPI as `traceforge-toolkit`). A
+framework-agnostic, CPU-only pipeline that forges AI-agent traces into classified,
+risk-scored, governed event streams with opt-in tool-call gating.
+
+### Added
+
+- **Framework-agnostic trace ingestion.** 20+ agent and framework mappings, including
+  Copilot (CLI/VSCode), Claude, Codex, Aider, Cline, Goose, OpenCode, OpenHands,
+  SWE-agent, Amazon Q, Continue, and Antigravity, plus the CrewAI, LangGraph,
+  Microsoft Agent Framework (MAF), OpenAI Agents, Pydantic-AI, and Smolagents
+  in-process frameworks.
+- **Six ingestion sources:** `file_watch`, `file_poll`, `http_poll`, SSE, `sqlite`,
+  and `replay`.
+- **Enrichment pipeline.** 7-dimension classification, risk-v2 scoring, a rule engine,
+  and recommended actions.
+- **CPU-only, torch-free ML heads** for phase, boundary, and title. The title-model
+  weights ship in the separate `traceforge-title-model` distribution and are pulled in
+  at install time.
+- **Governance.** A monitor/shield stage with PII redaction.
+- **Opt-in tool-call gating.** In-process `GatePolicy` / `Verdict`, out-of-process
+  `HttpGate` / `SubprocessGate` (delegating decisions to an external Policy Decision
+  Point over HTTP or a subprocess), and the IPC `GateServer` for CLIs that cannot
+  inject Python hooks.
+- **Eight storage sinks:** `Callback`, `Console`, `Jsonl`, `Sqlite`, `S3`, `Parquet`,
+  `OtelExporter`, and `Webhook`.
+- **SDK and CLI.** A `Pipeline` facade plus a `traceforge` CLI with the `watch`,
+  `replay`, `score`, `gate`, `detect`, `config`, `status`, `init`, and
+  `download-model` commands.
+
+### Security / hardening
+
+- Command-risk gating hardened to escalate destructive and data-exfiltration
+  patterns — raw-disk writes, filesystem formats, fork bombs, cron/persistence
+  writes, and outbound netcat.
+
+### Known limitations
+
+- The gate IPC server binds a POSIX `AF_UNIX` socket; on Windows that path is skipped
+  and a localhost TCP socket is used instead.
+
+[0.1.0]: https://github.com/dfinson/traceforge/releases/tag/v0.1.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,8 +3,11 @@
 This repo publishes **two** independent distributions to PyPI. This document is
 the operational runbook and go/no-go checklist for cutting a release.
 
-> **Status:** the first PyPI release is **prepared but BLOCKED**. Do not push a
-> release tag until the two gating items in [§7](#7-gono-go-checklist) are merged.
+> **Status:** packaging is **ready** and both former code blockers are resolved —
+> the F2 governance durability fix (#58) and the docs refresh (#78, plus red-team
+> passes #113/#114) are merged to `main`. Cutting the first release now depends only
+> on the one-time PyPI Trusted Publisher setup ([§5](#5-pypi-trusted-publishing-oidc))
+> and pushing the release tag ([§7](#7-gono-go-checklist)).
 
 ---
 
@@ -130,11 +133,14 @@ never bundles the titler weights and never approaches PyPI's 100 MiB per-file ca
 
 **Blockers (must be TRUE before any tag is pushed):**
 
-- [ ] **F2 — governance durability fix merged.** The `SessionRegistry.ensure()`
-      `_db=None` gate-state path can no-op `persist_no_commit`, losing durability.
-      Tracked as duck-round finding **F2**; a first release must not ship it.
-- [ ] **Docs-refresh PR merged.** README/SPEC are being reconciled with delivery
-      in a separate session; the release readme pointer must reflect that.
+- [x] **F2 — governance durability fix merged.** Resolved by **#58** (commit
+      `3710a3e`): `SessionRegistry` now holds two separate residency maps —
+      `_durable_states` (DB-backed observation writer) and `_gate_states`
+      (ephemeral `_db=None` gate) — so the gate-state path can no longer no-op
+      `persist_no_commit` and lose durability.
+- [x] **Docs-refresh PR merged.** Resolved by **#78** (Docusaurus site + README +
+      CONTRIBUTING) and the red-team doc passes **#113**/**#114**; README/SPEC now
+      reflect delivery.
 
 **Packaging readiness (verified by this PR):**
 
@@ -155,6 +161,14 @@ never bundles the titler weights and never approaches PyPI's 100 MiB per-file ca
       proven to build a complete wheel from itself.
 - [x] Trusted-publishing workflows in place for both distributions with
       `lfs: true` checkouts.
+
+**One-time publishing setup (still pending — do once before the first tag):**
+
+- [x] Create the `pypi` **GitHub Environment** on the repo (optionally with required
+      reviewers) — see [§5](#5-pypi-trusted-publishing-oidc). *(Done — the `pypi`
+      environment exists on the repo.)*
+- [ ] Register **PyPI Trusted Publishers** for **both** dists: `traceforge-toolkit`
+      (`publish.yml`) and `traceforge-title-model` (`publish-title-model.yml`).
 
 **Release steps (once blockers clear):**
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -165,8 +165,7 @@ never bundles the titler weights and never approaches PyPI's 100 MiB per-file ca
 **One-time publishing setup (still pending — do once before the first tag):**
 
 - [x] Create the `pypi` **GitHub Environment** on the repo (optionally with required
-      reviewers) — see [§5](#5-pypi-trusted-publishing-oidc). *(Done — the `pypi`
-      environment exists on the repo.)*
+      reviewers) — see [§5](#5-pypi-trusted-publishing-oidc). (done — environment exists on the repo)
 - [ ] Register **PyPI Trusted Publishers** for **both** dists: `traceforge-toolkit`
       (`publish.yml`) and `traceforge-title-model` (`publish-title-model.yml`).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1171,10 +1171,11 @@ traceforge/
 │   │   ├── gate_policy.py       # GatePolicy, preflight / postflight gates
 │   │   ├── gate_types.py        # GateContext, ToolCallRequest / Result
 │   │   └── verdict.py           # Verdict, Decision
-│   ├── gate/                    # Cross-process gate IPC
+│   ├── gate/                    # Cross-process gate IPC + external PDP gates
 │   │   ├── __init__.py
 │   │   ├── client.py
 │   │   ├── server.py
+│   │   ├── external.py          # HttpGate / SubprocessGate (out-of-process PDP)
 │   │   └── registry.py
 │   ├── gates/                   # Bundled gate detectors
 │   │   ├── __init__.py
@@ -1729,6 +1730,35 @@ pipeline.gate_maf()                    # Microsoft Agent Framework middleware
 The `Shield` enforces the returned `Verdict` using each framework's native blocking mechanism.
 The optional postflight callback receives the tool output for audit. (The `gate_*` helpers also
 exist directly on `GovernancePipeline` for gating-only use.)
+
+#### External gates (out-of-process PDP)
+
+When the ALLOW/DENY decision should be made *outside* the Python process, `gate/external.py`
+ships two drop-in preflight gates. Both implement the same synchronous `PreflightGate` protocol
+(`(ToolCallRequest, GateContext) -> Verdict`) as an in-process callback, so they compose straight
+into `GatePolicy().preflight(...)` with no adapter changes: the gate serializes a flat, redacted
+JSON projection of the call (never the in-process `EventTrace` escape hatch) and maps the decider's
+`{"decision": "deny", "reason": ...}` reply to a `Verdict` (an OPA-style `{"result": {...}}`
+envelope is unwrapped automatically).
+
+* **`HttpGate`** — POSTs the request to a persistent HTTP **Policy Decision Point** (e.g. an OPA
+  REST server). Use for a centralized, org-wide PDP where policy lives outside the codebase.
+* **`SubprocessGate`** — spawns a decider command per call and exchanges JSON over stdin/stdout.
+  Use for air-gapped or non-Python gating (OPA `eval`, a shell script) with no long-lived server.
+
+Both are **fail-closed by default** (`fail_open=False`): any error, timeout, non-2xx response,
+non-zero exit, or unparseable output DENIES the call, so a broken decider never silently disables
+enforcement. Both are **dependency-free** — stdlib `urllib` / `subprocess` only — and thread-safe.
+
+```python
+from traceforge.sdk import Pipeline, GatePolicy
+from traceforge.gate.external import HttpGate
+
+# Delegate every preflight decision to an external OPA PDP; fail closed on any error.
+policy = GatePolicy().preflight(HttpGate(endpoint="http://localhost:8181/v1/data/traceforge/gate"))
+pipeline = Pipeline.create(policy=policy)
+pipeline.gate_crewai()   # same framework binding as an in-process gate
+```
 
 #### Shell hook (Copilot / Claude Code CLI)
 


### PR DESCRIPTION
Docs-only reconciliation ahead of the `traceforge` `0.1.0` release. No changes under `src/`, `tests/`, or `website/`.

## RELEASING.md — clear the stale `BLOCKED` status
- Rewrote the L6–7 status banner: it no longer says "prepared but BLOCKED". Both former code blockers are merged to `main` — the **F2 governance durability fix (#58**, commit `3710a3e`, two-map residency `_durable_states`/`_gate_states`) and the **docs refresh (#78** + red-team passes **#113**/**#114)**. Cutting the release now depends only on the one-time PyPI Trusted Publisher setup and the tag push.
- In the §7 Go/No-Go checklist, flipped the two **blocker** checkboxes (F2, Docs-refresh) from `[ ]` to `[x]`, annotated with what resolved each.
- Left the operational work open/unchecked and made the one-time PyPI setup explicit: create the `pypi` GitHub Environment, register Trusted Publishers for both dists, push the title-model tag before the core tag, and smoke test.

## SPEC.md — document the external gates
- Added a concise **External gates (out-of-process PDP)** subsection under *Integration Patterns* covering `HttpGate` (POST to an HTTP PDP such as OPA) and `SubprocessGate` (per-call subprocess, JSON over stdin/stdout): their two use-cases (centralized/OPA PDP; air-gapped or non-Python gating), their **fail-closed** and **dependency-free (stdlib-only)** properties, and a short Python example wiring `HttpGate` into `GatePolicy().preflight(...)`.
- Listed `gate/external.py` in the module file tree.

## CHANGELOG.md — new file
- Created a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)–format file with a single `## [0.1.0] - 2026-07-07` section summarizing the real capabilities (20+ framework mappings, 6 sources, 7-dimension classification + risk-v2 + rules + recommendations, CPU-only ML heads, governance monitor/shield with PII redaction, opt-in gating incl. in-process/external/IPC, 8 sinks, SDK `Pipeline` + `traceforge` CLI), a **Security / hardening** note (command-risk gating escalation), and a **Known limitations** note (POSIX `AF_UNIX` gate IPC skipped on Windows; TCP used there).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>