### PR TITLE
docs: parity sweep — init mechanism, gate_* API shapes, escalate limitation (PR-F)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ print(trace.risk_score, trace.suggested_action)   # e.g. 72 escalate
 See the **[Getting Started guide](https://dfinson.github.io/traceforge/docs/getting-started/installation)**
 for the full CLI (`watch`, `replay`, `score`, `gate`, `init`, `detect`, `status`, `config`).
 
+`traceforge init <agent>` injects the blocking preflight gate hook into a supported agent's own
+native config — for Claude Code, a `PreToolUse` hook in `.claude/settings.json` that runs
+`traceforge gate --stdin`. It does not scaffold `~/.traceforge/` (that config bootstrap happens
+automatically on first config access).
+
 ## Features
 
 | | |

--- a/SPEC.md
+++ b/SPEC.md
@@ -901,7 +901,12 @@ On first config access, `~/.traceforge/` is auto-created with:
 - `config.yaml` (default configuration template)
 - `mappings/` (directory for user custom mappings)
 
-No separate `traceforge init` command needed.
+This config bootstrap is automatic and is **not** what `traceforge init` does. `traceforge init
+<agent>` is a separate command that injects the blocking **preflight gate hook** into a supported
+agent's own native hook configuration — for Claude Code it writes/merges a `PreToolUse` hook into
+`.claude/settings.json` whose command runs `traceforge gate --stdin`. It does not scaffold or touch
+`~/.traceforge/`. Which agents are hook-capable, and which currently ship an `init` injector, is
+tracked in the [Framework Compatibility](#framework-compatibility) matrix below.
 
 ### Environment Variables
 
@@ -1197,7 +1202,7 @@ traceforge/
 │       ├── detect.py            # traceforge detect         (framework auto-detection)
 │       ├── config_cmd.py        # traceforge config         (inspect / emit config)
 │       ├── status.py            # traceforge status         (environment / model status)
-│       ├── init_cmd.py          # traceforge init           (scaffold ~/.traceforge)
+│       ├── init_cmd.py          # traceforge init <agent>   (inject the preflight gate hook into an agent's native config)
 │       ├── runner.py            # Shared pipeline runner
 │       └── factory.py           # Source / adapter / sink construction from config
 ├── tests/

--- a/website/docs/governance/gate.md
+++ b/website/docs/governance/gate.md
@@ -75,12 +75,25 @@ async def can_use_tool(tool_name, input_data, session_id):
         "tool_input": input_data,
         "session_id": session_id,
     })
-    return trace.suggested_action not in ("deny", "escalate", "transform")
+    return trace.suggested_action not in ("deny", "escalate")
 ```
 
 `score_tool_call()` is read-only: it scores against accumulated state but does **not** advance
 the counter, budget, taint, or drift. State changes only when the monitor observes an event from
 its source, so blocked calls never corrupt budget or taint.
+
+:::warning Known limitation — an `escalate` verdict collapses to deny
+
+Enforcement is **binary today**: a gate `Verdict` carries only `Decision.ALLOW` or `Decision.DENY`
+— there is no `ESCALATE` decision. A risk **recommendation** of `escalate` (surfaced above as a
+`suggested_action`, and as `RecommendedAction.ESCALATE` on a `SessionMeta`) therefore has **no
+distinct enforcement path**. An in-process `GatePolicy` that wants to escalate has to return
+`Verdict.deny(...)`, and the cross-process relay (`traceforge gate --stdin`) maps an `escalate`
+verdict to **deny** as well. In practice an "escalate" outcome currently **blocks the tool exactly
+like a deny** — there is no human-in-the-loop approval/hold step yet. Read-only scoring still
+exposes `escalate` as a recommendation (see above), so a consumer that interprets recommendations
+itself can distinguish it; the **gate** cannot.
+:::
 
 ## The two servers
 

--- a/website/docs/reference/adapters.md
+++ b/website/docs/reference/adapters.md
@@ -144,3 +144,54 @@ Two ship today:
 
 Both use tree-sitter for AST-based parsing, support full-file and incremental (chunked)
 modes, and hold back the final event until the next chunk confirms structural closure.
+
+## Gating adapters (`gate_*`)
+
+The adapters above are **ingestion** adapters (raw input → `SessionEvent`). TraceForge ships a second,
+unrelated family of adapters on the enforcement side: the in-process **gating adapters**. Each one
+binds a registered [`GatePolicy`](../governance/gate.md) into one agent framework's *native* blocking
+mechanism, so a preflight `Verdict.deny(...)` actually stops the tool call. They are surfaced on the
+SDK facade (`Pipeline.gate_*`) and also live directly on `GovernancePipeline` for gating-only use
+(the facade methods just delegate). They enforce nothing until a `GatePolicy` is registered
+(`Pipeline.create(policy=...)`); with no gates the shield allows by default.
+
+| Adapter | Returns | Framework binding & how DENY blocks | Session id source |
+| --- | --- | --- | --- |
+| `gate_crewai()` | `None` | CrewAI `before_tool_call` / `after_tool_call` hooks (global — call once per process). DENY → the before-hook returns `False`. | `ctx.crew.fingerprint`, else `"crewai"` |
+| `gate_langchain(tool)` | the same `tool` (its `_run` is wrapped) | Wraps the tool's `_run`. DENY → raises `ToolException`. Idempotent. | invocation `config["configurable"]["thread_id"]`, else `"langchain"` |
+| `gate_langgraph(tools)` | a `ToolNode` | Built with `wrap_tool_call`. DENY → returns a denial `ToolMessage` (status `error`) without executing. | request `config.configurable.thread_id`, else `"langgraph"` |
+| `gate_semantic_kernel(kernel)` | `None` | Registers an `auto_function_invocation` filter. DENY → skips `next_handler` and injects a denial `FunctionResult`. | `kernel.service_id`, else `"semantic_kernel"` |
+| `gate_maf()` | a `FunctionMiddleware` instance | Microsoft Agent Framework middleware. DENY → raises `MiddlewareTermination`. | `context.session.conversation_id`, else `"maf"` |
+| `gate_smolagents(agent_cls=None)` | a gated subclass of `agent_cls` (default `ToolCallingAgent`) | Overrides `execute_tool_call`. DENY → returns `"[BLOCKED] <reason>"` as the observation without executing. | `agent.session_id`, else `"smolagents"` |
+| `gate_pydantic_ai(agent)` | `None` (wraps the agent's toolsets in place) | Wraps each leaf toolset's `call_tool`. DENY → raises `RuntimeError("Denied: …")`. Idempotent. | `ctx.run_id`, else `"pydantic_ai"` |
+| `gate_openai_agents(agent)` | the `agent` (an input guardrail is appended) | Registers an input guardrail. DENY → trips `GuardrailTripwireTriggered`, rejecting the turn. Idempotent. Note: input guardrails fire on the agent's **input message**, not per tool call. | `agent.name`, else `"openai_agents"` |
+
+Every adapter runs the same two-step chain per call: **preflight** scores the pending call and runs the
+policy's preflight gate, returning a `Verdict` (`ALLOW` / `DENY` — see the
+[escalate limitation](../governance/gate.md#read-only-scoring-interpret-it-yourself)); if allowed, the
+tool runs and **postflight** returns a `PostflightVerdict` whose `action` is enforced with the same
+framework-native signal — `SUPPRESS` replaces the output with a placeholder, `REDACT` rewrites it, and
+`TERMINATE` raises/ends the run.
+
+### Session identity
+
+`session_id` is the correlation key that ties observation and gating to **one** `SessionState` — the
+per-session record holding the single tool-call counter, budget, taint ledger, drift window, and gate
+history. To share that state between an observed stream and the gate, use the **same** `session_id` on
+both; different ids create independent sessions.
+
+- **Observation.** The ingestion adapter stamps `SessionEvent.session_id` (e.g.
+  `MappedJsonAdapter.from_yaml(mapping, session_id="s1")`). The governance monitor keys `SessionState`
+  by it and is the single writer that advances state.
+- **In-process gating.** Each `gate_*` adapter derives the session id from the framework's own run/thread
+  context (the *Session id source* column above), falling back to a framework-named literal when absent.
+  That id is threaded into the scored payload and surfaces on `ToolCallRequest.session_id` and
+  `GateContext.session_id`; the `Shield` builds the `GateContext` from that session's live state
+  (`tool_call_count`, `denied_count`, `prior_verdicts`, `prior_tool_call_ids`).
+- **Cross-process (shell-hook) gating.** `traceforge gate --stdin` reads `session_id` from the incoming
+  hook event and routes the request to the pipeline that registered it in the gate registry
+  (`lookup_session`), falling back to the `_default` session that `traceforge watch` registers. A missing
+  `session_id` **fails closed** (deny).
+
+See [The Gate](../governance/gate.md) for the enforcement model and [SDK reference](./sdk.md) for the
+`Verdict` / `GateContext` / `ToolCallRequest` object model.

--- a/website/docs/reference/sdk.md
+++ b/website/docs/reference/sdk.md
@@ -107,7 +107,7 @@ class EventTrace:
     structure: tuple[Structure, ...]
     risk_score: int | None
     risk_band: RiskBand | None
-    suggested_action: Recommendation | None   # allow/warn/escalate/deny/transform
+    suggested_action: Recommendation | None   # allow/warn/escalate/deny
     reason: str | None
     stage: TraceStage                          # adapted -> classified -> assessed
 ```


### PR DESCRIPTION
## PR-F — docs parity sweep

Docs-only sweep that corrects documentation which had drifted from the real implementation. **No `.py`, test, or mapping changes** — every claim below was verified against source before writing.

### Per-file summary
- **SPEC.md** — Rewrote the §Bootstrap passage and the CLI-tree comment: `traceforge init <agent>` is a *separate* command that injects the blocking **preflight gate hook** into an agent's native config (e.g. Claude Code → `.claude/settings.json` `PreToolUse` running `traceforge gate --stdin`); it does **not** scaffold `~/.traceforge/`. Removed the false "No separate init needed" / "scaffold ~/.traceforge" wording. References the existing **Framework Compatibility** matrix instead of restating the per-agent injector list (that list is owned by a parallel PR).
- **website/docs/reference/adapters.md** — New "Gating adapters (`gate_*`)" section documenting the previously-undocumented in-process adapter API: per-framework signature, return type, DENY/blocking behavior, idempotency, and postflight actions, verified against `governance/pipeline.py` (and surfaced on the `Pipeline` SDK facade). Added a "Session identity" subsection covering how `session_id` flows through observation, in-process gating, and cross-process (shell-hook) gating.
- **website/docs/governance/gate.md** — Documented the **known limitation** that an `escalate` verdict currently collapses to a binary **deny** (the gate `Decision` enum is allow/deny only; there is no distinct escalate enforcement path). Also fixed a read-only-scoring example that listed a non-existent `transform` `suggested_action`.
- **website/docs/reference/sdk.md** — Dropped the phantom `/transform` from the `EventTrace.suggested_action` (`Recommendation`) comment; `Recommendation` has no `transform` (only `RecommendedAction` does, documented separately and left intact).
- **README.md** — Added one factual sentence describing what `traceforge init <agent>` does (parity with the corrected SPEC).

### Notes
- No code was changed to "fix" the escalate collapse — it is documented as a current limitation only. The dead `escalate` branch in `gate/client.py` is untouched (owned by another PR).
- No docs linter exists in-repo (Docusaurus site validates links at build time); relative links and the referenced heading anchor were verified manually.

**Please hold for coordinator review — do not merge.**

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>