### PR TITLE
feat(sdk): in-process observe_* auto-subscriber — crewai + openai_agents (PR-J phase 1)

### DIFF
--- a/src/traceforge/sdk/__init__.py
+++ b/src/traceforge/sdk/__init__.py
@@ -29,6 +29,7 @@ from traceforge.sdk.gate_types import (  # noqa: E402
     ToolCallRequest,
     ToolCallResult,
 )
+from traceforge.sdk.observe import ObservationHandle  # noqa: E402
 from traceforge.sdk.verdict import (  # noqa: E402
     Decision,
     PostflightGate,
@@ -44,6 +45,7 @@ from traceforge.sdk.pipeline import Pipeline  # noqa: E402
 
 __all__ = [
     "Pipeline",
+    "ObservationHandle",
     "EventTrace",
     "TraceStage",
     "Verdict",

--- a/src/traceforge/sdk/observe.py
+++ b/src/traceforge/sdk/observe.py
@@ -1,0 +1,541 @@
+"""In-process observation auto-subscriber (PR-J phase 1).
+
+This module productizes the ad-hoc capture glue under ``scripts/capture_traces/``
+into a first-class, shipped SDK feature. It subscribes to a framework's **native**
+global event bus / trace processor, maps each native event through the **existing**
+``traceforge/mappings/<framework>.yaml`` config (via
+:class:`~traceforge.adapters.mapped_json.MappedJsonAdapter`), and pushes the resulting
+:class:`~traceforge.types.SessionEvent` objects into a live SDK
+:class:`~traceforge.sdk.pipeline.Pipeline` through its ``push`` seam — exactly the
+same code path a file-watch adapter would use.
+
+Phase 1 covers the two frameworks that expose a global bus / processor:
+
+* **CrewAI** — ``crewai.events.crewai_event_bus`` (``register_handler`` / ``off``).
+* **OpenAI Agents SDK** — ``agents.add_trace_processor`` /
+  ``agents.set_trace_processors`` with a duck-typed ``TracingProcessor``.
+
+LangChain/LangGraph (callback-handler based) and the OpenTelemetry bridge
+(pydantic_ai / smolagents / maf / semantic_kernel) are intentionally **out of scope**
+here — they are phase 2/3 and depend on mapping files another PR is still adding.
+
+Design notes
+------------
+* Each ``observe_*`` returns an :class:`ObservationHandle`. The handle owns its native
+  subscription and tears it down cleanly via :meth:`ObservationHandle.stop` (idempotent),
+  ``with`` / ``async with``, leaving **no** residual global subscription.
+* The SDK pipeline is asyncio-single-threaded, but native buses invoke callbacks from
+  arbitrary threads (CrewAI dispatches sync handlers on a ``ThreadPoolExecutor``). Every
+  ``observe_*`` therefore captures the running loop at call time and marshals pushes onto
+  it with :func:`asyncio.run_coroutine_threadsafe` — never blocking on the result from the
+  callback thread. :meth:`ObservationHandle.drain` awaits the in-flight pushes for
+  deterministic teardown / testing.
+* Native framework imports are **lazy** (inside the default bus / registration helpers), so
+  importing this module never imports crewai / agents and never touches the network. The
+  bus / processor registration hooks are injectable, which is what the test-suite uses in
+  place of the real (uninstalled) frameworks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import pkgutil
+import threading
+from concurrent.futures import Future
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from traceforge.adapters.mapped_json import MappedJsonAdapter
+    from traceforge.sdk.pipeline import Pipeline
+    from traceforge.types import SessionEvent
+
+logger = logging.getLogger(__name__)
+
+# ``.../traceforge/sdk/observe.py`` -> ``.../traceforge/mappings``. Resolved from this
+# file (not via importing the top-level package) to avoid any import-time coupling.
+_MAPPINGS_DIR = Path(__file__).resolve().parent.parent / "mappings"
+
+
+def _load_adapter(framework: str, session_id: str) -> "MappedJsonAdapter":
+    """Build the shared mapping adapter for ``framework`` (reuses the shipped YAML)."""
+    from traceforge.adapters.mapped_json import MappedJsonAdapter
+
+    return MappedJsonAdapter.from_yaml(str(_MAPPINGS_DIR / f"{framework}.yaml"), session_id)
+
+
+# ─── JSON-able serialization (ported from scripts/capture_traces/capture_crewai.py) ──
+
+
+def _jsonable(value: Any, seen: set[int] | None = None) -> Any:
+    """Generic JSON conversion that keeps native field names and containers.
+
+    Mirrors the capture-script serializer so the native CrewAI event object is turned
+    into the same flat dict shape the ``crewai`` YAML mapping already expects.
+    """
+    seen = seen or set()
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    obj_id = id(value)
+    if obj_id in seen:
+        return f"<circular:{type(value).__name__}>"
+    if isinstance(value, dict):
+        seen.add(obj_id)
+        return {str(k): _jsonable(v, seen) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        seen.add(obj_id)
+        return [_jsonable(v, seen) for v in value]
+    if isinstance(value, type):
+        return f"{value.__module__}.{value.__qualname__}"
+    if hasattr(value, "model_dump"):
+        seen.add(obj_id)
+        try:
+            return _jsonable(value.model_dump(mode="json"), seen)
+        except Exception:
+            try:
+                return _jsonable(value.model_dump(mode="python"), seen)
+            except Exception:
+                return _jsonable(getattr(value, "__dict__", str(value)), seen)
+    if hasattr(value, "dict"):
+        seen.add(obj_id)
+        try:
+            return _jsonable(value.dict(), seen)
+        except Exception:
+            return _jsonable(getattr(value, "__dict__", str(value)), seen)
+    if hasattr(value, "__dict__") and not callable(value):
+        seen.add(obj_id)
+        return _jsonable(vars(value), seen)
+    return str(value)
+
+
+# ─── Base handle ─────────────────────────────────────────────────────────────
+
+
+class ObservationHandle:
+    """A live in-process subscription bridging a native event bus into the pipeline.
+
+    Constructed and activated by the ``observe_*`` functions; not meant to be
+    instantiated directly. Call :meth:`stop` (or use the object as a context manager)
+    to unsubscribe cleanly. Use :meth:`drain` to await pushes that native callbacks
+    scheduled onto the pipeline loop.
+    """
+
+    def __init__(self, pipeline: "Pipeline", framework: str, adapter: "MappedJsonAdapter") -> None:
+        self._pipeline = pipeline
+        self._framework = framework
+        self._adapter = adapter
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            raise RuntimeError(
+                f"observe_{framework}() must be called from within a running asyncio event "
+                "loop (the SDK pipeline is async). Call it inside an async function; run a "
+                "framework's blocking entrypoint via asyncio.to_thread(...) so this loop stays "
+                "free to receive pushes."
+            ) from None
+        self._lock = threading.Lock()
+        self._pending: set[Future] = set()
+        self._active = False
+
+    # ---- lifecycle ----------------------------------------------------------
+
+    def _activate(self) -> "ObservationHandle":
+        """Register with the native bus and mark the handle live. Returns ``self``."""
+        self._subscribe()
+        self._active = True
+        return self
+
+    @property
+    def active(self) -> bool:
+        """True while the native subscription is installed (False after :meth:`stop`)."""
+        return self._active
+
+    @property
+    def framework(self) -> str:
+        """The phase-1 framework this handle observes (``crewai`` / ``openai_agents``)."""
+        return self._framework
+
+    def stop(self) -> None:
+        """Unsubscribe from the native bus. Idempotent; leaves no residual subscription."""
+        if not self._active:
+            return
+        self._active = False
+        try:
+            self._unsubscribe()
+        except Exception:
+            logger.warning("observe(%s): error during unsubscribe", self._framework, exc_info=True)
+
+    async def drain(self) -> None:
+        """Await all pushes that native callbacks have scheduled onto the pipeline loop."""
+        with self._lock:
+            pending = list(self._pending)
+        if pending:
+            await asyncio.gather(
+                *(asyncio.wrap_future(fut) for fut in pending), return_exceptions=True
+            )
+
+    def __enter__(self) -> "ObservationHandle":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
+
+    async def __aenter__(self) -> "ObservationHandle":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        try:
+            await self.drain()
+        finally:
+            self.stop()
+
+    # ---- native-callback -> pipeline bridge --------------------------------
+
+    def _ingest(self, native: Any) -> None:
+        """Map one native event dict and schedule the resulting pushes onto the loop.
+
+        Safe to call from any thread. Never raises into the native bus: mapping errors
+        are swallowed (logged) so one bad event can't tear down the framework's run.
+        """
+        if not self._active or not isinstance(native, dict):
+            return
+        loop = self._loop
+        if loop.is_closed():
+            return
+        try:
+            with self._lock:
+                events = self._map(native)
+        except Exception:
+            logger.warning(
+                "observe(%s): failed to map native event", self._framework, exc_info=True
+            )
+            return
+        if not events:
+            return
+        try:
+            fut = asyncio.run_coroutine_threadsafe(self._push(events), loop)
+        except RuntimeError:
+            return  # loop is shutting down
+        with self._lock:
+            self._pending.add(fut)
+        fut.add_done_callback(self._discard)
+
+    def _discard(self, fut: Future) -> None:
+        with self._lock:
+            self._pending.discard(fut)
+
+    def _map(self, native: dict[str, Any]) -> list["SessionEvent"]:
+        """Run the native dict through the YAML mapping, attaching the raw event.
+
+        Replicates :meth:`JsonLineAdapter.parse`'s raw-event attach (the base normally
+        does this, but we call ``parse_dict`` directly to skip JSON (de)serialization).
+        """
+        out: list[SessionEvent] = []
+        for event in self._adapter.parse_dict(native):
+            if event.raw_event is None:
+                event = event.model_copy(update={"raw_event": native})
+            out.append(event)
+        return out
+
+    async def _push(self, events: "Sequence[SessionEvent]") -> None:
+        for event in events:
+            await self._pipeline.push(event)
+
+    # ---- subclass hooks -----------------------------------------------------
+
+    def _subscribe(self) -> None:  # pragma: no cover - abstract-ish
+        raise NotImplementedError
+
+    def _unsubscribe(self) -> None:  # pragma: no cover - abstract-ish
+        raise NotImplementedError
+
+
+# ─── CrewAI ──────────────────────────────────────────────────────────────────
+
+
+def _default_crewai_bus() -> Any:
+    """Return the process-global CrewAI event bus singleton (lazy native import)."""
+    from crewai.events import crewai_event_bus
+
+    return crewai_event_bus
+
+
+def _discover_crewai_event_types() -> list[type]:
+    """Discover every concrete ``BaseEvent`` subclass CrewAI ships.
+
+    CrewAI's bus dispatches by **exact** ``type(event)`` (no MRO walk), so a handler must
+    be registered per concrete event class. This mirrors the capture script's pkgutil walk
+    over ``crewai.events.types``.
+    """
+    from crewai.events.types.event_bus_types import BaseEvent  # type: ignore[import-not-found]
+    import crewai.events.types as event_types_pkg  # type: ignore[import-not-found]
+
+    found: list[type] = []
+    seen: set[type] = set()
+    for module_info in pkgutil.iter_modules(event_types_pkg.__path__):
+        module = importlib.import_module(f"{event_types_pkg.__name__}.{module_info.name}")
+        for value in vars(module).values():
+            if (
+                isinstance(value, type)
+                and issubclass(value, BaseEvent)
+                and value is not BaseEvent
+                and value not in seen
+            ):
+                seen.add(value)
+                found.append(value)
+    return found
+
+
+class _CrewAiObserver(ObservationHandle):
+    """Bridges the CrewAI event bus into the pipeline."""
+
+    def __init__(
+        self,
+        pipeline: "Pipeline",
+        *,
+        session_id: str,
+        event_bus: Any | None,
+        event_types: "Iterable[type] | None",
+    ) -> None:
+        self._bus = event_bus if event_bus is not None else _default_crewai_bus()
+        self._event_types: list[type] = (
+            list(event_types) if event_types is not None else _discover_crewai_event_types()
+        )
+        # One shared handler registered under every event type; CrewAI stores handlers in a
+        # per-type set, so ``off`` with the same object removes it cleanly (no leak).
+        self._handler = self._make_handler()
+        super().__init__(pipeline, "crewai", _load_adapter("crewai", session_id))
+
+    def _make_handler(self) -> Callable[..., None]:
+        observer = self
+
+        def handler(source: Any, event: Any, *args: Any, **kwargs: Any) -> None:
+            observer._ingest(_jsonable(event))
+
+        return handler
+
+    def _subscribe(self) -> None:
+        for event_type in self._event_types:
+            self._bus.register_handler(event_type, self._handler)
+
+    def _unsubscribe(self) -> None:
+        for event_type in self._event_types:
+            try:
+                self._bus.off(event_type, self._handler)
+            except Exception:
+                logger.warning(
+                    "observe(crewai): failed to detach handler for %r", event_type, exc_info=True
+                )
+
+
+def observe_crewai(
+    pipeline: "Pipeline",
+    *,
+    session_id: str = "crewai",
+    event_bus: Any | None = None,
+    event_types: "Iterable[type] | None" = None,
+) -> ObservationHandle:
+    """Subscribe to CrewAI's global event bus and stream mapped events into ``pipeline``.
+
+    Args:
+        pipeline: The live SDK :class:`~traceforge.sdk.pipeline.Pipeline` to push into.
+        session_id: Session id stamped on every produced event (default ``"crewai"``).
+        event_bus: Native bus to subscribe to; defaults to ``crewai.events.crewai_event_bus``.
+            Injectable for testing.
+        event_types: Concrete CrewAI event classes to register handlers for; defaults to
+            auto-discovering all shipped ``BaseEvent`` subclasses. Injectable for testing.
+
+    Returns:
+        An :class:`ObservationHandle`; call :meth:`~ObservationHandle.stop` (or use it as a
+        context manager) to unsubscribe.
+
+    Must be called from within a running asyncio loop. Because ``crew.kickoff()`` blocks and
+    CrewAI runs handlers on worker threads, run the kickoff via ``asyncio.to_thread(...)`` so
+    this loop stays free to receive pushes.
+    """
+    return _CrewAiObserver(
+        pipeline, session_id=session_id, event_bus=event_bus, event_types=event_types
+    )._activate()
+
+
+# ─── OpenAI Agents SDK ───────────────────────────────────────────────────────
+
+
+def _openai_trace_provider() -> Any | None:
+    """Best-effort handle on the Agents SDK global trace provider (lazy import)."""
+    try:
+        from agents.tracing import get_trace_provider
+
+        return get_trace_provider()
+    except Exception:
+        pass
+    try:
+        from agents.tracing.setup import GLOBAL_TRACE_PROVIDER
+
+        return GLOBAL_TRACE_PROVIDER
+    except Exception:
+        return None
+
+
+def _current_openai_processors(provider: Any) -> list[Any] | None:
+    if provider is None:
+        return None
+    multi = getattr(provider, "_multi_processor", None)
+    processors = getattr(multi, "_processors", None)
+    if processors is None:
+        return None
+    return list(processors)
+
+
+def _default_openai_register(processor: Any) -> None:
+    """Append ``processor`` to the Agents SDK's global processor list (additive)."""
+    from agents import add_trace_processor
+
+    add_trace_processor(processor)
+
+
+def _default_openai_unregister(processor: Any) -> None:
+    """Remove exactly ``processor`` from the Agents SDK's global processor list.
+
+    The SDK exposes no public "remove one processor" API, so this reads the provider's
+    current processors and re-sets the list without ours, leaving every other processor
+    (e.g. the default batch exporter) untouched.
+    """
+    from agents import set_trace_processors
+
+    current = _current_openai_processors(_openai_trace_provider())
+    if current is None:
+        logger.warning(
+            "observe(openai_agents): could not read current trace processors; "
+            "teardown could not confirm removal"
+        )
+        return
+    set_trace_processors([proc for proc in current if proc is not processor])
+
+
+class _OpenAiAgentsObserver(ObservationHandle):
+    """Bridges the OpenAI Agents SDK tracing pipeline into the pipeline."""
+
+    def __init__(
+        self,
+        pipeline: "Pipeline",
+        *,
+        session_id: str,
+        register: Callable[[Any], None] | None,
+        unregister: Callable[[Any], None] | None,
+    ) -> None:
+        self._register = register if register is not None else _default_openai_register
+        self._unregister = unregister if unregister is not None else _default_openai_unregister
+        super().__init__(pipeline, "openai_agents", _load_adapter("openai_agents", session_id))
+        self._processor = self._make_processor()
+
+    def _make_processor(self) -> Any:
+        observer = self
+
+        class _Processor:
+            """Duck-typed ``agents.tracing.TracingProcessor``.
+
+            The SDK's multi-processor calls these by name without an isinstance check, so a
+            plain object suffices and we avoid importing ``agents`` to build it.
+            """
+
+            def on_trace_start(self, trace: Any) -> None:
+                observer._ingest_export(trace)
+
+            def on_trace_end(self, trace: Any) -> None:
+                pass
+
+            def on_span_start(self, span: Any) -> None:
+                pass
+
+            def on_span_end(self, span: Any) -> None:
+                observer._ingest_export(span)
+
+            def shutdown(self) -> None:
+                pass
+
+            def force_flush(self) -> None:
+                pass
+
+        return _Processor()
+
+    @property
+    def processor(self) -> Any:
+        """The duck-typed tracing processor registered with the Agents SDK."""
+        return self._processor
+
+    def _ingest_export(self, obj: Any) -> None:
+        export = getattr(obj, "export", None)
+        data = export() if callable(export) else obj
+        if isinstance(data, dict):
+            self._ingest(data)
+
+    def _subscribe(self) -> None:
+        self._register(self._processor)
+
+    def _unsubscribe(self) -> None:
+        self._unregister(self._processor)
+
+
+def observe_openai_agents(
+    pipeline: "Pipeline",
+    *,
+    session_id: str = "openai_agents",
+    register: Callable[[Any], None] | None = None,
+    unregister: Callable[[Any], None] | None = None,
+) -> ObservationHandle:
+    """Register an Agents SDK trace processor that streams mapped events into ``pipeline``.
+
+    Args:
+        pipeline: The live SDK :class:`~traceforge.sdk.pipeline.Pipeline` to push into.
+        session_id: Session id stamped on every produced event (default ``"openai_agents"``).
+        register: Callable that installs the processor; defaults to ``agents.add_trace_processor``.
+            Injectable for testing.
+        unregister: Callable that removes the processor; defaults to filtering it out of
+            ``agents.set_trace_processors``. Injectable for testing.
+
+    Returns:
+        An :class:`ObservationHandle`; call :meth:`~ObservationHandle.stop` (or use it as a
+        context manager) to unregister the processor.
+
+    Must be called from within a running asyncio loop (the Agents SDK ``Runner`` is async).
+    """
+    return _OpenAiAgentsObserver(
+        pipeline, session_id=session_id, register=register, unregister=unregister
+    )._activate()
+
+
+# ─── Unified dispatch ────────────────────────────────────────────────────────
+
+_OBSERVERS: dict[str, Callable[..., ObservationHandle]] = {
+    "crewai": observe_crewai,
+    "openai_agents": observe_openai_agents,
+}
+
+
+def observe(pipeline: "Pipeline", framework: str, **kwargs: Any) -> ObservationHandle:
+    """Subscribe to ``framework``'s native bus by name (phase 1: crewai / openai_agents).
+
+    Thin dispatcher over :func:`observe_crewai` / :func:`observe_openai_agents`; extra
+    keyword arguments are forwarded to the selected observer.
+    """
+    try:
+        factory = _OBSERVERS[framework]
+    except KeyError:
+        supported = ", ".join(sorted(_OBSERVERS))
+        raise ValueError(
+            f"observe: unsupported framework {framework!r}; phase-1 supports: {supported}"
+        ) from None
+    return factory(pipeline, **kwargs)
+
+
+__all__ = [
+    "ObservationHandle",
+    "observe",
+    "observe_crewai",
+    "observe_openai_agents",
+]

--- a/src/traceforge/sdk/pipeline.py
+++ b/src/traceforge/sdk/pipeline.py
@@ -54,6 +54,7 @@ from traceforge.pipeline import EventPipeline
 if TYPE_CHECKING:
     from traceforge.config.models import GovernanceConfig
     from traceforge.sdk.gate_policy import GatePolicy
+    from traceforge.sdk.observe import ObservationHandle
     from traceforge.sinks.base import StorageSink
     from traceforge.trace import EventTrace
     from traceforge.types import SessionEvent, TelemetrySpan, UsageRecord
@@ -251,6 +252,47 @@ class Pipeline:
     def gate_openai_agents(self, agent):
         """Gate an OpenAI Agents SDK agent."""
         return self._governance.gate_openai_agents(agent)
+
+    # ---- in-process observation auto-subscriber (PR-J phase 1) -------------
+    # Additive, self-contained facade over ``traceforge.sdk.observe``: subscribe to a
+    # framework's NATIVE global bus/processor, map native events through the existing
+    # mappings/*.yaml, and push the results via ``push`` above. Each returns an
+    # ObservationHandle whose ``stop()`` unsubscribes with no residual global state.
+    # observe.py is imported lazily so this module never pulls in a native framework.
+
+    def observe_crewai(
+        self,
+        *,
+        session_id: str = "crewai",
+        event_bus=None,
+        event_types=None,
+    ) -> "ObservationHandle":
+        """Subscribe to CrewAI's global event bus; stream mapped events into this pipeline."""
+        from traceforge.sdk.observe import observe_crewai
+
+        return observe_crewai(
+            self, session_id=session_id, event_bus=event_bus, event_types=event_types
+        )
+
+    def observe_openai_agents(
+        self,
+        *,
+        session_id: str = "openai_agents",
+        register=None,
+        unregister=None,
+    ) -> "ObservationHandle":
+        """Register an OpenAI Agents SDK trace processor that streams into this pipeline."""
+        from traceforge.sdk.observe import observe_openai_agents
+
+        return observe_openai_agents(
+            self, session_id=session_id, register=register, unregister=unregister
+        )
+
+    def observe(self, framework: str, **kwargs) -> "ObservationHandle":
+        """Subscribe to ``framework``'s native bus by name (phase 1: crewai / openai_agents)."""
+        from traceforge.sdk.observe import observe
+
+        return observe(self, framework, **kwargs)
 
     # ---- escape hatches ----------------------------------------------------
 

--- a/tests/e2e/test_observation_pipeline_e2e.py
+++ b/tests/e2e/test_observation_pipeline_e2e.py
@@ -11,6 +11,7 @@ Also covers the 5 YAML mappings that had zero test coverage:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -18,6 +19,7 @@ import pytest
 
 from traceforge.adapters.mapped_json import MappedJsonAdapter
 from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk import Pipeline
 from traceforge.types import EventKind
 
 MAPPINGS_DIR = Path(__file__).resolve().parent.parent.parent / "src" / "traceforge" / "mappings"
@@ -781,3 +783,406 @@ class TestAiderFullPipelineE2E:
 
         assert len(all_metas) == 3
         assert all(m is not None for m in all_metas)
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# In-process observe_* auto-subscriber (PR-J phase 1: crewai + openai_agents)
+#
+# These exercise the shipped SDK feature end to end: subscribe to a framework's
+# NATIVE global bus/processor, map native events through the existing YAML mappings,
+# and push the resulting SessionEvents through Pipeline.push into a RecordingSink.
+# The native frameworks aren't installed in the test env, so the bus / processor
+# registration seams are injected with faithful fakes (CrewAI dispatches by EXACT
+# event type; OpenAI Agents exposes Trace.export()/Span.export()).
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class _FakeCrewBus:
+    """Stand-in for ``crewai.events.crewai_event_bus``.
+
+    Dispatches to handlers keyed by the EXACT event type (CrewAI does no MRO walk),
+    exposing the ``register_handler`` / ``off`` pair the observer subscribes through.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[type, list] = {}
+
+    def register_handler(self, event_type: type, handler) -> None:
+        self._handlers.setdefault(event_type, []).append(handler)
+
+    def off(self, event_type: type, handler) -> None:
+        handlers = self._handlers.get(event_type)
+        if not handlers:
+            return
+        remaining = [h for h in handlers if h is not handler]
+        if remaining:
+            self._handlers[event_type] = remaining
+        else:
+            del self._handlers[event_type]
+
+    def emit(self, event, source=None) -> None:
+        for handler in list(self._handlers.get(type(event), [])):
+            handler(source, event)
+
+    @property
+    def total_handlers(self) -> int:
+        return sum(len(handlers) for handlers in self._handlers.values())
+
+
+class _FakeCrewEvent:
+    """A native-style CrewAI event: plain object whose ``__dict__`` is the payload.
+
+    It deliberately has no ``model_dump`` / ``dict`` so the observer's ``_jsonable``
+    serializer walks ``vars()`` — the same shape the ``crewai`` YAML mapping expects.
+    """
+
+    def __init__(self, **fields) -> None:
+        self.__dict__.update(fields)
+
+
+class _ToolUsageStarted(_FakeCrewEvent):
+    pass
+
+
+class _ToolUsageFinished(_FakeCrewEvent):
+    pass
+
+
+class _CrewKickoffStarted(_FakeCrewEvent):
+    pass
+
+
+class _LlmCallCompleted(_FakeCrewEvent):
+    pass
+
+
+_CREWAI_EVENT_TYPES = [
+    _ToolUsageStarted,
+    _ToolUsageFinished,
+    _CrewKickoffStarted,
+    _LlmCallCompleted,
+]
+
+
+class _FakeExport:
+    """Native-style OpenAI Agents trace/span: exposes ``export()`` returning a dict."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def export(self) -> dict:
+        return self._data
+
+
+class _FakeProcessorRegistry:
+    """Injected register/unregister seam for the OpenAI Agents observer."""
+
+    def __init__(self) -> None:
+        self.processors: list = []
+
+    def register(self, processor) -> None:
+        self.processors.append(processor)
+
+    def unregister(self, processor) -> None:
+        self.processors = [p for p in self.processors if p is not processor]
+
+
+def _fake_trace(trace_id: str = "trace_1", workflow_name: str = "demo_wf") -> _FakeExport:
+    return _FakeExport(
+        {
+            "object": "trace",
+            "id": trace_id,
+            "workflow_name": workflow_name,
+            "group_id": None,
+            "metadata": None,
+        }
+    )
+
+
+def _fake_function_span(
+    span_id: str = "span_1",
+    trace_id: str = "trace_1",
+    name: str = "read_file",
+    arguments: str = '{"path": "main.py"}',
+    output: str = "file contents",
+    error=None,
+) -> _FakeExport:
+    return _FakeExport(
+        {
+            "object": "trace.span",
+            "id": span_id,
+            "trace_id": trace_id,
+            "parent_id": None,
+            "started_at": "2025-06-01T10:00:00Z",
+            "ended_at": "2025-06-01T10:00:01Z",
+            "error": error,
+            "span_data": {"type": "function", "name": name, "input": arguments, "output": output},
+        }
+    )
+
+
+def _new_pipeline(recording_sink) -> Pipeline:
+    """A deterministic observation-only pipeline (no ML structuring, no governance)."""
+    return Pipeline.create(sinks=[recording_sink.sink], enable_structure=False, governance=False)
+
+
+class TestObserveCrewAiE2E:
+    """observe_crewai: subscribe to the CrewAI bus and stream mapped SessionEvents."""
+
+    async def test_subscribe_and_push_mapped_events(self, recording_sink):
+        # observe's contract is "map native events and push the resulting SessionEvents".
+        # Assert that at the push seam: spy the facade's push so the mapping check is exact
+        # and deterministic. (Downstream enrichment may coalesce/reorder related tool events;
+        # that is the pipeline's concern and is covered by the real-sink wiring test below.)
+        pipeline = _new_pipeline(recording_sink)
+        pushed: list = []
+
+        async def _spy_push(event):
+            pushed.append(event)
+
+        pipeline.push = _spy_push
+        bus = _FakeCrewBus()
+        handle = pipeline.observe_crewai(
+            session_id="crew-sess", event_bus=bus, event_types=_CREWAI_EVENT_TYPES
+        )
+        try:
+            assert handle.active is True
+            assert handle.framework == "crewai"
+            # subscribe registers exactly one handler per concrete event type
+            assert bus.total_handlers == len(_CREWAI_EVENT_TYPES)
+
+            bus.emit(
+                _CrewKickoffStarted(
+                    type="crew_kickoff_started",
+                    crew_name="demo-crew",
+                    event_id="evt-kick",
+                    timestamp="2025-06-01T10:00:00Z",
+                )
+            )
+            bus.emit(
+                _ToolUsageStarted(
+                    type="tool_usage_started",
+                    tool_name="read_file",
+                    tool_args={"path": "main.py"},
+                    event_id="call-1",
+                    timestamp="2025-06-01T10:00:01Z",
+                )
+            )
+            bus.emit(
+                _ToolUsageFinished(
+                    type="tool_usage_finished",
+                    tool_name="read_file",
+                    output="file contents",
+                    timestamp="2025-06-01T10:00:02Z",
+                )
+            )
+            await handle.drain()
+        finally:
+            handle.stop()
+            await pipeline.close()
+
+        kinds = [event.kind for event in pushed]
+        assert kinds == ["session.started", "tool.call.started", "tool.call.completed"]
+
+        started = pushed[1]
+        assert started.session_id == "crew-sess"
+        assert started.payload["tool_name"] == "read_file"
+        assert started.payload["tool_call_id"] == "call-1"
+        assert started.payload["arguments"] == {"path": "main.py"}
+        # the verbatim native event is preserved as raw_event
+        assert started.raw_event is not None
+        assert started.raw_event["type"] == "tool_usage_started"
+
+        finished = pushed[2]
+        assert finished.payload["tool_name"] == "read_file"
+        assert finished.payload["result"] == "file contents"
+
+    async def test_cross_thread_callback_push(self, recording_sink):
+        """CrewAI runs sync handlers on a worker thread; pushes must marshal to the loop."""
+        pipeline = _new_pipeline(recording_sink)
+        bus = _FakeCrewBus()
+        handle = pipeline.observe_crewai(
+            session_id="crew-sess", event_bus=bus, event_types=_CREWAI_EVENT_TYPES
+        )
+        event = _ToolUsageStarted(
+            type="tool_usage_started",
+            tool_name="read_file",
+            tool_args={"path": "a.py"},
+            event_id="call-9",
+            timestamp="2025-06-01T10:00:00Z",
+        )
+        # emit from OFF the event loop thread, exactly like CrewAI's ThreadPoolExecutor
+        await asyncio.to_thread(bus.emit, event)
+        await handle.drain()
+        await pipeline.flush()
+        handle.stop()
+        await pipeline.close()
+
+        assert [e.kind for e in recording_sink.events] == ["tool.call.started"]
+        assert recording_sink.events[0].payload["tool_call_id"] == "call-9"
+
+    async def test_teardown_leaves_no_subscription(self, recording_sink):
+        pipeline = _new_pipeline(recording_sink)
+        bus = _FakeCrewBus()
+        handle = pipeline.observe_crewai(
+            session_id="crew-sess", event_bus=bus, event_types=_CREWAI_EVENT_TYPES
+        )
+        assert bus.total_handlers == len(_CREWAI_EVENT_TYPES)
+
+        handle.stop()
+        assert handle.active is False
+        assert bus.total_handlers == 0  # no residual global subscription
+
+        # events emitted after teardown are ignored
+        bus.emit(
+            _ToolUsageStarted(
+                type="tool_usage_started",
+                tool_name="x",
+                tool_args={},
+                event_id="c",
+                timestamp="2025-06-01T10:00:00Z",
+            )
+        )
+        await handle.drain()
+        await pipeline.flush()
+        assert recording_sink.events == []
+
+        handle.stop()  # idempotent
+        await pipeline.close()
+
+    def test_requires_running_loop(self, recording_sink):
+        """Called outside a running loop it fails fast, without touching the bus."""
+        pipeline = _new_pipeline(recording_sink)
+        bus = _FakeCrewBus()
+        with pytest.raises(RuntimeError, match="running asyncio event loop"):
+            pipeline.observe_crewai(event_bus=bus, event_types=_CREWAI_EVENT_TYPES)
+        assert bus.total_handlers == 0
+
+
+class TestObserveOpenAiAgentsE2E:
+    """observe_openai_agents: register a trace processor and stream mapped SessionEvents."""
+
+    async def test_subscribe_and_push_mapped_events(self, recording_sink):
+        # Assert observe's mapping contract at the push seam (see the crewai test): spy push so
+        # a function span's fan-out to started+completed is checked exactly, without the
+        # downstream enricher coalescing the pair.
+        pipeline = _new_pipeline(recording_sink)
+        pushed: list = []
+
+        async def _spy_push(event):
+            pushed.append(event)
+
+        pipeline.push = _spy_push
+        registry = _FakeProcessorRegistry()
+        handle = pipeline.observe_openai_agents(
+            session_id="oai-sess", register=registry.register, unregister=registry.unregister
+        )
+        try:
+            assert handle.active is True
+            assert handle.framework == "openai_agents"
+            assert len(registry.processors) == 1
+            processor = registry.processors[0]
+
+            processor.on_trace_start(_fake_trace(trace_id="trace_1", workflow_name="demo_wf"))
+            # a single function span export fans out to started + completed events
+            processor.on_span_end(_fake_function_span(span_id="span_1", name="read_file"))
+            await handle.drain()
+        finally:
+            handle.stop()
+            await pipeline.close()
+
+        kinds = [event.kind for event in pushed]
+        assert kinds == ["session.started", "tool.call.started", "tool.call.completed"]
+
+        session_started = pushed[0]
+        assert session_started.session_id == "oai-sess"
+        assert session_started.payload["trace_id"] == "trace_1"
+        assert session_started.payload["workflow_name"] == "demo_wf"
+
+        tool_started = pushed[1]
+        assert tool_started.payload["tool_name"] == "read_file"
+        assert tool_started.payload["tool_call_id"] == "span_1"
+
+        tool_completed = pushed[2]
+        assert tool_completed.payload["result"] == "file contents"
+        assert tool_completed.raw_event is not None
+
+    async def test_processor_pushes_through_real_pipeline(self, recording_sink):
+        """Wiring check: a registered processor's export reaches the real pipeline's sink."""
+        pipeline = _new_pipeline(recording_sink)
+        registry = _FakeProcessorRegistry()
+        handle = pipeline.observe_openai_agents(
+            session_id="oai-sess", register=registry.register, unregister=registry.unregister
+        )
+        processor = registry.processors[0]
+        # a lone lifecycle event flows straight through (no start/end pair to coalesce)
+        processor.on_trace_start(_fake_trace(trace_id="trace_9", workflow_name="wf"))
+        await handle.drain()
+        await pipeline.flush()
+        handle.stop()
+        await pipeline.close()
+
+        started = [e for e in recording_sink.events if e.kind == "session.started"]
+        assert len(started) == 1
+        assert started[0].session_id == "oai-sess"
+        assert started[0].payload["trace_id"] == "trace_9"
+
+    async def test_teardown_unregisters_processor(self, recording_sink):
+        pipeline = _new_pipeline(recording_sink)
+        registry = _FakeProcessorRegistry()
+        handle = pipeline.observe_openai_agents(
+            session_id="oai-sess", register=registry.register, unregister=registry.unregister
+        )
+        assert len(registry.processors) == 1
+        processor = registry.processors[0]
+
+        handle.stop()
+        assert handle.active is False
+        assert registry.processors == []  # processor removed — no residual subscription
+
+        # driving the detached processor after teardown pushes nothing
+        processor.on_trace_start(_fake_trace())
+        processor.on_span_end(_fake_function_span())
+        await handle.drain()
+        await pipeline.flush()
+        assert recording_sink.events == []
+
+        handle.stop()  # idempotent
+        await pipeline.close()
+
+
+class TestObserveDispatch:
+    """The unified pipeline.observe(framework) dispatcher and its phase-1 scope fence."""
+
+    async def test_observe_by_name_crewai(self, recording_sink):
+        pipeline = _new_pipeline(recording_sink)
+        bus = _FakeCrewBus()
+        handle = pipeline.observe(
+            "crewai", session_id="x", event_bus=bus, event_types=_CREWAI_EVENT_TYPES
+        )
+        assert handle.framework == "crewai"
+        assert bus.total_handlers == len(_CREWAI_EVENT_TYPES)
+        handle.stop()
+        assert bus.total_handlers == 0
+        await pipeline.close()
+
+    async def test_observe_by_name_openai_agents(self, recording_sink):
+        pipeline = _new_pipeline(recording_sink)
+        registry = _FakeProcessorRegistry()
+        handle = pipeline.observe(
+            "openai_agents",
+            session_id="x",
+            register=registry.register,
+            unregister=registry.unregister,
+        )
+        assert handle.framework == "openai_agents"
+        assert len(registry.processors) == 1
+        handle.stop()
+        assert registry.processors == []
+        await pipeline.close()
+
+    def test_unsupported_framework_rejected(self, recording_sink):
+        """Phase 1 is crewai + openai_agents only; other frameworks raise (no silent no-op)."""
+        pipeline = _new_pipeline(recording_sink)
+        with pytest.raises(ValueError, match="unsupported framework"):
+            pipeline.observe("langchain")


### PR DESCRIPTION
## What

Productizes the ad-hoc capture glue under `scripts/capture_traces/` into a shipped, in-process **`observe_*` auto-subscriber** SDK API (audit gap **S3-1**, High). This is **Phase 1** of PR-J and is scoped to the two frameworks that expose a global bus/processor: **crewai** and **openai_agents**.

## API shipped

New module `src/traceforge/sdk/observe.py` plus a small, self-contained facade region on `Pipeline`:

- `pipeline.observe_crewai(*, session_id="crewai", event_bus=None, event_types=None)`
- `pipeline.observe_openai_agents(*, session_id="openai_agents", register=None, unregister=None)`
- `pipeline.observe(framework, **kwargs)` — unified dispatcher (phase-1: `crewai` / `openai_agents`; anything else raises `ValueError`)
- `ObservationHandle` — returned by each; exported from `traceforge.sdk`

Each observer:
1. Subscribes to the framework's **native** global event bus / trace processor.
2. Maps native events through the **existing** `mappings/{crewai,openai_agents}.yaml` (reused as-is — no new mappings authored).
3. Pushes the resulting `SessionEvent`s into the pipeline via the **existing** `Pipeline.push()` seam.

`ObservationHandle.stop()` (also a sync/async context manager, plus `drain()` for in-flight pushes) unsubscribes cleanly — **no leaked global subscription**. Cross-thread safe: CrewAI runs handlers on a worker-thread pool, so pushes are marshalled onto the pipeline's loop via `run_coroutine_threadsafe`.

## Scope fences (honored)

- **Phase 1 = crewai + openai_agents ONLY.** No langchain/langgraph callback handler, no OpenTelemetry bridge (pydantic_ai/smolagents/maf/semantic_kernel) — those are Phase 2/3 and depend on mappings other PRs are landing.
- **`Pipeline.push()` is unchanged** — signature and behavior untouched; the observer only *calls* it.
- Edits are localized to `sdk/observe.py` (new) + a clearly-bounded additive facade region in `sdk/pipeline.py` and the `ObservationHandle` export in `sdk/__init__.py`, so the follow-up teardown/ungate PR can touch `sdk/pipeline.py` without conflict.
- No changes to `governance/pipeline.py`, `shield.py`, or `gate/client.py`.

## Tests

Extends `tests/e2e/test_observation_pipeline_e2e.py` with 10 tests covering, per framework: exact mapping at the push seam (kinds, session_id, payload fields, `raw_event`), real-pipeline→sink wiring, cross-thread marshalling (crewai), no-leak teardown, the unified dispatcher, and the phase-1 scope fence. Mapping correctness is asserted at the `push` boundary (observe's true contract) so it stays deterministic regardless of downstream enrichment coalescing.

## Verification

- Deterministic; no network at import (native frameworks are lazy-imported).
- `ruff check .` and `ruff format --check .` clean.
- Full suite green: **2989 passed, 7 skipped**.
- Branched off latest `main`.

**Do not merge** — holding for coordinator review.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>