### PR TITLE
feat(init): inject preflight gate hook for 8 more CLI agents (PR-K)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `traceforge init` now injects the preflight gate hook for 8 more CLI/editor agents —
+  `copilot-cli`, `codex`, `gemini`, `cline`, `cursor`, `amazon-q`, `opencode`, and
+  `openhands` — in addition to `claude-code`. Each writer lands the agent's native hook
+  config (a merged JSON hook, a Cline hook script, or an OpenCode TS plugin) and is
+  idempotent on re-run.
+- `traceforge gate --stdin --agent <name>` option that renders the gate verdict in the
+  target agent's native deny contract (JSON shape + exit code). The internal allow/deny
+  decision and fail-closed behavior are unchanged; only the output formatting is
+  per-agent. `--format` is retained for backward compatibility.
 - `TRACEFORGE_TITLE_MODEL` environment variable to override the titler (span) weights
   directory, matching `TRACEFORGE_PHASE_MODEL` / `TRACEFORGE_BOUNDARY_MODEL`.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1903,8 +1903,10 @@ enforcement decisions.
 traceforge gates across two surfaces. **CLI / editor agents** wire a shell hook that shells out
 to `traceforge gate --stdin`, which relays the tool call to the running pipeline's IPC server and
 prints a verdict in the agent's native hook dialect. **In-process SDK frameworks** bind a `gate_*`
-adapter that wraps the framework's native hook. Today `traceforge init` ships an injector for
-**only Claude Code**; every other hook-capable agent must be wired manually (see PR-K).
+adapter that wraps the framework's native hook. `traceforge init <agent>` ships an injector for
+**all 9 hook-capable CLI/editor agents**: it writes (or idempotently merges into) that agent's
+native hook config so every tool call is relayed through `traceforge gate --stdin --agent <agent>`,
+which renders the verdict in the agent's own deny dialect.
 
 #### CLI / editor agents (shell-hook gating)
 
@@ -1915,15 +1917,15 @@ independently reconciled. **9 of 12 are hook-capable**; only Continue, Goose, an
 
 | Agent | Capable? | Event | Config location | Deny contract | `init` injector |
 |-------|:--------:|-------|-----------------|---------------|:---------------:|
-| **Claude Code** | ✓ | `PreToolUse` | `~/.claude/settings.json` or `.claude/settings.json` | exit 2 OR stdout `hookSpecificOutput.permissionDecision:"deny"` | ✓ **shipped** |
-| **GitHub Copilot CLI** (+ **Copilot Cloud**, same hook) | ✓ | `preToolUse` (+ earlier `permissionRequest`) | `~/.copilot/hooks/*.json`, `.github/hooks/*.json`, or `.github/copilot/settings.json` | stdout `{"permissionDecision":"deny",...}` OR non-zero exit **≠ 2** (exit 2 reserved → use **exit 1**) | ✗ |
-| **OpenAI Codex CLI** | ✓ | `PreToolUse` (`[hooks]` system, **not** `notify`) | `~/.codex/hooks.json` or `[hooks]` in `~/.codex/config.toml` | exit 2 (stderr) OR `hookSpecificOutput.permissionDecision:"deny"` OR legacy `{"decision":"block"}` | ✗ |
-| **Cursor** | ✓ (v1.7+) | `preToolUse` / `beforeShellExecution` / `beforeMCPExecution` | `~/.cursor/hooks.json` or `<project>/.cursor/hooks.json` | exit 2 OR `{"permission":"deny","user_message":...,"agent_message":...}`; per-hook `"failClosed":true` | ✗ |
-| **Gemini CLI** | ✓ | `BeforeTool` | `~/.gemini/settings.json` or `.gemini/settings.json` | exit 2 (stderr) OR `{"decision":"deny","reason":...}` (`"block"` alias) | ✗ |
-| **Cline** | ✓ (v4.0.0+) | `PreToolUse` | **script file** named `PreToolUse` in `<workspace>/.clinerules/hooks/` or `~/Documents/Cline/Hooks/` | stdout `{"cancel":true,"errorMessage":...}` **only** (no exit-2) | ✗ |
-| **Amazon Q Developer CLI** | ✓ (v1.16.2+) | `preToolUse` | agent-config JSON: `~/.aws/amazonq/cli-agents/<name>.json` or `.amazonq/cli-agents/<name>.json` | **exit 2 only** (stderr → reason) | ✗ |
-| **OpenCode** | ✓ (v1.17.15+) | `tool.execute.before` (plugin hook) | **JS/TS plugin** at `.opencode/plugins/*.ts` or `~/.config/opencode/plugins/*.ts` (or the `opencode.json` `"plugin"` array) | `throw new Error(reason)` in the plugin (throw when the gate exits non-zero); plugin gets Bun `$` to shell out to `traceforge gate --stdin` | ✗ |
-| **OpenHands** | ✓ (sdk 1.33.0+) | `pre_tool_use` | `.openhands/hooks.json` (project) or `~/.openhands/hooks.json` (global) | exit 2 OR stdout `{"decision":"deny","reason":...}` OR `{"continue":false}`; stdin = `{event_type,tool_name,tool_input,session_id,working_dir}` | ✗ |
+| **Claude Code** | ✓ | `PreToolUse` | `~/.claude/settings.json` or `.claude/settings.json` | exit 2 OR stdout `hookSpecificOutput.permissionDecision:"deny"` | ✓ |
+| **GitHub Copilot CLI** (+ **Copilot Cloud**, same hook) | ✓ | `preToolUse` (+ earlier `permissionRequest`) | `~/.copilot/hooks/*.json`, `.github/hooks/*.json`, or `.github/copilot/settings.json` | stdout `{"permissionDecision":"deny",...}` OR non-zero exit **≠ 2** (exit 2 reserved → use **exit 1**) | ✓ |
+| **OpenAI Codex CLI** | ✓ | `PreToolUse` (`[hooks]` system, **not** `notify`) | `~/.codex/hooks.json` or `[hooks]` in `~/.codex/config.toml` | exit 2 (stderr) OR `hookSpecificOutput.permissionDecision:"deny"` OR legacy `{"decision":"block"}` | ✓ |
+| **Cursor** | ✓ (v1.7+) | `preToolUse` / `beforeShellExecution` / `beforeMCPExecution` | `~/.cursor/hooks.json` or `<project>/.cursor/hooks.json` | exit 2 OR `{"permission":"deny","user_message":...,"agent_message":...}`; per-hook `"failClosed":true` | ✓ |
+| **Gemini CLI** | ✓ | `BeforeTool` | `~/.gemini/settings.json` or `.gemini/settings.json` | exit 2 (stderr) OR `{"decision":"deny","reason":...}` (`"block"` alias) | ✓ |
+| **Cline** | ✓ (v4.0.0+) | `PreToolUse` | **script file** named `PreToolUse` in `<workspace>/.clinerules/hooks/` or `~/Documents/Cline/Hooks/` | stdout `{"cancel":true,"errorMessage":...}` **only** (no exit-2) | ✓ |
+| **Amazon Q Developer CLI** | ✓ (v1.16.2+) | `preToolUse` | agent-config JSON: `~/.aws/amazonq/cli-agents/<name>.json` or `.amazonq/cli-agents/<name>.json` | **exit 2 only** (stderr → reason) | ✓ |
+| **OpenCode** | ✓ (v1.17.15+) | `tool.execute.before` (plugin hook) | **JS/TS plugin** at `.opencode/plugins/*.ts` or `~/.config/opencode/plugins/*.ts` (or the `opencode.json` `"plugin"` array) | `throw new Error(reason)` in the plugin (throw when the gate exits non-zero); plugin gets Bun `$` to shell out to `traceforge gate --stdin` | ✓ |
+| **OpenHands** | ✓ (sdk 1.33.0+) | `pre_tool_use` | `.openhands/hooks.json` (project) or `~/.openhands/hooks.json` (global) | exit 2 OR stdout `{"decision":"deny","reason":...}` OR `{"continue":false}`; stdin = `{event_type,tool_name,tool_input,session_id,working_dir}` | ✓ |
 | **Continue** | ✗ | — | static tool-policy (allow/ask/exclude) in `config.yaml` | no shell-out lifecycle hook | — |
 | **Goose** | ✗ | — | internal `permission_manager` / YAML + LLM "SmartApprove" | no external shell-out hook | — |
 | **Aider** | ✗ | — | `--yes-always` / `--auto-commits` only | no tool-call lifecycle | — |
@@ -1950,9 +1952,9 @@ per-agent adapter selected by an `--agent <name>` tag the injector writes into t
 Amazon Q, OpenHands; Copilot uses exit 1). The two that use no exit code at all: **Cline** (a JSON
 `{"cancel":true}` script file) and **OpenCode** (a JS/TS plugin that throws to deny). Other
 divergences: **Amazon Q** is exit-2-only, and **OpenHands** runs in-sandbox and must stay
-`async:false` to block. PR-K adds **8 injectors** (Copilot CLI, Codex, Gemini, Cline, Cursor,
-Amazon Q, OpenCode, OpenHands; Claude Code already ships; Copilot Cloud rides Copilot CLI's
-injector).
+`async:false` to block. PR-K **adds the 8 remaining injectors** (Copilot CLI, Codex, Gemini,
+Cline, Cursor, Amazon Q, OpenCode, OpenHands), so `traceforge init` now covers all 9 hook-capable
+agents — Claude Code already shipped, and Copilot Cloud rides Copilot CLI's injector.
 
 #### In-process SDK frameworks (`gate_*` adapters)
 

--- a/src/traceforge/cli/gate_cmd.py
+++ b/src/traceforge/cli/gate_cmd.py
@@ -4,27 +4,57 @@ from __future__ import annotations
 
 import click
 
+#: CLI / editor agents that expose an injectable, blocking preflight hook. The
+#: injector (``traceforge init``) writes ``gate --stdin --agent <name>`` into each
+#: agent's hook config, and ``--agent`` selects the matching deny-contract dialect
+#: (JSON shape + exit code) — see ``traceforge.gate.client._output_deny``.
+SUPPORTED_AGENTS: tuple[str, ...] = (
+    "claude-code",
+    "copilot-cli",
+    "codex",
+    "gemini",
+    "cline",
+    "cursor",
+    "amazon-q",
+    "opencode",
+    "openhands",
+)
+
 
 @click.command("gate")
 @click.option("--stdin", "from_stdin", is_flag=True, help="Read event JSON from stdin.")
 @click.option(
+    "--agent",
+    "agent",
+    default=None,
+    type=click.Choice(SUPPORTED_AGENTS),
+    help="Translate the verdict into this agent's native hook deny contract "
+    "(shape + exit code). Defaults to the Claude Code dialect.",
+)
+@click.option(
     "--format",
     "output_format",
-    default="claude-code",
+    default=None,
     type=click.Choice(["claude-code", "json"]),
-    help="Output format for the verdict.",
+    help='Output format for the verdict (legacy; prefer --agent). "json" emits the raw verdict.',
 )
-def gate(from_stdin: bool, output_format: str) -> None:
+def gate(from_stdin: bool, agent: str | None, output_format: str | None) -> None:
     """Relay a tool call event to the running Pipeline for gating.
 
     Reads event JSON from stdin, looks up the Pipeline IPC server by session_id,
-    sends the event for scoring, and outputs the verdict in the specified format.
+    sends the event for scoring, and outputs the verdict in the target agent's
+    native hook dialect.
 
-    Typically invoked by agent hooks (e.g., Claude Code PreToolUse).
+    Typically invoked by agent hooks (e.g. Claude Code PreToolUse, Copilot CLI
+    preToolUse, Codex PreToolUse). ``--agent`` picks the deny contract; when it is
+    omitted the Claude Code dialect is used (also selectable via ``--format``).
     """
     if not from_stdin:
         raise click.UsageError("--stdin is required (only stdin mode is currently supported)")
 
+    # --agent is the primary selector; --format stays for backward compatibility.
+    dialect = agent or output_format or "claude-code"
+
     from traceforge.gate.client import gate_from_stdin
 
-    gate_from_stdin(format=output_format)
+    gate_from_stdin(format=dialect)

--- a/src/traceforge/cli/init_cmd.py
+++ b/src/traceforge/cli/init_cmd.py
@@ -1,86 +1,328 @@
-"""traceforge init — auto-inject hook configs for supported agents."""
+"""traceforge init — auto-inject preflight gate hook configs for supported agents.
+
+Each supported CLI/editor agent exposes an injectable, blocking preflight hook (see
+SPEC.md "Framework Compatibility"). ``init`` writes — or idempotently merges into —
+that agent's native hook config so every tool call is relayed through
+``traceforge gate --stdin --agent <agent>``, which denies the call in the agent's own
+deny dialect when policy blocks it. The per-agent *deny contract* (JSON shape + exit
+code) lives in ``traceforge.gate.client``; this module only lays down the wiring.
+"""
 
 from __future__ import annotations
 
 import json
+import stat
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import click
 
+from traceforge.cli.gate_cmd import SUPPORTED_AGENTS
+
 
 @click.command("init")
-@click.argument("agent", type=click.Choice(["claude-code"]))
+@click.argument("agent", type=click.Choice(list(SUPPORTED_AGENTS)))
 @click.option("--project", "-p", default=".", help="Project root directory.")
 def init(agent: str, project: str) -> None:
-    """Auto-inject traceforge hook configuration for a supported agent.
+    """Inject a traceforge preflight gate hook for a supported agent.
 
-    Currently supported agents:
-      - claude-code: Writes PreToolUse hook to .claude/settings.json
+    The hook relays every tool call through ``traceforge gate --stdin --agent
+    <agent>`` and blocks it — in the agent's own deny dialect — when policy denies.
+    Re-running is a no-op once the traceforge hook is already present.
+
+    \b
+    Supported agents and where the hook lands:
+      claude-code  <project>/.claude/settings.json               (PreToolUse)
+      copilot-cli  <project>/.github/hooks/traceforge.json        (preToolUse; +Copilot Cloud)
+      codex        ~/.codex/hooks.json                            (PreToolUse)
+      gemini       <project>/.gemini/settings.json                (BeforeTool)
+      cline        <project>/.clinerules/hooks/PreToolUse         (hook script)
+      cursor       <project>/.cursor/hooks.json                   (preToolUse, failClosed)
+      amazon-q     <project>/.amazonq/cli-agents/traceforge.json  (preToolUse)
+      opencode     <project>/.opencode/plugins/traceforge.ts      (tool.execute.before plugin)
+      openhands    <project>/.openhands/hooks.json                (pre_tool_use, sync)
     """
     project_root = Path(project).resolve()
-
-    if agent == "claude-code":
-        _init_claude_code(project_root)
+    _WRITERS[agent](project_root)
 
 
-def _init_claude_code(project_root: Path) -> None:
-    """Write Claude Code PreToolUse hook config."""
-    settings_dir = project_root / ".claude"
-    settings_dir.mkdir(parents=True, exist_ok=True)
-    settings_file = settings_dir / "settings.json"
-
-    # Load existing or start fresh
-    if settings_file.exists():
-        try:
-            settings = json.loads(settings_file.read_text())
-        except (json.JSONDecodeError, OSError):
-            settings = {}
-    else:
-        settings = {}
-
-    # Determine the traceforge command
-    traceforge_cmd = _find_traceforge_command()
-
-    # Build hook config
-    hook_entry = {
-        "type": "command",
-        "command": f"{traceforge_cmd} gate --stdin",
-    }
-
-    # Insert into hooks.PreToolUse
-    hooks = settings.setdefault("hooks", {})
-    pre_tool_use = hooks.setdefault("PreToolUse", [])
-
-    # Check if traceforge hook already exists
-    for entry in pre_tool_use:
-        if isinstance(entry, dict):
-            hooks_list = entry.get("hooks", [])
-            for h in hooks_list:
-                if isinstance(h, dict) and "traceforge" in h.get("command", ""):
-                    click.echo("✓ traceforge hook already configured in .claude/settings.json")
-                    return
-
-    # Add a matcher for all tools with traceforge hook
-    pre_tool_use.append(
-        {
-            "matcher": ".*",
-            "hooks": [hook_entry],
-        }
-    )
-
-    settings_file.write_text(json.dumps(settings, indent=2) + "\n")
-    click.echo(f"✓ Wrote PreToolUse hook to {settings_file}")
-    click.echo(f"  Command: {traceforge_cmd} gate --stdin")
+# ─── Command / path helpers ──────────────────────────────────────────────────
 
 
 def _find_traceforge_command() -> str:
-    """Find the traceforge executable path."""
-    # If running as installed package, use the entry point
+    """Return the ``traceforge`` invocation string for a shell-hook command."""
     import shutil
 
     traceforge_path = shutil.which("traceforge")
     if traceforge_path:
         return traceforge_path
-    # Fallback: use python -m
+    # Fallback: run the module through the current interpreter.
     return f"{sys.executable} -m traceforge"
+
+
+def _traceforge_base_argv() -> list[str]:
+    """Return ``traceforge`` as an argv list (for JS/plugin embedding)."""
+    import shutil
+
+    traceforge_path = shutil.which("traceforge")
+    if traceforge_path:
+        return [traceforge_path]
+    return [sys.executable, "-m", "traceforge"]
+
+
+def _gate_command(agent: str) -> str:
+    """The shell command an agent hook runs: ``traceforge gate --stdin --agent X``."""
+    return f"{_find_traceforge_command()} gate --stdin --agent {agent}"
+
+
+def _home() -> Path:
+    """The user's home directory (indirected so tests can redirect it)."""
+    return Path.home()
+
+
+def _safe_read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _make_executable(path: Path) -> None:
+    """Best-effort ``chmod +x`` for POSIX hook scripts (a no-op on Windows)."""
+    try:
+        mode = path.stat().st_mode
+        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    except OSError:
+        pass
+
+
+def _already_has_traceforge(entries: list) -> bool:
+    """True if any hook entry already invokes traceforge (idempotency guard)."""
+    for entry in entries:
+        if isinstance(entry, dict) and "traceforge" in str(entry.get("command", "")):
+            return True
+    return False
+
+
+def _merge_json_hook(
+    config_file: Path,
+    event_key: str,
+    command: str,
+    *,
+    hook_extra: dict | None = None,
+    root_seed: dict | None = None,
+) -> None:
+    """Idempotently merge a ``{"type": "command", ...}`` hook into ``config_file``.
+
+    Loads (or seeds) the JSON config, appends a command hook under
+    ``hooks[event_key]``, and writes it back — unless a traceforge hook is already
+    present, in which case the file is left untouched.
+    """
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+
+    data: dict = {}
+    if config_file.exists():
+        try:
+            loaded = json.loads(config_file.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                data = loaded
+        except (json.JSONDecodeError, OSError):
+            data = {}
+    if not data and root_seed:
+        data = dict(root_seed)
+
+    hooks = data.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        hooks = {}
+        data["hooks"] = hooks
+    entries = hooks.setdefault(event_key, [])
+    if not isinstance(entries, list):
+        entries = []
+        hooks[event_key] = entries
+
+    if _already_has_traceforge(entries):
+        click.echo(f"✓ traceforge hook already configured in {config_file}")
+        return
+
+    hook: dict = {"type": "command", "command": command}
+    if hook_extra:
+        hook.update(hook_extra)
+    entries.append(hook)
+
+    config_file.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    click.echo(f"✓ Wrote {event_key} hook to {config_file}")
+    click.echo(f"  Command: {command}")
+
+
+# ─── Per-agent writers ───────────────────────────────────────────────────────
+
+
+def _init_claude_code(project_root: Path) -> None:
+    """Write the Claude Code PreToolUse hook to ``<project>/.claude/settings.json``.
+
+    Claude Code nests hooks under a ``{"matcher": ".*", "hooks": [...]}`` entry, so
+    this keeps its own writer rather than sharing the flat-list merger.
+    """
+    settings_file = project_root / ".claude" / "settings.json"
+    settings_file.parent.mkdir(parents=True, exist_ok=True)
+
+    settings: dict = {}
+    if settings_file.exists():
+        try:
+            loaded = json.loads(settings_file.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                settings = loaded
+        except (json.JSONDecodeError, OSError):
+            settings = {}
+
+    command = _gate_command("claude-code")
+    hooks = settings.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    for entry in pre_tool_use:
+        if isinstance(entry, dict):
+            for h in entry.get("hooks", []):
+                if isinstance(h, dict) and "traceforge" in h.get("command", ""):
+                    click.echo("✓ traceforge hook already configured in .claude/settings.json")
+                    return
+
+    pre_tool_use.append({"matcher": ".*", "hooks": [{"type": "command", "command": command}]})
+    settings_file.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    click.echo(f"✓ Wrote PreToolUse hook to {settings_file}")
+    click.echo(f"  Command: {command}")
+
+
+def _init_copilot_cli(project_root: Path) -> None:
+    # A project-committed hook here also covers Copilot Cloud (runs in the cloud
+    # runner), which is why it lands under .github/hooks rather than ~/.copilot.
+    _merge_json_hook(
+        project_root / ".github" / "hooks" / "traceforge.json",
+        "preToolUse",
+        _gate_command("copilot-cli"),
+    )
+
+
+def _init_codex(project_root: Path) -> None:
+    # Codex exposes no project-local hook location — only ~/.codex/hooks.json.
+    _merge_json_hook(_home() / ".codex" / "hooks.json", "PreToolUse", _gate_command("codex"))
+
+
+def _init_gemini(project_root: Path) -> None:
+    _merge_json_hook(
+        project_root / ".gemini" / "settings.json", "BeforeTool", _gate_command("gemini")
+    )
+
+
+def _init_cursor(project_root: Path) -> None:
+    # failClosed:true so a crashed hook still blocks the tool call.
+    _merge_json_hook(
+        project_root / ".cursor" / "hooks.json",
+        "preToolUse",
+        _gate_command("cursor"),
+        hook_extra={"failClosed": True},
+    )
+
+
+def _init_amazon_q(project_root: Path) -> None:
+    _merge_json_hook(
+        project_root / ".amazonq" / "cli-agents" / "traceforge.json",
+        "preToolUse",
+        _gate_command("amazon-q"),
+        root_seed={"name": "traceforge", "description": "traceforge preflight gate agent"},
+    )
+
+
+def _init_openhands(project_root: Path) -> None:
+    # async:false so the pre_tool_use hook runs synchronously and can block.
+    _merge_json_hook(
+        project_root / ".openhands" / "hooks.json",
+        "pre_tool_use",
+        _gate_command("openhands"),
+        hook_extra={"async": False},
+    )
+
+
+_CLINE_HOOK_SCRIPT = """\
+#!/usr/bin/env sh
+# traceforge preflight gate — Cline PreToolUse hook.
+# Relays the tool call to the running pipeline; a deny prints {"cancel": true}.
+exec __TRACEFORGE_CMD__
+"""
+
+
+def _init_cline(project_root: Path) -> None:
+    # Cline reads a *script file* literally named PreToolUse, not a JSON config.
+    script = project_root / ".clinerules" / "hooks" / "PreToolUse"
+    script.parent.mkdir(parents=True, exist_ok=True)
+
+    if script.exists() and "traceforge" in _safe_read(script):
+        click.echo(f"✓ traceforge hook already configured in {script}")
+        return
+
+    command = _gate_command("cline")
+    script.write_text(_CLINE_HOOK_SCRIPT.replace("__TRACEFORGE_CMD__", command), encoding="utf-8")
+    _make_executable(script)
+    click.echo(f"✓ Wrote PreToolUse hook script to {script}")
+    click.echo(f"  Command: {command}")
+
+
+_OPENCODE_PLUGIN_TS = """\
+// traceforge preflight gate — OpenCode plugin (tool.execute.before).
+// Shells out to `traceforge gate` and throws to DENY when the gate exits non-zero.
+import type { Plugin } from "@opencode-ai/plugin"
+
+const GATE_ARGV: string[] = __TRACEFORGE_GATE_ARGV__
+
+export const traceforgeGate: Plugin = async ({ $ }) => ({
+  "tool.execute.before": async (input, output) => {
+    const event = JSON.stringify({
+      tool_name: input.tool,
+      tool_input: output.args,
+      session_id: input.sessionID,
+    })
+    const res = await $`${GATE_ARGV}`.stdin(event).quiet().nothrow()
+    if (res.exitCode !== 0) {
+      let reason = res.stdout?.toString().trim() || res.stderr?.toString().trim() || ""
+      try {
+        reason = JSON.parse(reason).reason || reason
+      } catch {
+        // reason is already the plain-text deny message
+      }
+      throw new Error(
+        `traceforge gate denied this tool call: ${reason || "denied by traceforge policy"}`,
+      )
+    }
+  },
+})
+"""
+
+
+def _init_opencode(project_root: Path) -> None:
+    # OpenCode is wired as a JS/TS plugin that throws to deny, not a shell hook.
+    plugin = project_root / ".opencode" / "plugins" / "traceforge.ts"
+    plugin.parent.mkdir(parents=True, exist_ok=True)
+
+    if plugin.exists() and "traceforge" in _safe_read(plugin):
+        click.echo(f"✓ traceforge hook already configured in {plugin}")
+        return
+
+    argv = json.dumps([*_traceforge_base_argv(), "gate", "--stdin", "--agent", "opencode"])
+    plugin.write_text(
+        _OPENCODE_PLUGIN_TS.replace("__TRACEFORGE_GATE_ARGV__", argv), encoding="utf-8"
+    )
+    click.echo(f"✓ Wrote tool.execute.before plugin to {plugin}")
+    click.echo("  Denies via: traceforge gate --stdin --agent opencode")
+
+
+_WRITERS: dict[str, Callable[[Path], None]] = {
+    "claude-code": _init_claude_code,
+    "copilot-cli": _init_copilot_cli,
+    "codex": _init_codex,
+    "gemini": _init_gemini,
+    "cline": _init_cline,
+    "cursor": _init_cursor,
+    "amazon-q": _init_amazon_q,
+    "opencode": _init_opencode,
+    "openhands": _init_openhands,
+}

--- a/src/traceforge/gate/client.py
+++ b/src/traceforge/gate/client.py
@@ -67,8 +67,11 @@ def gate_from_stdin(*, format: str = "claude-code") -> None:
     only if even that fails do we exit 2 as a last-resort hard block.
 
     Args:
-        format: Output format. "claude-code" outputs Claude Code hook JSON.
-                "json" outputs raw verdict JSON.
+        format: Output *dialect*. "claude-code"/"json" are the original formats;
+                the per-agent dialects ("copilot-cli", "codex", "gemini", "cline",
+                "cursor", "amazon-q", "opencode", "openhands") translate the same
+                verdict into that agent's native deny contract (JSON shape + exit
+                code). See :func:`_output_deny`.
     """
     try:
         _gate_from_stdin_impl(format=format)
@@ -150,27 +153,103 @@ def _gate_from_stdin_impl(*, format: str = "claude-code") -> None:
 
 
 def _output_allow(format: str) -> None:
-    """Output an allow verdict in the specified format."""
-    if format == "claude-code":
-        # Empty JSON = pass to normal permission flow
-        print("{}")
-    else:
+    """Emit a non-blocking (allow) verdict in the target agent's dialect.
+
+    The gate only ever *blocks* on deny; on allow it steps aside and defers to the
+    agent's own permission flow. For every hook dialect that means a neutral/empty
+    JSON object on stdout and a clean exit 0 — no ``deny`` field, no ``cancel``, no
+    non-zero exit. The raw ``json`` debug format is the sole exception: it prints an
+    explicit ``{"decision": "allow"}``.
+    """
+    if format == "json":
         print(json.dumps({"decision": "allow"}))
+    else:
+        # {} == "no decision" == defer to the agent's normal permission flow. This
+        # is identical in meaning across every hook dialect (Claude Code, Copilot,
+        # Codex, Gemini, Cline, Cursor, Amazon Q, OpenCode, OpenHands).
+        print("{}")
 
 
 def _output_deny(format: str, reason: str) -> None:
-    """Output a deny verdict in the specified format."""
-    if format == "claude-code":
+    """Emit a DENY verdict translated into the target agent's deny contract.
+
+    Only the *output shape and exit code* are per-agent — the allow/deny decision
+    itself is made upstream (fail-closed) and passed in here unchanged. Every branch
+    below is the verified contract from SPEC.md "Framework Compatibility". exit-2 is
+    the universal hard-deny for the exit-code agents, except **Copilot CLI** (exit 2
+    is reserved there → exit 1) and **Amazon Q** (exit-2-only, no stdout contract).
+    **Cline** (JSON ``{"cancel": true}`` script) and **OpenCode** (a plugin that
+    throws) carry no exit-code contract of their own; OpenCode's plugin keys off the
+    non-zero exit. A non-empty reason is guaranteed because an *empty* deny reason
+    fails **OPEN** on Codex.
+    """
+    reason = reason or "denied by traceforge policy"
+
+    if format == "json":
+        print(json.dumps({"decision": "deny", "reason": reason}))
+        return
+
+    if format in ("claude-code", "codex"):
+        # Claude Code's schema is the de facto standard, and Codex implements the
+        # same ``hookSpecificOutput.permissionDecision``. Claude Code reads stdout
+        # at exit 0 (unchanged bytes); Codex additionally hard-denies on exit 2 with
+        # the reason on stderr.
         print(
             json.dumps(
                 {
                     "hookSpecificOutput": {
                         "hookEventName": "PreToolUse",
                         "permissionDecision": "deny",
-                        "permissionDecisionReason": reason or "denied by traceforge policy",
+                        "permissionDecisionReason": reason,
                     }
                 }
             )
         )
-    else:
+        if format == "codex":
+            print(reason, file=sys.stderr)
+            raise SystemExit(2)
+        return
+
+    if format == "copilot-cli":
+        # Copilot CLI (+ Copilot Cloud, same hook): deny via stdout permissionDecision
+        # OR a non-zero exit *other than 2* (exit 2 is reserved) → use exit 1.
+        print(json.dumps({"permissionDecision": "deny", "permissionDecisionReason": reason}))
+        raise SystemExit(1)
+
+    if format == "gemini":
+        # Gemini BeforeTool: stdout must be JSON only ("silence"); the reason goes to
+        # stderr to feed the exit-2 path without polluting stdout.
         print(json.dumps({"decision": "deny", "reason": reason}))
+        print(reason, file=sys.stderr)
+        raise SystemExit(2)
+
+    if format == "cursor":
+        print(json.dumps({"permission": "deny", "user_message": reason, "agent_message": reason}))
+        raise SystemExit(2)
+
+    if format == "cline":
+        # Cline PreToolUse script: cancel via JSON only — no exit-2 contract.
+        print(json.dumps({"cancel": True, "errorMessage": reason}))
+        return
+
+    if format == "amazon-q":
+        # Amazon Q treats any non-zero exit OTHER than 2 as warning-only and has no
+        # stdout deny contract: exit 2 with the reason on stderr.
+        print(reason, file=sys.stderr)
+        raise SystemExit(2)
+
+    if format == "openhands":
+        print(json.dumps({"decision": "deny", "reason": reason}))
+        print(reason, file=sys.stderr)
+        raise SystemExit(2)
+
+    if format == "opencode":
+        # The OpenCode plugin shells out to the gate and throws when it exits
+        # non-zero; it reads the reason from stdout (JSON) or stderr.
+        print(json.dumps({"decision": "deny", "reason": reason}))
+        print(reason, file=sys.stderr)
+        raise SystemExit(2)
+
+    # Unknown dialect — fail closed hard rather than silently allowing.
+    print(json.dumps({"decision": "deny", "reason": reason}))
+    raise SystemExit(2)

--- a/tests/unit/test_gate_agent_dialects.py
+++ b/tests/unit/test_gate_agent_dialects.py
@@ -1,0 +1,147 @@
+"""Per-agent deny-contract translation for ``traceforge gate --stdin --agent`` (PR-K).
+
+The relay makes exactly one allow/deny decision (fail-closed) and then renders it in
+the target agent's *native* hook dialect. SPEC.md "Framework Compatibility" pins each
+contract: exit-2 is the universal hard-deny **except** Copilot CLI (exit 1, since 2 is
+reserved) and Amazon Q (exit-2-only, no stdout deny body), while Cline (JSON
+``{"cancel": true}`` script) and OpenCode (plugin ``throw``) carry no exit-code
+contract of their own.
+
+These drive the relay in-process (no subprocess) with a stubbed IPC verdict and assert
+the rendered deny shape + exit code and the non-blocking allow, per agent. The
+transport-level and generic fail-closed paths live in
+``tests/unit/test_gate_client_failclosed.py``; the subprocess round-trip lives in
+``tests/e2e/``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from traceforge.gate import client as gate_client
+from traceforge.gate.client import gate_from_stdin
+from traceforge.cli.gate_cmd import SUPPORTED_AGENTS
+
+_EVENT = {"tool_name": "rm", "tool_input": {"path": "/"}, "session_id": "s1"}
+_REASON = "blocked: rm -rf / is not allowed"
+
+
+def _drive(monkeypatch, capsys, dialect: str, verdict: dict) -> tuple[int, str, str]:
+    """Run the relay once with a stubbed IPC ``verdict`` and capture exit/out/err."""
+    monkeypatch.setattr("traceforge.gate.registry.lookup_session", lambda sid: "fake-sock")
+    monkeypatch.setattr(gate_client, "send_gate_request", lambda sock, payload: verdict)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(_EVENT)))
+
+    code = 0
+    try:
+        gate_from_stdin(format=dialect)
+    except SystemExit as exc:  # exit-code dialects hard-block via SystemExit
+        code = exc.code if isinstance(exc.code, int) else 1
+    captured = capsys.readouterr()
+    return code, captured.out.strip(), captured.err.strip()
+
+
+# agent -> (expected exit code, stdout-JSON predicate | None, reason must be on stderr)
+_DENY_CONTRACTS = {
+    "claude-code": (0, lambda d: d["hookSpecificOutput"]["permissionDecision"] == "deny", False),
+    "copilot-cli": (1, lambda d: d["permissionDecision"] == "deny", False),
+    "codex": (2, lambda d: d["hookSpecificOutput"]["permissionDecision"] == "deny", True),
+    "gemini": (2, lambda d: d == {"decision": "deny", "reason": _REASON}, True),
+    "cline": (0, lambda d: d["cancel"] is True and d["errorMessage"] == _REASON, False),
+    "cursor": (2, lambda d: d["permission"] == "deny", False),
+    "amazon-q": (2, None, True),  # exit-2-only, no stdout deny body
+    "opencode": (2, lambda d: d["decision"] == "deny", True),
+    "openhands": (2, lambda d: d["decision"] == "deny", True),
+}
+
+
+def test_deny_contract_table_covers_every_supported_agent() -> None:
+    """Guard: if a new agent joins ``SUPPORTED_AGENTS`` this test file must grow too."""
+    assert set(_DENY_CONTRACTS) == set(SUPPORTED_AGENTS)
+
+
+@pytest.mark.parametrize("agent", list(_DENY_CONTRACTS))
+def test_agent_deny_shape_and_exit_code(monkeypatch, capsys, agent: str) -> None:
+    """A denied verdict renders as ``agent``'s native deny contract (shape + code)."""
+    expected_code, stdout_pred, reason_on_stderr = _DENY_CONTRACTS[agent]
+    exit_code, out, err = _drive(
+        monkeypatch, capsys, agent, {"decision": "deny", "reason": _REASON}
+    )
+
+    assert exit_code == expected_code, (agent, out, err)
+
+    if stdout_pred is None:
+        # Amazon Q: no stdout deny body — the exit code *is* the whole contract.
+        assert out == "", (agent, out)
+    else:
+        verdict = json.loads(out)  # also asserts stdout is a single JSON object
+        assert stdout_pred(verdict), (agent, verdict)
+
+    if reason_on_stderr:
+        assert _REASON in err, (agent, err)
+
+
+def test_gemini_stdout_is_json_only(monkeypatch, capsys) -> None:
+    """Gemini's BeforeTool contract requires stdout be JSON *only* (reason -> stderr)."""
+    _, out, err = _drive(monkeypatch, capsys, "gemini", {"decision": "deny", "reason": _REASON})
+    assert json.loads(out) == {"decision": "deny", "reason": _REASON}
+    assert out.count("{") == 1  # no stray log lines around the JSON
+    assert _REASON in err
+
+
+def test_amazon_q_has_no_stdout_body(monkeypatch, capsys) -> None:
+    """Amazon Q is exit-2-only: nothing may leak onto stdout (no deny JSON contract)."""
+    code, out, err = _drive(
+        monkeypatch, capsys, "amazon-q", {"decision": "deny", "reason": _REASON}
+    )
+    assert code == 2
+    assert out == ""
+    assert _REASON in err
+
+
+def test_codex_empty_reason_is_backfilled(monkeypatch, capsys) -> None:
+    """An *empty* Codex deny reason fails OPEN — the relay must backfill a reason."""
+    code, out, err = _drive(monkeypatch, capsys, "codex", {"decision": "deny", "reason": ""})
+    assert code == 2
+    reason = json.loads(out)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert reason.strip(), "empty deny reason would fail OPEN on Codex"
+    assert err.strip()
+
+
+@pytest.mark.parametrize("agent", list(SUPPORTED_AGENTS))
+def test_agent_allow_is_non_blocking(monkeypatch, capsys, agent: str) -> None:
+    """An allowed verdict never blocks: neutral stdout, clean exit 0, in every dialect."""
+    code, out, err = _drive(monkeypatch, capsys, agent, {"decision": "allow"})
+    assert code == 0, (agent, out, err)
+    assert '"deny"' not in out and '"cancel": true' not in out, (agent, out)
+    json.loads(out)  # still valid JSON (a neutral "defer" object)
+
+
+@pytest.mark.parametrize("agent", list(SUPPORTED_AGENTS))
+def test_agent_escalate_blocks_like_deny(monkeypatch, capsys, agent: str) -> None:
+    """An ``escalate`` verdict (human approval needed) must block, same as deny."""
+    expected_code = _DENY_CONTRACTS[agent][0]
+    code, out, _ = _drive(
+        monkeypatch, capsys, agent, {"decision": "escalate", "reason": "needs review"}
+    )
+    assert code == expected_code, (agent, out)
+
+
+def test_agent_dialect_preserves_fail_closed(monkeypatch, capsys) -> None:
+    """A crash under an exit-code dialect still hard-denies (fail-closed, exit 2)."""
+
+    def boom(session_id):
+        raise RuntimeError("registry database is locked")
+
+    monkeypatch.setattr("traceforge.gate.registry.lookup_session", boom)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(_EVENT)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        gate_from_stdin(format="codex")
+
+    assert excinfo.value.code == 2
+    verdict = json.loads(capsys.readouterr().out.strip())
+    assert verdict["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/tests/unit/test_init_injectors.py
+++ b/tests/unit/test_init_injectors.py
@@ -1,0 +1,193 @@
+"""Per-agent hook injection by ``traceforge init`` (PR-K).
+
+``init claude-code`` shipped first; PR-K adds the eight other hook-capable CLI/editor
+agents from SPEC.md "Framework Compatibility". Each injector lays down that agent's
+*native* preflight wiring — a merged JSON hook, a Cline hook *script*, or an OpenCode
+TS *plugin* — that relays tool calls through ``traceforge gate --stdin --agent
+<name>``, and each must be idempotent (a second run adds nothing).
+
+These are in-process ``CliRunner`` tests (the subprocess/on-disk contract for
+claude-code lives in ``tests/e2e/``). ``codex`` is the one home-scoped agent — it has
+no project-local hook location — so its writer is redirected through the module-level
+``_home`` seam.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import traceforge.cli.init_cmd as init_cmd
+from traceforge.cli.gate_cmd import SUPPORTED_AGENTS
+from traceforge.cli.init_cmd import init
+
+# agent -> (config path relative to its scope root, scope, JSON event key | None)
+#   scope "project": path is under --project;  scope "home": path is under ~ (_home()).
+#   event key None marks the two non-JSON writers (Cline script / OpenCode plugin).
+_AGENTS = {
+    "claude-code": (".claude/settings.json", "project", "PreToolUse"),
+    "copilot-cli": (".github/hooks/traceforge.json", "project", "preToolUse"),
+    "codex": (".codex/hooks.json", "home", "PreToolUse"),
+    "gemini": (".gemini/settings.json", "project", "BeforeTool"),
+    "cline": (".clinerules/hooks/PreToolUse", "project", None),
+    "cursor": (".cursor/hooks.json", "project", "preToolUse"),
+    "amazon-q": (".amazonq/cli-agents/traceforge.json", "project", "preToolUse"),
+    "opencode": (".opencode/plugins/traceforge.ts", "project", None),
+    "openhands": (".openhands/hooks.json", "project", "pre_tool_use"),
+}
+
+
+def test_agent_table_matches_supported_agents() -> None:
+    """Guard: a newly supported agent must also gain init-injector coverage here."""
+    assert set(_AGENTS) == set(SUPPORTED_AGENTS)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the injector's ``_home`` seam (used only by the codex writer)."""
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(init_cmd, "_home", lambda: h)
+    return h
+
+
+def _config_path(agent: str, project: Path, home: Path) -> Path:
+    rel, scope, _ = _AGENTS[agent]
+    return (home if scope == "home" else project) / rel
+
+
+def _run(agent: str, project: Path):
+    return CliRunner().invoke(init, [agent, "--project", str(project)])
+
+
+@pytest.mark.parametrize("agent", list(_AGENTS))
+def test_init_writes_hook_to_expected_path(agent: str, tmp_path: Path, home: Path) -> None:
+    """``init <agent>`` lands the gate hook at the agent's canonical config path."""
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    result = _run(agent, project)
+    assert result.exit_code == 0, result.output
+
+    config = _config_path(agent, project, home)
+    assert config.is_file(), f"{agent}: expected hook at {config}"
+
+    text = config.read_text(encoding="utf-8")
+    if agent == "opencode":
+        # OpenCode embeds the command as a JSON argv array, so the tokens are quoted
+        # separately rather than as one contiguous shell string.
+        for token in ('"gate"', '"--stdin"', '"--agent"', '"opencode"'):
+            assert token in text, (agent, token)
+        assert "tool.execute.before" in text and "throw new Error" in text
+    else:
+        assert f"gate --stdin --agent {agent}" in text, (agent, text)
+
+
+@pytest.mark.parametrize("agent", list(_AGENTS))
+def test_init_is_idempotent(agent: str, tmp_path: Path, home: Path) -> None:
+    """A second ``init <agent>`` no-ops: same bytes on disk, friendly notice, one entry."""
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    first = _run(agent, project)
+    assert first.exit_code == 0, first.output
+    config = _config_path(agent, project, home)
+    after_first = config.read_bytes()
+
+    second = _run(agent, project)
+    assert second.exit_code == 0, second.output
+    assert "already configured" in second.output, (agent, second.output)
+    assert config.read_bytes() == after_first, f"{agent}: re-run must not rewrite the config"
+
+    # Exactly one traceforge hook entry — never a duplicate.
+    text = config.read_text(encoding="utf-8")
+    needle = '"--agent"' if agent == "opencode" else f"--agent {agent}"
+    assert text.count(needle) == 1, (agent, text)
+
+
+@pytest.mark.parametrize("agent", [a for a, (_, _, ev) in _AGENTS.items() if ev is not None])
+def test_json_writers_produce_well_formed_config(agent: str, tmp_path: Path, home: Path) -> None:
+    """The JSON writers emit parseable config with the command under the right event."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _run(agent, project)
+
+    _, _, event_key = _AGENTS[agent]
+    data = json.loads(_config_path(agent, project, home).read_text(encoding="utf-8"))
+    entries = data["hooks"][event_key]
+    assert isinstance(entries, list) and entries
+
+    commands = _gather_commands(entries)
+    assert any("traceforge" in c and f"--agent {agent}" in c for c in commands), (agent, commands)
+
+
+def _gather_commands(entries: list) -> list[str]:
+    """Flatten hook ``command`` strings from either flat or claude-nested entries."""
+    commands: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if "command" in entry:  # flat: {"type": "command", "command": ...}
+            commands.append(str(entry["command"]))
+        for nested in entry.get("hooks", []):  # claude: {"matcher", "hooks": [...]}
+            if isinstance(nested, dict) and "command" in nested:
+                commands.append(str(nested["command"]))
+    return commands
+
+
+def test_cursor_hook_is_fail_closed(tmp_path: Path, home: Path) -> None:
+    """Cursor's hook carries ``failClosed: true`` so a crashed hook still blocks."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _run("cursor", project)
+
+    data = json.loads((project / ".cursor" / "hooks.json").read_text(encoding="utf-8"))
+    assert data["hooks"]["preToolUse"][0]["failClosed"] is True
+
+
+def test_openhands_hook_is_synchronous(tmp_path: Path, home: Path) -> None:
+    """OpenHands must run the pre_tool_use hook synchronously (async:false) to block."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _run("openhands", project)
+
+    data = json.loads((project / ".openhands" / "hooks.json").read_text(encoding="utf-8"))
+    assert data["hooks"]["pre_tool_use"][0]["async"] is False
+
+
+def test_amazon_q_writes_agent_config_shell(tmp_path: Path, home: Path) -> None:
+    """Amazon Q's cli-agents file keeps its ``name``/``description`` envelope."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _run("amazon-q", project)
+
+    data = json.loads(
+        (project / ".amazonq" / "cli-agents" / "traceforge.json").read_text(encoding="utf-8")
+    )
+    assert data["name"] == "traceforge"
+    assert "preToolUse" in data["hooks"]
+
+
+def test_codex_is_home_scoped_not_project(tmp_path: Path, home: Path) -> None:
+    """Codex has no project-local hook path — it must write under ~/.codex only."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _run("codex", project)
+
+    assert (home / ".codex" / "hooks.json").is_file()
+    assert not (project / ".codex").exists()
+
+
+def test_cline_writes_executable_shaped_script(tmp_path: Path, home: Path) -> None:
+    """Cline gets a hook *script* (shebang + exec), not a JSON config."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _run("cline", project)
+
+    script = project / ".clinerules" / "hooks" / "PreToolUse"
+    text = script.read_text(encoding="utf-8")
+    assert text.startswith("#!"), "cline hook must be a runnable script"
+    assert "gate --stdin --agent cline" in text


### PR DESCRIPTION
## Summary

`traceforge init <agent>` previously injected a blocking PreToolUse gate hook for **only** `claude-code`. Per the verified audit in SPEC.md "Framework Compatibility" (9 of 12 CLI/editor agents expose an injectable blocking preflight hook), this PR extends the injector to the **8 other capable agents**, each wired with its **own verified deny contract**.

The design keeps a single relay command and translates its output per agent: a new `--agent <name>` option on `traceforge gate` renders the internal gate verdict into the target agent's native deny shape + exit code. **Only output formatting is per-agent** — the internal allow/deny decision logic and the fail-closed hardening (any unexpected error still denies) are unchanged, and `claude-code`'s existing emitted bytes are preserved.

The injected hook command is now `traceforge gate --stdin --agent <name>`.

## Per-agent contracts (from SPEC.md matrix — authoritative)

| Agent | Config written | Event | Deny contract (gate output) |
|---|---|---|---|
| claude-code | `<proj>/.claude/settings.json` (matcher `.*`) | `PreToolUse` | stdout `hookSpecificOutput.permissionDecision=deny`, exit 0 (**unchanged**) |
| copilot-cli | `<proj>/.github/hooks/traceforge.json` | `preToolUse` | stdout `{"permissionDecision":"deny",…}` + **exit 1** (2 is reserved). Also covers Copilot Cloud. |
| codex | `~/.codex/hooks.json` (home-scoped) | `PreToolUse` | stdout `hookSpecificOutput` deny + stderr reason + **exit 2**. Empty reason backfilled (empty fails OPEN). |
| gemini | `<proj>/.gemini/settings.json` | `BeforeTool` | stdout `{"decision":"deny",…}` JSON-only + **exit 2** (reason → stderr for silence) |
| cline | `<proj>/.clinerules/hooks/PreToolUse` (**script**) | `PreToolUse` | stdout `{"cancel":true,…}` **only**, exit 0 (no exit-2) |
| cursor | `<proj>/.cursor/hooks.json` (`failClosed:true`) | `preToolUse` | stdout `{"permission":"deny",…}` + **exit 2** |
| amazon-q | `<proj>/.amazonq/cli-agents/traceforge.json` | `preToolUse` | **exit 2 only** + stderr reason (no stdout deny body) |
| opencode | `<proj>/.opencode/plugins/traceforge.ts` (**TS plugin**) | `tool.execute.before` | plugin `throw new Error(reason)` when the gate exits non-zero |
| openhands | `<proj>/.openhands/hooks.json` (`async:false`) | `pre_tool_use` | stdout `{"decision":"deny",…}` + **exit 2** |

ALLOW is a neutral `{}` + exit 0 across every dialect (defer to the agent's own permission flow); the legacy `--format json` debug shape is unchanged.

## Changes

- **`src/traceforge/cli/init_cmd.py`** — `click.Choice` expanded to all 9 agents; one idempotent `_init_<agent>` writer per agent (JSON merge, Cline script, OpenCode TS plugin). Re-running detects an existing traceforge hook and no-ops with a friendly message.
- **`src/traceforge/cli/gate_cmd.py`** — new `--agent` option (`--format` retained for back-compat); resolves to the per-agent dialect.
- **`src/traceforge/gate/client.py`** — `_output_deny` / `_output_allow` now dispatch per-agent deny shape + exit code. Decision logic and fail-closed wrapper untouched.
- **Docs** — `init` help text lists all 9 agents + paths; SPEC.md intro, matrix `init injector` column, and PR-K note updated to reflect all 9 shipping; CHANGELOG Unreleased entry added.
- **Tests** — `tests/unit/test_init_injectors.py` and `tests/unit/test_gate_agent_dialects.py` (63 new tests): per-agent init writes the right config to the right path with the right hook command, idempotent re-run no-ops, and gate `--agent` emits the correct deny shape + exit code and non-blocking allow. A fail-closed-under-dialect test proves a crash still hard-denies.

## Verification

- `ruff check .` — clean; `ruff format --check .` — 414 files already formatted.
- `tests/unit` — **2038 passed, 2 skipped**; all init/gate e2e green (39 passed). No existing test regressed.

## Caveats

- SPEC pins each agent's event name / config path / deny contract; the full internal structure of a few JSON config files is plausible best-effort within that contract.
- `codex` is home-scoped (no project-local hook location), so its writer ignores `--project` and always targets `~/.codex/hooks.json`.
- `opencode` (TS plugin) and `cline` (hook script) are file-based rather than JSON-merged.

Do **not** merge — left for coordinator review.