### PR TITLE
feat(ingest): wire opencode into auto_detect (grounded host path)

### DIFF
--- a/src/traceforge/sources/auto_detect.py
+++ b/src/traceforge/sources/auto_detect.py
@@ -86,6 +86,7 @@ def detect_frameworks(frameworks: list[str] | None = None) -> list[DetectedFrame
         "cline": _detect_cline,
         "goose": _detect_goose,
         "amazonq": _detect_amazonq,
+        "opencode": _detect_opencode,
         "aider": _detect_aider,
     }
 
@@ -161,6 +162,20 @@ def _detect_amazonq() -> DetectedFramework | None:
     path = _amazonq_data_dir() / "data.sqlite3"
     if path.is_file():
         return DetectedFramework("amazonq", path, "amazonq", "sqlite")
+    return None
+
+
+def _detect_opencode() -> DetectedFramework | None:
+    # OpenCode (>=1.17) persists its event-sourced session store as a single
+    # SQLite database under the XDG data dir. It uses the same ~/.local/share
+    # layout on every platform — on Windows this expands to
+    # %USERPROFILE%\.local\share\opencode\opencode.db, not %LOCALAPPDATA% —
+    # verified against a real harvested artifact (tests/fixtures/raw_traces/
+    # opencode/meta.yaml). The opencode mapping + preprocessor already ship;
+    # this only wires the existing ingestion support into auto-detection.
+    path = _expand("~/.local/share/opencode/opencode.db")
+    if path.is_file():
+        return DetectedFramework("opencode", path, "opencode", "sqlite")
     return None
 
 

--- a/tests/e2e/test_auto_detect_e2e.py
+++ b/tests/e2e/test_auto_detect_e2e.py
@@ -60,6 +60,15 @@ def _framework_layout(home: Path) -> dict[str, tuple[Path, bool, str, str]]:
         ),
         "goose": (goose_dir / "sessions", False, "goose", "poll"),
         "amazonq": (amazonq_dir / "data.sqlite3", True, "amazonq", "sqlite"),
+        # OpenCode uses the same ~/.local/share layout on every platform (on
+        # Windows this resolves under %USERPROFILE%, since tmp_traceforge_home
+        # redirects HOME/USERPROFILE here), so it is not OS-branched above.
+        "opencode": (
+            home / ".local" / "share" / "opencode" / "opencode.db",
+            True,
+            "opencode",
+            "sqlite",
+        ),
     }
 
 
@@ -159,3 +168,31 @@ def test_aider_detected_from_cwd(
     assert detected[0].adapter == "aider_markdown"
     assert detected[0].ingestion_mode == "file_watch"
     assert _same_path(detected[0].path, history)
+
+
+def test_opencode_detected_at_verified_sqlite_path(tmp_traceforge_home: Path) -> None:
+    """OpenCode is detected at its verified host path with the sqlite mode.
+
+    The event-sourced store lives at ``~/.local/share/opencode/opencode.db`` on
+    every platform (on Windows that expands under ``%USERPROFILE%``, not
+    ``%LOCALAPPDATA%``). The opencode mapping + preprocessor already ship; this
+    asserts the detector wires that existing ingestion support in.
+    """
+    db = tmp_traceforge_home / ".local" / "share" / "opencode" / "opencode.db"
+    db.parent.mkdir(parents=True)
+    db.write_bytes(b"")
+
+    detected = detect_frameworks(["opencode"])
+
+    assert len(detected) == 1
+    found = detected[0]
+    assert found.name == "opencode"
+    assert found.adapter == "opencode"
+    assert found.ingestion_mode == "sqlite"
+    assert _same_path(found.path, db)
+
+
+def test_opencode_missing_store_is_clean_no_match(tmp_traceforge_home: Path) -> None:
+    # No opencode.db on disk → the detector returns no match rather than
+    # fabricating a detection for an absent store.
+    assert detect_frameworks(["opencode"]) == []


### PR DESCRIPTION
## What & why

OpenCode already ships full ingestion support — `mappings/opencode.yaml` + the registered `opencode` preprocessor (`@register_preprocessor("opencode")`) — but it was never wired into `detect_frameworks()`. This is the injected-but-not-detected residual from PR-K (#130): `traceforge init opencode` writes a gate hook, yet `traceforge detect`/`watch` couldn't see an opencode install. This PR closes that one gap.

**No new mapping YAML and no preprocessor change** — this only registers the *existing* adapter/preprocessor with the enumerator.

## Host path probed & how it was grounded

| Path probed | Mode | Grounding |
|---|---|---|
| `~/.local/share/opencode/opencode.db` | `sqlite` | Verified against a **real harvested artifact** — `tests/fixtures/raw_traces/opencode/meta.yaml` records `source_path: C:\Users\davidfinson\.local\share\opencode\opencode.db`. That Windows path is exactly `~/.local/share/...` expanded, proving OpenCode uses the same `~/.local/share` layout on every platform (**not** `%LOCALAPPDATA%`). So one `os.path.expanduser("~/.local/share/opencode/opencode.db")` expression covers Linux, macOS, and Windows. |

The detector returns **no match** when the store is absent — it never fabricates a detection.

**`XDG_DATA_HOME` override intentionally omitted.** Honoring it would require scrubbing `XDG_DATA_HOME` in the shared e2e fixture (`tmp_traceforge_home`), which is outside the "auto_detect.py + its test only" scope for this PR. The verified default (`~/.local/share`) is what OpenCode uses in practice; the override can be a trivial follow-up if wanted.

## Scope guardrails honored

- Touches **only** `src/traceforge/sources/auto_detect.py` (+ `tests/e2e/test_auto_detect_e2e.py`). No changes to governance/pipeline, sdk/*, watch.py, shield.py, gate/*, or init_cmd.py.
- No new mapping YAML. No preprocessor change (opencode was already fully supported).
- Detector is idempotent (pure path probe) and fails gracefully.

## Diff summary

- `sources/auto_detect.py` (+15): `_detect_opencode` (adapter `"opencode"`, mode `"sqlite"`) + registration in `all_detectors`.
- `tests/e2e/test_auto_detect_e2e.py` (+37): opencode added to the set-equality `_framework_layout` test; new `test_opencode_detected_at_verified_sqlite_path` and `test_opencode_missing_store_is_clean_no_match`.

## Verification (ruff 0.15.20; Python 3.12)

- `ruff check` + `ruff format --check`: clean.
- Full unit suite: **2044 passed, 2 skipped**.
- `test_auto_detect_e2e.py` + `test_cli_detect_e2e.py`: **15 passed** (incl. the 2 new opencode tests).

Base: current `main` (`741950a`). **Hold for coordinator review — do not merge.**

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
