### PR TITLE
feat(mappings): add langchain + semantic_kernel observation mappings (PR-H)

### DIFF
--- a/scripts/capture_traces/capture_langchain.py
+++ b/scripts/capture_traces/capture_langchain.py
@@ -1,0 +1,295 @@
+"""Capture a REAL LangChain raw trace from a coding task on a vendored demo repo.
+
+This drives a classic ``AgentExecutor`` (tool-calling agent) with a
+``BaseCallbackHandler`` attached, and serializes each callback into ONE flat
+JSON row keyed by an ``event`` discriminator — exactly the shape
+mappings/langchain.yaml consumes. The raw callbacks carry only ``run_id`` on
+end/error hooks, so the handler forward-fills ``name`` via a run_id→name map,
+matching the mapping's assumption.
+
+NB: this is deliberately DISTINCT from capture_langgraph.py. LangGraph captures
+``astream_events(version="v2")`` (I/O nested under ``data``); here we capture the
+verbatim ``BaseCallbackHandler`` arguments, which is a different surface.
+
+Run (isolated env, never pollutes the project .venv):
+    $env:OPENAI_API_KEY = [Environment]::GetEnvironmentVariable('OPENAI_API_KEY','User')
+    uv run --with "langchain>=0.3" --with "langchain-openai" --with fastapi `
+        --with "pydantic>=2" --with pytest --with httpx --with "uvicorn[standard]" `
+        python scripts/capture_traces/capture_langchain.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any
+from uuid import UUID
+
+from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _harness import package_version, write_trace  # noqa: E402
+from _repo_task import CANONICAL_TASK, SYSTEM_PROMPT, Workspace  # noqa: E402
+
+MODEL = os.environ.get("CAPTURE_MODEL", "gpt-5")
+
+
+def _jsonable(value: Any, seen: set[int] | None = None) -> Any:
+    """Generic JSON conversion that keeps native field names and containers."""
+    seen = seen or set()
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, UUID):
+        return str(value)
+    obj_id = id(value)
+    if obj_id in seen:
+        return f"<circular:{type(value).__name__}>"
+    if isinstance(value, dict):
+        seen.add(obj_id)
+        return {str(k): _jsonable(v, seen) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        seen.add(obj_id)
+        return [_jsonable(v, seen) for v in value]
+    if isinstance(value, type):
+        return f"{value.__module__}.{value.__qualname__}"
+    if hasattr(value, "model_dump"):
+        seen.add(obj_id)
+        try:
+            return _jsonable(value.model_dump(mode="json"), seen)
+        except Exception:
+            return _jsonable(getattr(value, "__dict__", str(value)), seen)
+    if hasattr(value, "__dict__") and not callable(value):
+        seen.add(obj_id)
+        return _jsonable(vars(value), seen)
+    return str(value)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+class _CaptureHandler(BaseCallbackHandler):
+    """Flatten every BaseCallbackHandler callback into a single JSON row.
+
+    Each row is ``{"event": "on_...", "run_id": str, "timestamp": iso, ...}`` with
+    the verbatim callback arguments under their native names. ``name`` is
+    forward-filled onto end/error rows via a run_id→name map so the mapping can
+    rely on a stable tool/model name.
+    """
+
+    run_inline = True  # dispatch callbacks synchronously so rows stay ordered
+
+    def __init__(self, lines: list[dict[str, Any]], lock: Lock) -> None:
+        self._lines = lines
+        self._lock = lock
+        self._names: dict[str, str] = {}
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+    def _emit(self, event: str, run_id: Any = None, **fields: Any) -> None:
+        row: dict[str, Any] = {"event": event, "timestamp": _now()}
+        if run_id is not None:
+            row["run_id"] = str(run_id)
+        for key, val in fields.items():
+            if val is not None:
+                row[key] = _jsonable(val)
+        with self._lock:
+            self._lines.append(row)
+
+    def _remember(self, run_id: Any, name: str | None) -> str | None:
+        if run_id is not None and name:
+            self._names[str(run_id)] = name
+        return name
+
+    def _recall(self, run_id: Any) -> str | None:
+        return self._names.get(str(run_id)) if run_id is not None else None
+
+    @staticmethod
+    def _name_of(serialized: Any, kwargs: dict[str, Any]) -> str | None:
+        if kwargs.get("name"):
+            return kwargs["name"]
+        if isinstance(serialized, dict):
+            return serialized.get("name") or (serialized.get("id") or [None])[-1]
+        return None
+
+    # ── chain / runnable lifecycle ───────────────────────────────────────────
+    def on_chain_start(self, serialized, inputs, *, run_id=None, **kwargs) -> None:
+        name = self._remember(run_id, self._name_of(serialized, kwargs))
+        self._emit(
+            "on_chain_start",
+            run_id,
+            name=name,
+            inputs=inputs,
+            parent_run_id=kwargs.get("parent_run_id"),
+            tags=kwargs.get("tags"),
+            metadata=kwargs.get("metadata"),
+        )
+
+    def on_chain_end(self, outputs, *, run_id=None, **kwargs) -> None:
+        self._emit("on_chain_end", run_id, name=self._recall(run_id), outputs=outputs)
+
+    def on_chain_error(self, error, *, run_id=None, **kwargs) -> None:
+        self._emit("on_chain_error", run_id, name=self._recall(run_id), error=str(error))
+
+    # ── LLM / chat-model calls ───────────────────────────────────────────────
+    def on_llm_start(self, serialized, prompts, *, run_id=None, **kwargs) -> None:
+        name = self._remember(run_id, self._name_of(serialized, kwargs))
+        self._emit(
+            "on_llm_start",
+            run_id,
+            name=name,
+            prompts=prompts,
+            tags=kwargs.get("tags"),
+            metadata=kwargs.get("metadata"),
+        )
+
+    def on_chat_model_start(self, serialized, messages, *, run_id=None, **kwargs) -> None:
+        name = self._remember(run_id, self._name_of(serialized, kwargs))
+        self._emit(
+            "on_chat_model_start",
+            run_id,
+            name=name,
+            messages=messages,
+            tags=kwargs.get("tags"),
+            metadata=kwargs.get("metadata"),
+        )
+
+    def on_llm_new_token(self, token, *, run_id=None, **kwargs) -> None:
+        self._emit("on_llm_new_token", run_id, name=self._recall(run_id), token=token)
+
+    def on_llm_end(self, response, *, run_id=None, **kwargs) -> None:
+        self._emit("on_llm_end", run_id, name=self._recall(run_id), response=response)
+
+    def on_llm_error(self, error, *, run_id=None, **kwargs) -> None:
+        self._emit("on_llm_error", run_id, name=self._recall(run_id), error=str(error))
+
+    # ── tool calls ───────────────────────────────────────────────────────────
+    def on_tool_start(self, serialized, input_str, *, run_id=None, **kwargs) -> None:
+        name = self._remember(run_id, self._name_of(serialized, kwargs))
+        self._emit(
+            "on_tool_start",
+            run_id,
+            name=name,
+            input_str=input_str,
+            inputs=kwargs.get("inputs"),
+            tags=kwargs.get("tags"),
+            metadata=kwargs.get("metadata"),
+        )
+
+    def on_tool_end(self, output, *, run_id=None, **kwargs) -> None:
+        self._emit("on_tool_end", run_id, name=self._recall(run_id), output=output)
+
+    def on_tool_error(self, error, *, run_id=None, **kwargs) -> None:
+        self._emit("on_tool_error", run_id, name=self._recall(run_id), error=str(error))
+
+    # ── agent reasoning / actions ────────────────────────────────────────────
+    def on_agent_action(self, action, *, run_id=None, **kwargs) -> None:
+        self._emit(
+            "on_agent_action",
+            run_id,
+            tool=getattr(action, "tool", None),
+            tool_input=getattr(action, "tool_input", None),
+            log=getattr(action, "log", None),
+        )
+
+    def on_agent_finish(self, finish, *, run_id=None, **kwargs) -> None:
+        return_values = getattr(finish, "return_values", None)
+        self._emit(
+            "on_agent_finish", run_id, return_values=return_values, log=getattr(finish, "log", None)
+        )
+
+    # ── retriever (RAG) ──────────────────────────────────────────────────────
+    def on_retriever_start(self, serialized, query, *, run_id=None, **kwargs) -> None:
+        name = self._remember(run_id, self._name_of(serialized, kwargs))
+        self._emit("on_retriever_start", run_id, name=name, query=query)
+
+    def on_retriever_end(self, documents, *, run_id=None, **kwargs) -> None:
+        self._emit("on_retriever_end", run_id, name=self._recall(run_id), documents=documents)
+
+    def on_retriever_error(self, error, *, run_id=None, **kwargs) -> None:
+        self._emit("on_retriever_error", run_id, name=self._recall(run_id), error=str(error))
+
+    # ── freeform text / retries / custom events ──────────────────────────────
+    def on_text(self, text, *, run_id=None, **kwargs) -> None:
+        self._emit("on_text", run_id, text=text)
+
+    def on_retry(self, retry_state, *, run_id=None, **kwargs) -> None:
+        self._emit("on_retry", run_id, name=self._recall(run_id))
+
+    def on_custom_event(self, name, data, *, run_id=None, **kwargs) -> None:
+        self._emit("on_custom_event", run_id, name=name, data=data)
+
+
+def _build_executor(ws: Workspace) -> AgentExecutor:
+    @tool
+    def list_dir(subpath: str = ".") -> str:
+        """List files under a path in the repo."""
+        return ws.list_dir(subpath)
+
+    @tool
+    def read_file(path: str) -> str:
+        """Read a file relative to the repo root."""
+        return ws.read_file(path)
+
+    @tool
+    def write_file(path: str, content: str) -> str:
+        """Overwrite or create a file relative to the repo root."""
+        return ws.write_file(path, content)
+
+    @tool
+    def run_pytest() -> str:
+        """Run the repo's pytest suite and return the transcript."""
+        return ws.run_pytest()
+
+    tools = [list_dir, read_file, write_file, run_pytest]
+    llm = ChatOpenAI(
+        model=MODEL,
+        reasoning={"effort": "low", "summary": "auto"},
+        output_version="responses/v1",
+    )
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", SYSTEM_PROMPT),
+            ("human", "{input}"),
+            ("placeholder", "{agent_scratchpad}"),
+        ]
+    )
+    agent = create_tool_calling_agent(llm, tools, prompt)
+    return AgentExecutor(agent=agent, tools=tools, max_iterations=30, verbose=False)
+
+
+def _capture(ws: Workspace) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    handler = _CaptureHandler(lines, Lock())
+    executor = _build_executor(ws)
+    executor.invoke({"input": CANONICAL_TASK}, config={"callbacks": [handler]})
+    return lines
+
+
+def main() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("OPENAI_API_KEY is not set; this capture makes a real paid call.")
+    ws = Workspace()
+    try:
+        lines = _capture(ws)
+    finally:
+        ws.cleanup()
+    write_trace(
+        framework="langchain",
+        scenario="demo_issue_tracker_get_endpoint",
+        lines=lines,
+        source_repo="langchain-ai/langchain",
+        framework_version=package_version("langchain-core"),
+        model=MODEL,
+        notes="Real OpenAI session; BaseCallbackHandler capture on demo-issue-tracker-api.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/capture_traces/capture_semantic_kernel.py
+++ b/scripts/capture_traces/capture_semantic_kernel.py
@@ -1,0 +1,283 @@
+"""Capture a REAL Semantic Kernel raw trace from a coding task on a demo repo.
+
+Semantic Kernel's in-process observation surface is its *filters* — "around"
+callbacks registered per FilterTypes. This script registers all three relevant
+filters (FUNCTION_INVOCATION, AUTO_FUNCTION_INVOCATION, PROMPT_RENDERING) on a
+real Kernel, runs the canonical coding task with automatic tool calling, and
+serializes each filter tick into ONE flat JSON row keyed by a ``type``
+discriminator — exactly the shape mappings/semantic_kernel.yaml consumes.
+
+Filters run code, ``await next(context)``, then run more code, so each emits a
+``*.started`` row before ``next`` and a ``*.completed``/``*.failed`` row after; a
+generated ``invocation_id`` pairs the halves. The FUNCTION_INVOCATION filter
+splits on ``context.function.metadata.is_prompt`` into prompt_function.* (LLM
+calls) vs native_function.* (tool calls). Note that an auto-invoked tool passes
+through BOTH the function-invocation and auto-function-invocation filters, so it
+legitimately appears as native_function.* AND auto_function.* — both are real SK
+filter emissions and both map to tool.call.* .
+
+Run (isolated env, never pollutes the project .venv):
+    $env:OPENAI_API_KEY = [Environment]::GetEnvironmentVariable('OPENAI_API_KEY','User')
+    uv run --with "semantic-kernel>=1.0" --with fastapi --with "pydantic>=2" `
+        --with pytest --with httpx --with "uvicorn[standard]" `
+        python scripts/capture_traces/capture_semantic_kernel.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai import FunctionChoiceBehavior
+from semantic_kernel.connectors.ai.open_ai import (
+    OpenAIChatCompletion,
+    OpenAIChatPromptExecutionSettings,
+)
+from semantic_kernel.filters import FilterTypes
+from semantic_kernel.functions import KernelArguments, kernel_function
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _harness import package_version, write_trace  # noqa: E402
+from _repo_task import CANONICAL_TASK, SYSTEM_PROMPT, Workspace  # noqa: E402
+
+MODEL = os.environ.get("CAPTURE_MODEL", "gpt-5")
+SERVICE_ID = "default"
+
+
+def _jsonable(value: Any, seen: set[int] | None = None) -> Any:
+    """Generic JSON conversion that keeps native field names and containers."""
+    seen = seen or set()
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    obj_id = id(value)
+    if obj_id in seen:
+        return f"<circular:{type(value).__name__}>"
+    if isinstance(value, dict):
+        seen.add(obj_id)
+        return {str(k): _jsonable(v, seen) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        seen.add(obj_id)
+        return [_jsonable(v, seen) for v in value]
+    if hasattr(value, "model_dump"):
+        seen.add(obj_id)
+        try:
+            return _jsonable(value.model_dump(mode="json"), seen)
+        except Exception:
+            return _jsonable(getattr(value, "__dict__", str(value)), seen)
+    if hasattr(value, "__dict__") and not callable(value):
+        seen.add(obj_id)
+        return _jsonable(vars(value), seen)
+    return str(value)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _arguments(context: Any) -> Any:
+    """Serialize KernelArguments without the injected settings/kernel plumbing."""
+    args = getattr(context, "arguments", None)
+    if not args:
+        return None
+    try:
+        raw = {k: v for k, v in dict(args).items() if k not in {"settings", "kernel", "service"}}
+    except Exception:
+        return None
+    return _jsonable(raw) or None
+
+
+def _result_value(result: Any) -> Any:
+    if result is None:
+        return None
+    return _jsonable(getattr(result, "value", result))
+
+
+def _usage(result: Any) -> dict[str, Any] | None:
+    """Pull token usage out of a prompt FunctionResult's metadata, if present."""
+    metadata = getattr(result, "metadata", None)
+    usage = metadata.get("usage") if isinstance(metadata, dict) else None
+    if usage is None:
+        return None
+
+    def _get(name: str) -> Any:
+        if isinstance(usage, dict):
+            return usage.get(name)
+        return getattr(usage, name, None)
+
+    out = {"prompt_tokens": _get("prompt_tokens"), "completion_tokens": _get("completion_tokens")}
+    return {k: v for k, v in out.items() if v is not None} or None
+
+
+def _model(result: Any) -> str:
+    metadata = getattr(result, "metadata", None)
+    if isinstance(metadata, dict) and metadata.get("model"):
+        return str(metadata["model"])
+    return MODEL
+
+
+class _FilterCapture:
+    """Registers SK filters that append flat rows to ``lines``."""
+
+    def __init__(self, lines: list[dict[str, Any]]) -> None:
+        self._lines = lines
+
+    def _emit(self, type_: str, **fields: Any) -> None:
+        row: dict[str, Any] = {"type": type_, "timestamp": _now()}
+        for key, val in fields.items():
+            if val is not None:
+                row[key] = val
+        self._lines.append(row)
+
+    @staticmethod
+    def _meta(context: Any) -> tuple[str | None, str | None, bool]:
+        func = getattr(context, "function", None)
+        meta = getattr(func, "metadata", None)
+        name = getattr(meta, "name", None)
+        plugin = getattr(meta, "plugin_name", None)
+        is_prompt = bool(getattr(meta, "is_prompt", False))
+        return name, plugin, is_prompt
+
+    def register(self, kernel: Kernel) -> None:
+        kernel.add_filter(FilterTypes.FUNCTION_INVOCATION, self.function_invocation)
+        kernel.add_filter(FilterTypes.AUTO_FUNCTION_INVOCATION, self.auto_function_invocation)
+        kernel.add_filter(FilterTypes.PROMPT_RENDERING, self.prompt_rendering)
+
+    async def function_invocation(self, context: Any, next: Any) -> None:
+        name, plugin, is_prompt = self._meta(context)
+        prefix = "prompt_function" if is_prompt else "native_function"
+        invocation_id = str(uuid4())
+        self._emit(
+            f"{prefix}.started",
+            invocation_id=invocation_id,
+            function_name=name,
+            plugin_name=plugin,
+            arguments=_arguments(context),
+        )
+        try:
+            await next(context)
+        except Exception as exc:  # emit failure, then re-raise to preserve behavior
+            self._emit(
+                f"{prefix}.failed",
+                invocation_id=invocation_id,
+                function_name=name,
+                plugin_name=plugin,
+                error=str(exc),
+            )
+            raise
+        result = getattr(context, "result", None)
+        fields: dict[str, Any] = {
+            "invocation_id": invocation_id,
+            "function_name": name,
+            "plugin_name": plugin,
+            "result": _result_value(result),
+        }
+        if is_prompt:
+            fields["model"] = _model(result)
+            fields["usage"] = _usage(result)
+        self._emit(f"{prefix}.completed", **fields)
+
+    async def auto_function_invocation(self, context: Any, next: Any) -> None:
+        name, plugin, _ = self._meta(context)
+        invocation_id = str(uuid4())
+        self._emit(
+            "auto_function.started",
+            invocation_id=invocation_id,
+            function_name=name,
+            plugin_name=plugin,
+            arguments=_arguments(context),
+            function_count=getattr(context, "function_count", None),
+            request_sequence_index=getattr(context, "request_sequence_index", None),
+            function_sequence_index=getattr(context, "function_sequence_index", None),
+        )
+        await next(context)
+        self._emit(
+            "auto_function.completed",
+            invocation_id=invocation_id,
+            function_name=name,
+            plugin_name=plugin,
+            result=_result_value(getattr(context, "function_result", None)),
+            terminate=getattr(context, "terminate", None),
+        )
+
+    async def prompt_rendering(self, context: Any, next: Any) -> None:
+        name, plugin, _ = self._meta(context)
+        self._emit("prompt_rendering.started", function_name=name, plugin_name=plugin)
+        await next(context)
+        self._emit(
+            "prompt_rendering.completed",
+            function_name=name,
+            plugin_name=plugin,
+            rendered_prompt=getattr(context, "rendered_prompt", None),
+        )
+
+
+class RepoTools:
+    """Native SK plugin exposing the shared demo-repo tool surface."""
+
+    def __init__(self, ws: Workspace) -> None:
+        self._ws = ws
+
+    @kernel_function(name="list_dir", description="List files under a path in the repo.")
+    def list_dir(self, subpath: str = ".") -> str:
+        return self._ws.list_dir(subpath)
+
+    @kernel_function(name="read_file", description="Read a file relative to the repo root.")
+    def read_file(self, path: str) -> str:
+        return self._ws.read_file(path)
+
+    @kernel_function(name="write_file", description="Overwrite or create a file in the repo.")
+    def write_file(self, path: str, content: str) -> str:
+        return self._ws.write_file(path, content)
+
+    @kernel_function(name="run_pytest", description="Run the repo's pytest suite.")
+    def run_pytest(self) -> str:
+        return self._ws.run_pytest()
+
+
+async def _capture(ws: Workspace) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    kernel = Kernel()
+    kernel.add_service(OpenAIChatCompletion(service_id=SERVICE_ID, ai_model_id=MODEL))
+    kernel.add_plugin(RepoTools(ws), plugin_name="repo")
+    _FilterCapture(lines).register(kernel)
+
+    settings = OpenAIChatPromptExecutionSettings(
+        service_id=SERVICE_ID,
+        function_choice_behavior=FunctionChoiceBehavior.Auto(),
+    )
+    await kernel.invoke_prompt(
+        function_name="chat",
+        plugin_name="assistant",
+        prompt=f"{SYSTEM_PROMPT}\n\n{CANONICAL_TASK}",
+        arguments=KernelArguments(settings=settings),
+    )
+    return lines
+
+
+def main() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("OPENAI_API_KEY is not set; this capture makes a real paid call.")
+    ws = Workspace()
+    try:
+        lines = asyncio.run(_capture(ws))
+    finally:
+        ws.cleanup()
+    write_trace(
+        framework="semantic_kernel",
+        scenario="demo_issue_tracker_get_endpoint",
+        lines=lines,
+        source_repo="microsoft/semantic-kernel",
+        framework_version=package_version("semantic-kernel"),
+        model=MODEL,
+        notes="Real OpenAI session; SK filter capture on demo-issue-tracker-api.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/traceforge/mappings/langchain.yaml
+++ b/src/traceforge/mappings/langchain.yaml
@@ -1,0 +1,185 @@
+# LangChain callback-handler event mapping for MappedJsonAdapter.
+# Targets: langchain-core >= 0.3 (BaseCallbackHandler contract; confirmed against 1.4.7)
+# Source: langchain-ai/langchain libs/core/langchain_core/callbacks/base.py
+#         (BaseCallbackHandler) — the classic in-process observation surface that
+#         wraps chains, chat/LLM models, tools, agents and retrievers. This is the
+#         same channel pipeline.gate_langchain(tool) hooks into.
+#
+# This mapping consumes ONE flat JSON object per callback, as emitted by
+# scripts/capture_traces/capture_langchain.py. Each row is the verbatim callback
+# arguments flattened under an "event" discriminator, e.g.
+#   {"event": "on_tool_start", "run_id": "..", "name": "search",
+#    "serialized": {..}, "input_str": "..", "inputs": {..}, "tags": [..],
+#    "metadata": {..}, "timestamp": ".."}
+# The capture handler also forward-fills "name" onto end/error rows (the raw
+# on_tool_end/on_llm_end callbacks carry only run_id, not the name) by keying on
+# run_id, so downstream mapping can rely on a stable "name" field.
+#
+# NB: this is DISTINCT from mappings/langgraph.yaml. LangGraph's mapping targets
+# astream_events(version="v2"), whose flat rows nest tool/LLM I/O under `data`.
+# Here the shape is the raw callback arguments (serialized/input_str/inputs/
+# output/prompts/response...), which is what the callback handler actually sees.
+#
+# Real callback argument names (langchain_core.callbacks.BaseCallbackHandler):
+#   on_chain_start(serialized, inputs, *, run_id, parent_run_id, tags, metadata)
+#   on_chain_end(outputs, *, run_id, parent_run_id)
+#   on_chat_model_start(serialized, messages, *, run_id, tags, metadata)
+#   on_llm_start(serialized, prompts, *, run_id, tags, metadata)
+#   on_llm_end(response: LLMResult, *, run_id, ...)   # chat models END here too
+#   on_llm_new_token(token, *, chunk, run_id, ...)
+#   on_tool_start(serialized, input_str, *, run_id, tags, metadata, inputs)
+#   on_tool_end(output, *, run_id, ...)
+#   on_agent_action(action: AgentAction{tool, tool_input, log}, *, run_id)
+#   on_agent_finish(finish: AgentFinish{return_values, log}, *, run_id)
+#   on_retriever_start(serialized, query, *, run_id, ...)
+#   on_retriever_end(documents, *, run_id, ...)
+# Model name: metadata.ls_model_name (LangSmithParams, merged into callback metadata).
+# Token usage (on_llm_end, OpenAI shape):
+#   response.llm_output.token_usage = {prompt_tokens, completion_tokens, total_tokens}
+#   response.llm_output.model_name
+
+framework: langchain
+framework_version: ">=0.3"
+ingestion_mode: file_watch
+type_field: event
+timestamp_field: timestamp
+
+motivation:
+  sources:
+    # AgentAction.log is the ReAct "Thought:"/tool-selection rationale that
+    # immediately precedes the tool call — the intent behind the invocation.
+    - events: ["on_agent_action"]
+      field: content
+      role: intent
+
+events:
+  # ── Chain / runnable lifecycle ──
+  on_chain_start:
+    kind: workflow.started
+    payload:
+      run_id: run_id
+      name: name
+      inputs: inputs
+  on_chain_end:
+    kind: workflow.completed
+    payload:
+      run_id: run_id
+      name: name
+      output: outputs
+  on_chain_error:
+    kind: workflow.failed
+    payload:
+      run_id: run_id
+      name: name
+      error: error
+
+  # ── LLM calls (string-completion models) ──
+  on_llm_start:
+    kind: llm.call.started
+    payload:
+      run_id: run_id
+      model: metadata.ls_model_name
+      prompts: prompts
+  on_llm_new_token:
+    kind: llm.output.chunk
+    payload:
+      run_id: run_id
+      content: token
+  # on_llm_end fires for BOTH completion LLMs and chat models (there is no
+  # on_chat_model_end in the callback contract).
+  on_llm_end:
+    kind: llm.call.completed
+    payload:
+      run_id: run_id
+      model: response.llm_output.model_name
+      output: response.generations.0.0.text
+      input_tokens: response.llm_output.token_usage.prompt_tokens
+      output_tokens: response.llm_output.token_usage.completion_tokens
+      total_tokens: response.llm_output.token_usage.total_tokens
+  on_llm_error:
+    kind: llm.call.failed
+    payload:
+      run_id: run_id
+      error: error
+
+  # ── Chat-model calls (primary path for modern LangChain) ──
+  on_chat_model_start:
+    kind: llm.call.started
+    payload:
+      run_id: run_id
+      model: metadata.ls_model_name
+
+  # ── Tool calls ──
+  on_tool_start:
+    kind: tool.call.started
+    payload:
+      tool_name: name
+      tool_call_id: run_id
+      arguments: inputs
+      input: input_str
+  on_tool_end:
+    kind: tool.call.completed
+    payload:
+      tool_name: name
+      tool_call_id: run_id
+      result: output
+  on_tool_error:
+    kind: tool.call.failed
+    payload:
+      tool_name: name
+      tool_call_id: run_id
+      error: error
+
+  # ── Agent reasoning / actions (classic AgentExecutor / ReAct loop) ──
+  on_agent_action:
+    kind: message.assistant
+    payload:
+      run_id: run_id
+      content: log
+      tool: tool
+      tool_input: tool_input
+  on_agent_finish:
+    kind: agent.completed
+    payload:
+      run_id: run_id
+      output: return_values.output
+      log: log
+
+  # ── Retriever (RAG) ──
+  on_retriever_start:
+    kind: knowledge.query.started
+    payload:
+      run_id: run_id
+      name: name
+      query: query
+  on_retriever_end:
+    kind: knowledge.query.completed
+    payload:
+      run_id: run_id
+      results: documents
+  on_retriever_error:
+    kind: knowledge.query.failed
+    payload:
+      run_id: run_id
+      error: error
+
+  # ── Freeform agent text / scratchpad ──
+  on_text:
+    kind: message.assistant
+    payload:
+      run_id: run_id
+      content: text
+
+  # ── Retry (tenacity RetryCallState) ──
+  on_retry:
+    kind: session.warning
+    payload:
+      run_id: run_id
+
+  # ── Custom user events (adispatch_custom_event) ──
+  on_custom_event:
+    kind: custom.event
+    payload:
+      run_id: run_id
+      name: name
+      data: data

--- a/src/traceforge/mappings/semantic_kernel.yaml
+++ b/src/traceforge/mappings/semantic_kernel.yaml
@@ -1,0 +1,129 @@
+# Semantic Kernel filter event mapping for MappedJsonAdapter.
+# Targets: semantic-kernel >= 1.0 (filter contract; confirmed against 1.36.0)
+# Source: microsoft/semantic-kernel python/semantic_kernel/filters/
+#         (FUNCTION_INVOCATION, AUTO_FUNCTION_INVOCATION, PROMPT_RENDERING).
+#         Filters are the in-process observation surface SK exposes via
+#         @kernel.filter(...); it is the same channel pipeline.gate_semantic_kernel(kernel)
+#         registers its auto-function-invocation gate on.
+#
+# This mapping consumes ONE flat JSON object per filter tick, as emitted by
+# scripts/capture_traces/capture_semantic_kernel.py. SK filters are "around"
+# callbacks (they run code, `await next(context)`, then run more code), so the
+# capture emits a started row before next() and a completed/failed row after.
+# A capture-generated invocation_id pairs the two halves.
+#
+# Real filter context fields (python/semantic_kernel/filters/...):
+#   FunctionInvocationContext:     function, kernel, arguments, is_streaming, result
+#   AutoFunctionInvocationContext: function, arguments, chat_history, function_result,
+#                                  request_sequence_index, function_sequence_index,
+#                                  function_count, terminate
+#   PromptRenderContext:           function, arguments, rendered_prompt, function_result
+#   context.function is a KernelFunction whose .metadata (KernelFunctionMetadata) has
+#   {name, plugin_name, description, parameters, is_prompt, ...}.
+#   FunctionResult: {function, value, rendered_prompt, metadata}. For a prompt
+#   function the metadata carries usage (CompletionUsage{prompt_tokens,
+#   completion_tokens, ...}).
+#
+# The FUNCTION_INVOCATION filter splits on KernelFunctionMetadata.is_prompt:
+#   is_prompt == True  -> prompt_function.* (a model call)   -> llm.call.*
+#   is_prompt == False -> native_function.* (a tool/plugin)  -> tool.call.*
+# AUTO_FUNCTION_INVOCATION wraps each tool auto-invoked during chat completion
+#   -> auto_function.* -> tool.call.*
+# PROMPT_RENDERING wraps template rendering -> prompt_rendering.* -> prompt.render.*
+
+framework: semantic_kernel
+framework_version: ">=1.0"
+ingestion_mode: file_watch
+type_field: type
+timestamp_field: timestamp
+
+motivation:
+  sources:
+    # The fully rendered prompt is the instruction/context the model acts on —
+    # the intent behind the tool calls it subsequently emits.
+    - events: ["prompt_rendering.completed"]
+      field: content
+      role: intent
+
+events:
+  # ── Prompt (LLM) function invocations: KernelFunctionMetadata.is_prompt == True ──
+  prompt_function.started:
+    kind: llm.call.started
+    payload:
+      function_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      arguments: arguments
+  prompt_function.completed:
+    kind: llm.call.completed
+    payload:
+      function_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      model: model
+      output: result
+      input_tokens: usage.prompt_tokens
+      output_tokens: usage.completion_tokens
+  prompt_function.failed:
+    kind: llm.call.failed
+    payload:
+      function_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      error: error
+
+  # ── Native (tool/plugin) function invocations: is_prompt == False ──
+  native_function.started:
+    kind: tool.call.started
+    payload:
+      tool_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      arguments: arguments
+  native_function.completed:
+    kind: tool.call.completed
+    payload:
+      tool_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      result: result
+  native_function.failed:
+    kind: tool.call.failed
+    payload:
+      tool_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      error: error
+
+  # ── Auto function invocation (tool calling inside chat completion) ──
+  auto_function.started:
+    kind: tool.call.started
+    payload:
+      tool_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      arguments: arguments
+      function_count: function_count
+      request_sequence_index: request_sequence_index
+      function_sequence_index: function_sequence_index
+  auto_function.completed:
+    kind: tool.call.completed
+    payload:
+      tool_name: function_name
+      plugin_name: plugin_name
+      tool_call_id: invocation_id
+      result: result
+      terminate: terminate
+
+  # ── Prompt rendering (template -> final prompt string) ──
+  prompt_rendering.started:
+    kind: prompt.render.started
+    payload:
+      function_name: function_name
+      plugin_name: plugin_name
+  prompt_rendering.completed:
+    kind: prompt.render.completed
+    payload:
+      function_name: function_name
+      plugin_name: plugin_name
+      content: rendered_prompt

--- a/tests/integration/test_langchain_sk_mappings.py
+++ b/tests/integration/test_langchain_sk_mappings.py
@@ -1,0 +1,394 @@
+"""Integration tests for the langchain + semantic_kernel YAML mappings (PR-H).
+
+Mirrors tests/integration/test_new_mappings.py: each YAML must load, validate
+against the FrameworkMapping schema, and map representative native events to the
+correct canonical kinds with payloads preserved through dot-path resolution.
+
+Field names in the sample events are grounded in the real framework surfaces:
+- langchain: langchain_core.callbacks.BaseCallbackHandler callback arguments
+  (serialized/input_str/inputs/output/prompts/response...), flattened under an
+  "event" discriminator by scripts/capture_traces/capture_langchain.py.
+- semantic_kernel: SK filter contexts (FUNCTION_INVOCATION / AUTO_FUNCTION_INVOCATION
+  / PROMPT_RENDERING) flattened under a "type" discriminator by
+  scripts/capture_traces/capture_semantic_kernel.py.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from traceforge.adapters.mapped_json import MappedJsonAdapter
+from traceforge.types import EventKind
+
+MAPPINGS_DIR = Path(__file__).resolve().parents[2] / "src" / "traceforge" / "mappings"
+
+
+class TestLangChainMapping:
+    """LangChain BaseCallbackHandler YAML mapping coverage."""
+
+    @pytest.fixture
+    def adapter(self) -> MappedJsonAdapter:
+        return MappedJsonAdapter.from_yaml(
+            str(MAPPINGS_DIR / "langchain.yaml"), session_id="lc-session"
+        )
+
+    def test_chain_lifecycle(self, adapter):
+        """on_chain_start -> workflow.started, on_chain_end -> workflow.completed."""
+        events_raw = [
+            {
+                "event": "on_chain_start",
+                "timestamp": "2024-06-01T10:00:00Z",
+                "run_id": "chain-1",
+                "name": "AgentExecutor",
+                "inputs": {"input": "list the files"},
+            },
+            {
+                "event": "on_chain_end",
+                "timestamp": "2024-06-01T10:00:05Z",
+                "run_id": "chain-1",
+                "name": "AgentExecutor",
+                "outputs": {"output": "done"},
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.WORKFLOW_STARTED
+        assert all_events[0].payload["run_id"] == "chain-1"
+        assert all_events[0].payload["name"] == "AgentExecutor"
+        assert all_events[1].kind == EventKind.WORKFLOW_COMPLETED
+        assert all_events[1].payload["output"] == {"output": "done"}
+
+    def test_chat_model_and_llm_end_tokens(self, adapter):
+        """on_chat_model_start -> llm.call.started; on_llm_end -> llm.call.completed
+        with token usage read from the OpenAI llm_output.token_usage shape."""
+        events_raw = [
+            {
+                "event": "on_chat_model_start",
+                "timestamp": "2024-06-01T10:00:01Z",
+                "run_id": "llm-1",
+                "name": "ChatOpenAI",
+                "metadata": {"ls_model_name": "gpt-4o", "ls_provider": "openai"},
+            },
+            {
+                "event": "on_llm_end",
+                "timestamp": "2024-06-01T10:00:02Z",
+                "run_id": "llm-1",
+                "name": "ChatOpenAI",
+                "response": {
+                    "generations": [[{"text": "Here is the answer", "type": "ChatGeneration"}]],
+                    "llm_output": {
+                        "model_name": "gpt-4o",
+                        "token_usage": {
+                            "prompt_tokens": 120,
+                            "completion_tokens": 40,
+                            "total_tokens": 160,
+                        },
+                    },
+                },
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.LLM_CALL_STARTED
+        assert all_events[0].payload["model"] == "gpt-4o"
+        assert all_events[1].kind == EventKind.LLM_CALL_COMPLETED
+        assert all_events[1].payload["model"] == "gpt-4o"
+        assert all_events[1].payload["output"] == "Here is the answer"
+        assert all_events[1].payload["input_tokens"] == 120
+        assert all_events[1].payload["output_tokens"] == 40
+        assert all_events[1].payload["total_tokens"] == 160
+
+    def test_tool_calls(self, adapter):
+        """on_tool_start/end/error map to tool.call.* with name forward-filled."""
+        events_raw = [
+            {
+                "event": "on_tool_start",
+                "timestamp": "2024-06-01T10:00:03Z",
+                "run_id": "tool-1",
+                "name": "read_file",
+                "input_str": "src/app.py",
+                "inputs": {"path": "src/app.py"},
+            },
+            {
+                "event": "on_tool_end",
+                "timestamp": "2024-06-01T10:00:04Z",
+                "run_id": "tool-1",
+                "name": "read_file",
+                "output": "print('hi')",
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.TOOL_CALL_STARTED
+        assert all_events[0].payload["tool_name"] == "read_file"
+        assert all_events[0].payload["tool_call_id"] == "tool-1"
+        assert all_events[0].payload["arguments"] == {"path": "src/app.py"}
+        assert all_events[1].kind == EventKind.TOOL_CALL_COMPLETED
+        assert all_events[1].payload["result"] == "print('hi')"
+
+    def test_tool_error(self, adapter):
+        """on_tool_error -> tool.call.failed."""
+        raw = {
+            "event": "on_tool_error",
+            "timestamp": "2024-06-01T10:00:05Z",
+            "run_id": "tool-2",
+            "name": "run_pytest",
+            "error": "CalledProcessError: exit 1",
+        }
+        events = list(adapter.parse(json.dumps(raw)))
+        assert events[0].kind == EventKind.TOOL_CALL_FAILED
+        assert events[0].payload["tool_name"] == "run_pytest"
+        assert events[0].payload["error"] == "CalledProcessError: exit 1"
+
+    def test_agent_action_motivates_tool_call(self, adapter):
+        """AgentAction.log is captured as intent and attached to the next tool call."""
+        events_raw = [
+            {
+                "event": "on_agent_action",
+                "timestamp": "2024-06-01T10:00:06Z",
+                "run_id": "act-1",
+                # AgentAction.log carries the ReAct thought/tool-selection rationale;
+                # the YAML sources payload "content" from this raw "log" field.
+                "log": "I should read the app module to find the bug.",
+                "tool": "read_file",
+                "tool_input": {"path": "src/app.py"},
+            },
+            {
+                "event": "on_tool_start",
+                "timestamp": "2024-06-01T10:00:07Z",
+                "run_id": "tool-3",
+                "name": "read_file",
+                "input_str": "src/app.py",
+                "inputs": {"path": "src/app.py"},
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.MESSAGE_ASSISTANT
+        assert all_events[0].payload["tool"] == "read_file"
+        assert all_events[0].payload["content"].startswith("I should read")
+        tool_event = all_events[1]
+        assert tool_event.kind == EventKind.TOOL_CALL_STARTED
+        assert tool_event.metadata.motivation is not None
+        assert "read the app module" in tool_event.metadata.motivation.intent
+
+    def test_agent_finish(self, adapter):
+        """on_agent_finish -> agent.completed with the final output."""
+        raw = {
+            "event": "on_agent_finish",
+            "timestamp": "2024-06-01T10:00:08Z",
+            "run_id": "fin-1",
+            "return_values": {"output": "All tests pass."},
+            "log": "Final Answer: All tests pass.",
+        }
+        events = list(adapter.parse(json.dumps(raw)))
+        assert events[0].kind == EventKind.AGENT_COMPLETED
+        assert events[0].payload["output"] == "All tests pass."
+
+    def test_retriever_events(self, adapter):
+        """on_retriever_start/end -> knowledge.query.*"""
+        events_raw = [
+            {
+                "event": "on_retriever_start",
+                "timestamp": "2024-06-01T10:00:09Z",
+                "run_id": "ret-1",
+                "name": "VectorStoreRetriever",
+                "query": "how does auth work",
+            },
+            {
+                "event": "on_retriever_end",
+                "timestamp": "2024-06-01T10:00:10Z",
+                "run_id": "ret-1",
+                "documents": [{"page_content": "Auth uses JWT..."}],
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.KNOWLEDGE_QUERY_STARTED
+        assert all_events[0].payload["query"] == "how does auth work"
+        assert all_events[1].kind == EventKind.KNOWLEDGE_QUERY_COMPLETED
+
+    def test_session_id_from_constructor(self, adapter):
+        """Session ID always comes from the adapter constructor."""
+        raw = {
+            "event": "on_chain_start",
+            "timestamp": "2024-06-01T10:00:00Z",
+            "run_id": "r",
+            "name": "g",
+            "inputs": {},
+        }
+        events = list(adapter.parse(json.dumps(raw)))
+        assert events[0].session_id == "lc-session"
+        assert events[0].metadata.source_framework == "langchain"
+
+
+class TestSemanticKernelMapping:
+    """Semantic Kernel filter YAML mapping coverage."""
+
+    @pytest.fixture
+    def adapter(self) -> MappedJsonAdapter:
+        return MappedJsonAdapter.from_yaml(
+            str(MAPPINGS_DIR / "semantic_kernel.yaml"), session_id="sk-session"
+        )
+
+    def test_prompt_function_llm_call(self, adapter):
+        """A prompt function (is_prompt=True) maps to llm.call.* with usage."""
+        events_raw = [
+            {
+                "type": "prompt_function.started",
+                "timestamp": "2024-06-01T10:00:00Z",
+                "invocation_id": "inv-1",
+                "function_name": "chat",
+                "plugin_name": "assistant",
+                "arguments": {"question": "list the files"},
+            },
+            {
+                "type": "prompt_function.completed",
+                "timestamp": "2024-06-01T10:00:02Z",
+                "invocation_id": "inv-1",
+                "function_name": "chat",
+                "plugin_name": "assistant",
+                "model": "gpt-4o",
+                "result": "I'll list them now.",
+                "usage": {"prompt_tokens": 200, "completion_tokens": 25},
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.LLM_CALL_STARTED
+        assert all_events[0].payload["tool_call_id"] == "inv-1"
+        assert all_events[1].kind == EventKind.LLM_CALL_COMPLETED
+        assert all_events[1].payload["model"] == "gpt-4o"
+        assert all_events[1].payload["input_tokens"] == 200
+        assert all_events[1].payload["output_tokens"] == 25
+        assert all_events[1].payload["output"] == "I'll list them now."
+
+    def test_native_function_tool_call(self, adapter):
+        """A native function (is_prompt=False) maps to tool.call.*"""
+        events_raw = [
+            {
+                "type": "native_function.started",
+                "timestamp": "2024-06-01T10:00:03Z",
+                "invocation_id": "inv-2",
+                "function_name": "read_file",
+                "plugin_name": "repo",
+                "arguments": {"path": "src/app.py"},
+            },
+            {
+                "type": "native_function.completed",
+                "timestamp": "2024-06-01T10:00:04Z",
+                "invocation_id": "inv-2",
+                "function_name": "read_file",
+                "plugin_name": "repo",
+                "result": "print('hi')",
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.TOOL_CALL_STARTED
+        assert all_events[0].payload["tool_name"] == "read_file"
+        assert all_events[0].payload["plugin_name"] == "repo"
+        assert all_events[1].kind == EventKind.TOOL_CALL_COMPLETED
+        assert all_events[1].payload["result"] == "print('hi')"
+
+    def test_native_function_failure(self, adapter):
+        """native_function.failed -> tool.call.failed."""
+        raw = {
+            "type": "native_function.failed",
+            "timestamp": "2024-06-01T10:00:05Z",
+            "invocation_id": "inv-3",
+            "function_name": "run_pytest",
+            "plugin_name": "repo",
+            "error": "exit code 1",
+        }
+        events = list(adapter.parse(json.dumps(raw)))
+        assert events[0].kind == EventKind.TOOL_CALL_FAILED
+        assert events[0].payload["tool_name"] == "run_pytest"
+        assert events[0].payload["error"] == "exit code 1"
+
+    def test_auto_function_invocation(self, adapter):
+        """auto_function.* maps to tool.call.* and carries the SK sequence indices."""
+        events_raw = [
+            {
+                "type": "auto_function.started",
+                "timestamp": "2024-06-01T10:00:06Z",
+                "invocation_id": "inv-4",
+                "function_name": "write_file",
+                "plugin_name": "repo",
+                "arguments": {"path": "src/app.py", "content": "x = 1"},
+                "function_count": 2,
+                "request_sequence_index": 0,
+                "function_sequence_index": 1,
+            },
+            {
+                "type": "auto_function.completed",
+                "timestamp": "2024-06-01T10:00:07Z",
+                "invocation_id": "inv-4",
+                "function_name": "write_file",
+                "plugin_name": "repo",
+                "result": "wrote 5 bytes",
+                "terminate": False,
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == EventKind.TOOL_CALL_STARTED
+        assert all_events[0].payload["tool_name"] == "write_file"
+        assert all_events[0].payload["function_sequence_index"] == 1
+        assert all_events[1].kind == EventKind.TOOL_CALL_COMPLETED
+        assert all_events[1].payload["result"] == "wrote 5 bytes"
+
+    def test_prompt_rendering_motivates_tool_call(self, adapter):
+        """The rendered prompt is captured as intent and attached to later tool calls."""
+        events_raw = [
+            {
+                "type": "prompt_rendering.completed",
+                "timestamp": "2024-06-01T10:00:08Z",
+                "function_name": "chat",
+                "plugin_name": "assistant",
+                # PromptRenderContext.rendered_prompt is the fully rendered prompt;
+                # the YAML sources payload "content" from this raw "rendered_prompt".
+                "rendered_prompt": "System: you are a coding agent. User: fix the bug in app.py",
+            },
+            {
+                "type": "auto_function.started",
+                "timestamp": "2024-06-01T10:00:09Z",
+                "invocation_id": "inv-5",
+                "function_name": "read_file",
+                "plugin_name": "repo",
+                "arguments": {"path": "src/app.py"},
+            },
+        ]
+        all_events = []
+        for raw in events_raw:
+            all_events.extend(adapter.parse(json.dumps(raw)))
+        assert all_events[0].kind == "prompt.render.completed"
+        assert all_events[0].payload["content"].startswith("System:")
+        tool_event = all_events[1]
+        assert tool_event.kind == EventKind.TOOL_CALL_STARTED
+        assert tool_event.metadata.motivation is not None
+        assert "coding agent" in tool_event.metadata.motivation.intent
+
+    def test_session_id_and_framework(self, adapter):
+        """Session ID from constructor; framework provenance recorded."""
+        raw = {
+            "type": "prompt_rendering.started",
+            "timestamp": "2024-06-01T10:00:00Z",
+            "function_name": "chat",
+            "plugin_name": "assistant",
+        }
+        events = list(adapter.parse(json.dumps(raw)))
+        assert events[0].kind == "prompt.render.started"
+        assert events[0].session_id == "sk-session"
+        assert events[0].metadata.source_framework == "semantic_kernel"


### PR DESCRIPTION
## What & why

Closes audit gap **S3-2 (Medium)**. The `langchain` and `semantic_kernel` frameworks are gated (`gate_langchain` / `gate_semantic_kernel` in `governance/pipeline.py`) but shipped **no observation-mapping YAML**, unlike the ~22 other frameworks that each ship one under `src/traceforge/mappings/`. This adds both mappings so a native langchain / semantic-kernel event stream maps onto traceforge `SessionEvent`s the same way the others do.

**Additive / new-files-only** — no existing mappings, code, or docs are modified. (Does **not** add `gemini.yaml` / `cursor.yaml`; a separate PR owns those.)

## Deliverables

| File | Purpose |
|------|---------|
| `src/traceforge/mappings/langchain.yaml` | Maps flattened `BaseCallbackHandler` callbacks (chain / LLM / chat model / tool / agent / retriever) to canonical kinds. Model via `metadata.ls_model_name`; token usage via `response.llm_output.token_usage.*`; `AgentAction.log` → tool-call motivation. Deliberately distinct from `langgraph.yaml` (which targets `astream_events(version="v2")`, nesting I/O under `data`). |
| `src/traceforge/mappings/semantic_kernel.yaml` | Maps SK **filter** ticks — `FUNCTION_INVOCATION` (split on `function.metadata.is_prompt` into LLM vs tool calls), `AUTO_FUNCTION_INVOCATION`, `PROMPT_RENDERING` — to canonical kinds. Rendered prompt captured as motivation. |
| `scripts/capture_traces/capture_langchain.py` | Repeatable capture path: a `BaseCallbackHandler` that flattens each callback into one JSON row (forward-filling `name` via a run_id→name map), driving a real `AgentExecutor`. Mirrors existing capture scripts. |
| `scripts/capture_traces/capture_semantic_kernel.py` | Registers the three SK filters on a real `Kernel` with auto function calling and emits flat rows. Mirrors existing capture scripts. |
| `tests/integration/test_langchain_sk_mappings.py` | Load / schema-validate / map representative events for both mappings (14 tests), following `test_new_mappings.py`. |

## How the field mappings were validated

- **Grounded against the installed APIs** — introspected **langchain-core 1.4.7** and **semantic-kernel 1.36.0** to confirm exact callback signatures and filter-context field names (e.g. `LLMResult.llm_output.token_usage`, `metadata.ls_model_name`, `PromptRenderContext.rendered_prompt`, `KernelFunctionMetadata.is_prompt`, `AutoFunctionInvocationContext.function_count/…`).
- **New tests pass** — 14 new cases assert canonical kinds, payload extraction, and motivation flow. Two intentional assertions confirm the YAMLs source from the *real* framework fields (`AgentAction.log`, `rendered_prompt`), not convenience aliases.
- **No regressions** — full suite green: **3013 passed, 7 skipped**. The glob-parametrized invariants (`TestAllYAMLMappingsLoadable`, `TestYAMLMappings`, `TestAllMappingsMotivationParse`) auto-include both new YAMLs and pass.
- **Lint clean** — `ruff check .` and `ruff format --check .` (pinned `ruff==0.15.20`, matching CI).

## Note
Deterministic, no network at import. Capture scripts make real paid OpenAI calls when run manually and are **not** imported by the test suite (`testpaths=["tests"]`). This unblocks a later observation-subscriber PR's langchain/SK phase.

**Holding for coordinator review — please do not merge.**