### PR TITLE
feat(gate): enforce-by-default warnings + config policy + IPC auth hardening (PR-E/G)

### DIFF
--- a/src/traceforge/cli/init_cmd.py
+++ b/src/traceforge/cli/init_cmd.py
@@ -45,6 +45,12 @@ def init(agent: str, project: str) -> None:
     """
     project_root = Path(project).resolve()
     _WRITERS[agent](project_root)
+    # Enforce-by-default hint: the hook only *relays* to the gate, which ALLOWS
+    # every call until a policy is configured. Point operators at the missing step.
+    click.echo(
+        "  Note: configure a gate policy (governance.gate_policy) and run "
+        "`traceforge watch` — until then the gate allows every call."
+    )
 
 
 # ─── Command / path helpers ──────────────────────────────────────────────────

--- a/src/traceforge/cli/watch.py
+++ b/src/traceforge/cli/watch.py
@@ -25,6 +25,45 @@ from traceforge.sources.auto_detect import detect_frameworks
 logger = logging.getLogger(__name__)
 
 
+def _policy_is_enforcing(policy) -> bool:
+    """True if ``policy`` actually gates anything (a preflight or postflight gate).
+
+    ``None`` or an empty :class:`~traceforge.sdk.gate_policy.GatePolicy` means the
+    gate runs in allow-all mode.
+    """
+    return policy is not None and (policy.has_preflight or policy.has_postflight)
+
+
+def _warn_gating_inactive() -> None:
+    """Emit a LOUD warning that the gate is running in allow-all mode.
+
+    The gate IPC server and the injected agent hooks are up, but with no policy
+    every tool call is ALLOWED — enforcement is inactive. Operators must not
+    mistake "hooks installed" for "protected", so this is a prominent stderr
+    banner (plus a WARNING log), not a quiet line.
+    """
+    banner = (
+        "\n"
+        "  ============================================================\n"
+        "  WARNING: gating enforcement is INACTIVE (allow-all).\n"
+        "  No gate policy is configured, so EVERY tool call is ALLOWED.\n"
+        "  The gate IPC server and agent hooks are running, but they\n"
+        "  enforce nothing until you declare a policy.\n"
+        "\n"
+        "  Enable enforcement by declaring a policy in your config, e.g.:\n"
+        "    governance:\n"
+        "      gate_policy:\n"
+        "        preflight:\n"
+        "          - myapp.policies.block_destructive   # dotted gate, or\n"
+        "          - type: http                          # external decider\n"
+        "            endpoint: http://127.0.0.1:8181/v1/data/traceforge/gate\n"
+        "  then re-run:  traceforge watch --config <your-config>.yaml\n"
+        "  ============================================================\n"
+    )
+    click.echo(banner, err=True)
+    logger.warning("Gating enforcement INACTIVE (allow-all): no gate policy configured.")
+
+
 @click.command()
 @click.option("--config", "config_path", type=click.Path(exists=True), default=None)
 @click.option(
@@ -72,16 +111,16 @@ def watch(
     db_path.parent.mkdir(parents=True, exist_ok=True)
     store = SystemStore(db_path)
 
-    # Load policy from config if available
-    policy = None
-    if config and config.get("governance", {}).get("tool_preflight_gate"):
-        from traceforge.sdk.gate_policy import GatePolicy
+    # Load a full gate policy (preflight chain + postflight + external gates) from
+    # config. A declared-but-broken policy fails loudly below rather than silently
+    # degrading to allow-all.
+    from traceforge.governance.shield import build_policy_from_config
 
-        dotted = config["governance"]["tool_preflight_gate"]
-        from traceforge.governance.pipeline import _import_dotted
-
-        gate_fn = _import_dotted(dotted)
-        policy = GatePolicy().preflight(gate_fn)
+    try:
+        policy = build_policy_from_config(config)
+    except Exception as exc:  # noqa: BLE001 - refuse to start on a broken policy
+        click.echo(f"ERROR: gate policy failed to load — refusing to start: {exc}", err=True)
+        sys.exit(1)
 
     pipeline = create_default_pipeline(store, policy=policy)
 
@@ -91,6 +130,11 @@ def watch(
     gate_server = GateServer(pipeline)
     gate_server.start()
     click.echo(f"Gate IPC server listening on {gate_server.sock_path}")
+
+    # Enforce-by-default UX: the server is up, but with no policy it ALLOWS every
+    # call. Make that unmistakable so operators don't believe they're protected.
+    if not _policy_is_enforcing(policy):
+        _warn_gating_inactive()
 
     # Register a default session so CLI clients can find us without knowing session_id upfront.
     # Detected framework sessions are also registered individually.

--- a/src/traceforge/gate/client.py
+++ b/src/traceforge/gate/client.py
@@ -12,8 +12,15 @@ import struct
 import sys
 
 
-def send_gate_request(sock_path: str, payload: dict) -> dict:
-    """Send a gate request to the IPC server and return the verdict dict."""
+def send_gate_request(sock_path: str, payload: dict, *, token: str | None = None) -> dict:
+    """Send a gate request to the IPC server and return the verdict dict.
+
+    ``token`` is the per-server auth secret read from the registry row (see
+    :func:`traceforge.gate.registry.lookup_endpoint`). It is attached to the
+    request *envelope* only — the scored ``payload`` is unchanged — so the server
+    can authenticate the caller. A missing/invalid token makes the server reply
+    with a deny verdict, i.e. the relay fails closed.
+    """
     if sock_path.startswith("tcp://"):
         # Windows TCP fallback
         addr = sock_path[len("tcp://") :]
@@ -26,7 +33,7 @@ def send_gate_request(sock_path: str, payload: dict) -> dict:
 
     try:
         conn.settimeout(30.0)
-        data = json.dumps(payload).encode("utf-8")
+        data = json.dumps({"payload": payload, "token": token}).encode("utf-8")
         conn.sendall(struct.pack("!I", len(data)) + data)
 
         # Read length-prefixed response
@@ -89,7 +96,7 @@ def _gate_from_stdin_impl(*, format: str = "claude-code") -> None:
     Wrapped by :func:`gate_from_stdin`, which converts any unexpected exception
     into a fail-closed deny.
     """
-    from traceforge.gate.registry import lookup_session
+    from traceforge.gate.registry import lookup_endpoint
 
     # Read event from stdin
     event_raw = sys.stdin.read()
@@ -112,15 +119,16 @@ def _gate_from_stdin_impl(*, format: str = "claude-code") -> None:
         _output_deny(format, "no session_id in event")
         return
 
-    # Look up socket
-    sock_path = lookup_session(session_id)
-    if not sock_path:
+    # Look up socket + auth token for this session
+    endpoint = lookup_endpoint(session_id)
+    if endpoint is None:
         # Fall back to default session (traceforge watch registers as "_default")
-        sock_path = lookup_session("_default")
-    if not sock_path:
+        endpoint = lookup_endpoint("_default")
+    if endpoint is None:
         # Session not registered = deny (fail-closed)
         _output_deny(format, f"session {session_id} not registered with any pipeline")
         return
+    sock_path, token = endpoint
 
     # Build payload for score_tool_call
     payload = {
@@ -135,9 +143,10 @@ def _gate_from_stdin_impl(*, format: str = "claude-code") -> None:
     if event.get("mcp_server_name"):
         payload["mcp_server_name"] = event["mcp_server_name"]
 
-    # Send to Pipeline IPC
+    # Send to Pipeline IPC (the per-request token authenticates us to the server;
+    # a missing/invalid token makes the server deny → the relay fails closed).
     try:
-        verdict = send_gate_request(sock_path, payload)
+        verdict = send_gate_request(sock_path, payload, token=token)
     except (ConnectionRefusedError, FileNotFoundError, OSError) as exc:
         _output_deny(format, f"pipeline unreachable: {exc}")
         return

--- a/src/traceforge/gate/registry.py
+++ b/src/traceforge/gate/registry.py
@@ -24,43 +24,68 @@ def _system_db_path() -> str:
     return str(Path.home() / ".traceforge" / "system.db")
 
 
-def register_session(session_id: str, sock_path: str, *, db_path: str | None = None) -> None:
-    """Register a session_id → sock_path mapping."""
+def register_session(
+    session_id: str, sock_path: str, *, token: str | None = None, db_path: str | None = None
+) -> None:
+    """Register a session_id → (sock_path, token) mapping.
+
+    ``token`` is the owning server's per-process auth secret. Clients read it back
+    from this row and present it on every gate request so the server can reject
+    requests that target a poisoned or foreign row (see :mod:`traceforge.gate.server`).
+    """
     db = db_path or _system_db_path()
     Path(db).parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db)
     try:
         conn.execute(
-            "INSERT OR REPLACE INTO gate_endpoints (session_id, sock_path, pid) VALUES (?, ?, ?)",
-            (session_id, sock_path, os.getpid()),
+            "INSERT OR REPLACE INTO gate_endpoints (session_id, sock_path, pid, token) "
+            "VALUES (?, ?, ?, ?)",
+            (session_id, sock_path, os.getpid(), token),
         )
         conn.commit()
     finally:
         conn.close()
 
 
-def lookup_session(session_id: str, *, db_path: str | None = None) -> str | None:
-    """Look up the socket path for a session_id. Returns None if not found or stale."""
+def lookup_endpoint(
+    session_id: str, *, db_path: str | None = None
+) -> tuple[str, str | None] | None:
+    """Look up ``(sock_path, token)`` for a session_id.
+
+    Returns ``None`` if not found or if the owning process is dead (the stale row
+    is self-healed). The ``token`` is whatever the owner stored at registration
+    time (``None`` for legacy rows); the client forwards it so the server can
+    authenticate the request against its own secret.
+    """
     db = db_path or _system_db_path()
     if not Path(db).exists():
         return None
     conn = sqlite3.connect(db)
     try:
         row = conn.execute(
-            "SELECT sock_path, pid FROM gate_endpoints WHERE session_id = ?",
+            "SELECT sock_path, pid, token FROM gate_endpoints WHERE session_id = ?",
             (session_id,),
         ).fetchone()
         if row is None:
             return None
-        sock_path, pid = row
+        sock_path, pid, token = row
         # Verify PID is alive
         if not _pid_alive(pid):
             conn.execute("DELETE FROM gate_endpoints WHERE session_id = ?", (session_id,))
             conn.commit()
             return None
-        return sock_path
+        return sock_path, token
     finally:
         conn.close()
+
+
+def lookup_session(session_id: str, *, db_path: str | None = None) -> str | None:
+    """Look up the socket path for a session_id. Returns None if not found or stale.
+
+    Thin back-compat wrapper over :func:`lookup_endpoint` (drops the token).
+    """
+    endpoint = lookup_endpoint(session_id, db_path=db_path)
+    return endpoint[0] if endpoint is not None else None
 
 
 def unregister_session(session_id: str, *, db_path: str | None = None) -> None:

--- a/src/traceforge/gate/server.py
+++ b/src/traceforge/gate/server.py
@@ -12,8 +12,10 @@ Uses the same policy chain as all gate_* methods for consistent behavior.
 from __future__ import annotations
 
 import atexit
+import hmac
 import json
 import os
+import secrets
 import socket
 import struct
 import sys
@@ -45,16 +47,31 @@ class GateServer:
         self._server: socket.socket | None = None
         self._thread: threading.Thread | None = None
         self._running = False
+        # Per-server auth secret. Stored in this session's registry row at
+        # registration and required (constant-time compared) on every request, so
+        # another local user cannot poison the registry or hijack the session's row.
+        self._token = secrets.token_hex(32)
 
     @staticmethod
     def _default_sock_path() -> str:
         gates_dir = Path.home() / ".traceforge" / "gates"
         gates_dir.mkdir(parents=True, exist_ok=True)
+        if sys.platform != "win32":
+            # Owner-only gates dir (defense in depth alongside the 0600 socket).
+            try:
+                os.chmod(gates_dir, 0o700)
+            except OSError:
+                pass
         return str(gates_dir / f"{os.getpid()}.sock")
 
     @property
     def sock_path(self) -> str:
         return self._sock_path
+
+    @property
+    def token(self) -> str:
+        """The per-server auth token required on every gate request."""
+        return self._token
 
     def start(self) -> None:
         """Start the IPC server in a background daemon thread."""
@@ -76,6 +93,10 @@ class GateServer:
         else:
             self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self._server.bind(self._sock_path)
+            # Owner-only socket (0600): block another local user from connecting
+            # to poison the registry or hijack this session's gate. POSIX-only —
+            # the win32 branch above uses loopback TCP, which has no file mode.
+            os.chmod(self._sock_path, 0o600)
 
         self._server.listen(16)
         self._server.settimeout(1.0)  # allow periodic check of _running
@@ -109,7 +130,7 @@ class GateServer:
         """Register a session_id → this server's socket in the registry."""
         from traceforge.gate.registry import register_session
 
-        register_session(session_id, self._sock_path)
+        register_session(session_id, self._sock_path, token=self._token)
 
     def _serve_loop(self) -> None:
         while self._running:
@@ -130,6 +151,15 @@ class GateServer:
                 return
 
             request = json.loads(data)
+            # Auth: every request must carry this server's token. Reject (deny)
+            # anything without it BEFORE touching gate state, so a poisoned/foreign
+            # row or an unauthenticated local caller cannot drive enforcement.
+            if not self._verify_token(request.get("token") if isinstance(request, dict) else None):
+                deny = json.dumps(
+                    {"decision": "deny", "reason": "unauthorized gate request (fail-closed)"}
+                ).encode("utf-8")
+                conn.sendall(struct.pack("!I", len(deny)) + deny)
+                return
             payload = request.get("payload", request)
             response = self._process_gate_request(payload)
             resp_bytes = json.dumps(response).encode("utf-8")
@@ -142,6 +172,12 @@ class GateServer:
                 pass
         finally:
             conn.close()
+
+    def _verify_token(self, token: object) -> bool:
+        """Constant-time check that a request carries this server's auth token."""
+        if not isinstance(token, str) or not token:
+            return False
+        return hmac.compare_digest(token, self._token)
 
     def _process_gate_request(self, payload: dict) -> dict:
         """Score and gate a tool call using the pipeline's policy chain."""

--- a/src/traceforge/governance/shield.py
+++ b/src/traceforge/governance/shield.py
@@ -31,6 +31,132 @@ if TYPE_CHECKING:
     from traceforge.trace import EventTrace
 
 
+# ── Config → GatePolicy (declarative, enforce-by-default) ───────────────────────
+
+
+def build_policy_from_config(config: dict | None) -> "GatePolicy | None":
+    """Build a full :class:`GatePolicy` from a raw config mapping.
+
+    ``config`` is the plain dict produced by ``yaml.safe_load`` (what ``traceforge
+    watch`` holds), so this reads it directly rather than a Pydantic model. It lets
+    a config declare a *complete* policy — an ordered preflight CHAIN, a postflight
+    chain, and external out-of-process gates — under ``governance.gate_policy``::
+
+        governance:
+          gate_policy:
+            preflight:                         # ordered chain (first DENY wins)
+              - myapp.policies.block_rm_rf     # dotted in-process PreflightGate
+              - type: http                     # external decider (OPA/PDP)
+                endpoint: http://127.0.0.1:8181/v1/data/traceforge/gate
+              - type: subprocess
+                command: opa eval -I -f raw 'data.gate.deny'
+            postflight:                        # ordered chain (dotted PostflightGate)
+              - myapp.policies.redact_secrets
+            external:                          # convenience alias, appended to preflight
+              - type: subprocess
+                command: ./decider.sh
+
+    Each preflight entry is either a dotted import path to an in-process gate
+    callable, or an inline external-gate mapping (``type: http`` / ``subprocess``)
+    validated through the same Pydantic models the YAML config uses. Postflight
+    entries are dotted import paths.
+
+    Back-compat: when no ``gate_policy`` block is present, the legacy single-field
+    forms ``governance.tool_preflight_gate`` (dotted) and ``governance.preflight_gate``
+    (one external decider) are still honored — same semantics as
+    :meth:`GovernancePipeline.from_config`.
+
+    Returns ``None`` when nothing is declared, so the caller can warn that gating
+    enforcement is inactive. Raises on a *declared but malformed* policy (bad dotted
+    path or invalid external-gate config) — a broken policy must fail loudly at
+    startup rather than silently degrade to allow-all.
+    """
+    if not config:
+        return None
+    governance = config.get("governance")
+    if not isinstance(governance, dict):
+        return None
+
+    from traceforge.sdk.gate_policy import GatePolicy
+
+    policy = GatePolicy()
+    declared = False
+
+    gate_policy = governance.get("gate_policy")
+    if isinstance(gate_policy, dict):
+        preflight_entries = list(gate_policy.get("preflight") or [])
+        # `external:` is a convenience bucket appended to the preflight chain.
+        preflight_entries += list(gate_policy.get("external") or [])
+        for entry in preflight_entries:
+            policy.preflight(_preflight_gate_from_entry(entry))
+            declared = True
+        for entry in gate_policy.get("postflight") or []:
+            policy.postflight(_dotted_gate(entry))
+            declared = True
+
+    # Legacy single-field forms — only when no explicit gate_policy chain was set.
+    if not declared:
+        dotted = governance.get("tool_preflight_gate")
+        external = governance.get("preflight_gate")
+        if dotted:
+            policy.preflight(_dotted_gate(dotted))
+            declared = True
+        elif isinstance(external, dict):
+            policy.preflight(_external_gate_from_mapping(external))
+            declared = True
+
+    return policy if declared else None
+
+
+def _dotted_gate(entry: object):
+    """Import an in-process gate callable from a dotted path string."""
+    if not isinstance(entry, str) or not entry.strip():
+        raise TypeError(f"expected a dotted import path string, got {entry!r}")
+    from traceforge.governance.pipeline import _import_dotted
+
+    return _import_dotted(entry)
+
+
+def _preflight_gate_from_entry(entry: object):
+    """Build one preflight gate from a config entry.
+
+    A string is a dotted in-process gate; a mapping is an inline external decider.
+    """
+    if isinstance(entry, str):
+        return _dotted_gate(entry)
+    if isinstance(entry, dict):
+        return _external_gate_from_mapping(entry)
+    raise TypeError(f"invalid preflight gate entry: {entry!r}")
+
+
+def _external_gate_from_mapping(entry: dict):
+    """Validate + build an external (http/subprocess) gate from a raw mapping.
+
+    Reuses the YAML config's Pydantic models so validation, defaults, and the
+    fail-closed posture match ``governance.preflight_gate`` exactly.
+    """
+    from pydantic import TypeAdapter
+
+    from traceforge.config.models import ExternalGateConfig
+    from traceforge.gate.external import HttpGate, SubprocessGate
+
+    gate_cfg = TypeAdapter(ExternalGateConfig).validate_python(entry)
+    if gate_cfg.type == "http":
+        return HttpGate(
+            endpoint=gate_cfg.endpoint,
+            timeout=gate_cfg.timeout,
+            fail_open=gate_cfg.fail_open,
+            headers=dict(gate_cfg.headers) if gate_cfg.headers else None,
+            max_input_bytes=gate_cfg.max_input_bytes,
+        )
+    return SubprocessGate(
+        command=gate_cfg.command,
+        timeout=gate_cfg.timeout,
+        fail_open=gate_cfg.fail_open,
+        max_input_bytes=gate_cfg.max_input_bytes,
+    )
+
+
 class Shield:
     """Runtime enforcement checkpoint — preflight gating + postflight action.
 
@@ -270,29 +396,39 @@ class Shield:
     def _observe_completed_call(self, trace: "EventTrace", *, session_id: str) -> None:
         """Advance the single tool-call counter for a shield-allowed call that
         has now executed. The trace only ever observes what the gate allowed, so
-        this is the one writer of the counter in the gate channel."""
+        this is the one writer of the counter in the gate channel.
+
+        Concurrency: the gate IPC server handles each request on its own thread,
+        so concurrent calls on one session share a SessionState whose counters are
+        not self-synchronized. Serialize the read-modify-write under the shield
+        lock so no increment is lost."""
         state = self._ensure_gate_state(session_id)
-        phase_window = state.snapshot().phase_window
-        state.increment_budget(
-            mechanism=trace.mechanism,
-            effect=trace.effect,
-            scope=frozenset(trace.scope),
-            role=frozenset(trace.role),
-            action=frozenset(trace.action),
-            capability=frozenset(trace.capability),
-            structure=frozenset(trace.structure),
-            phase=phase_window[-1] if phase_window else None,
-        )
+        with self._lock:
+            phase_window = state.snapshot().phase_window
+            state.increment_budget(
+                mechanism=trace.mechanism,
+                effect=trace.effect,
+                scope=frozenset(trace.scope),
+                role=frozenset(trace.role),
+                action=frozenset(trace.action),
+                capability=frozenset(trace.capability),
+                structure=frozenset(trace.structure),
+                phase=phase_window[-1] if phase_window else None,
+            )
 
     def _record_denial(self, session_id: str, verdict: "Verdict") -> None:
         """Record a shield denial. Does not touch the tool-call counter."""
-        self._ensure_gate_state(session_id).record_denial(verdict)
+        state = self._ensure_gate_state(session_id)
+        with self._lock:
+            state.record_denial(verdict)
 
     def _record_allow(self, session_id: str, *, tool_call_id: str | None = None) -> None:
         """Record a shield allow. The tool-call counter is NOT advanced here —
         it advances only when the allowed call is observed at completion
         (see _observe_completed_call). The shield only reads the counter."""
-        self._ensure_gate_state(session_id).record_allow(tool_call_id=tool_call_id)
+        state = self._ensure_gate_state(session_id)
+        with self._lock:
+            state.record_allow(tool_call_id=tool_call_id)
 
     def _ensure_gate_state(self, session_id: str):
         """Return session state for gate context tracking (thread-safe, ephemeral)."""
@@ -310,13 +446,17 @@ class Shield:
         if state is None:
             return GateContext(session_id=session_id, tool_call_count=0, denied_count=0)
 
-        return GateContext(
-            session_id=session_id,
-            tool_call_count=state.tool_call_count,
-            denied_count=state.denied_count,
-            prior_verdicts=state.prior_verdicts(),
-            prior_tool_call_ids=state.prior_tool_call_ids(),
-        )
+        # Snapshot under the shield lock: concurrent gate threads may be appending
+        # to the same bounded deques, and reading them (prior_verdicts /
+        # prior_tool_call_ids materialize tuples) must not race a mutation.
+        with self._lock:
+            return GateContext(
+                session_id=session_id,
+                tool_call_count=state.tool_call_count,
+                denied_count=state.denied_count,
+                prior_verdicts=state.prior_verdicts(),
+                prior_tool_call_ids=state.prior_tool_call_ids(),
+            )
 
     def _to_tool_call_request(self, trace: "EventTrace") -> "ToolCallRequest":
         """Convert a fully-assessed EventTrace into a gate-facing ToolCallRequest."""

--- a/src/traceforge/migrations/models.py
+++ b/src/traceforge/migrations/models.py
@@ -81,6 +81,7 @@ gate_endpoints = Table(
     Column("session_id", Text, primary_key=True),
     Column("sock_path", Text, nullable=False),
     Column("pid", Integer, nullable=False),
+    Column("token", Text),
     Column("registered_at", Text, nullable=False, server_default="(datetime('now'))"),
 )
 

--- a/src/traceforge/migrations/versions/0001_initial.py
+++ b/src/traceforge/migrations/versions/0001_initial.py
@@ -158,6 +158,7 @@ def upgrade() -> None:
             session_id TEXT PRIMARY KEY,
             sock_path TEXT NOT NULL,
             pid INTEGER NOT NULL,
+            token TEXT,
             registered_at TEXT NOT NULL DEFAULT (datetime('now'))
         )
     """)

--- a/tests/e2e/test_gate_ipc_e2e.py
+++ b/tests/e2e/test_gate_ipc_e2e.py
@@ -100,6 +100,7 @@ def test_send_gate_request_round_trip_allow(tmp_traceforge_home: Path) -> None:
         verdict = send_gate_request(
             server.sock_path,
             {"tool_name": "read_file", "tool_input": {"path": "a.txt"}, "session_id": "s"},
+            token=server.token,
         )
     finally:
         server.stop()
@@ -118,6 +119,7 @@ def test_send_gate_request_round_trip_deny(tmp_traceforge_home: Path) -> None:
         verdict = send_gate_request(
             server.sock_path,
             {"tool_name": "rm", "tool_input": {}, "session_id": "s"},
+            token=server.token,
         )
     finally:
         server.stop()
@@ -138,6 +140,7 @@ def test_windows_tcp_transport_round_trip(tmp_traceforge_home: Path) -> None:
         verdict = send_gate_request(
             server.sock_path,
             {"tool_name": "rm", "tool_input": {"path": "/"}, "session_id": "win"},
+            token=server.token,
         )
     finally:
         server.stop()

--- a/tests/unit/test_gate_agent_dialects.py
+++ b/tests/unit/test_gate_agent_dialects.py
@@ -31,8 +31,10 @@ _REASON = "blocked: rm -rf / is not allowed"
 
 def _drive(monkeypatch, capsys, dialect: str, verdict: dict) -> tuple[int, str, str]:
     """Run the relay once with a stubbed IPC ``verdict`` and capture exit/out/err."""
-    monkeypatch.setattr("traceforge.gate.registry.lookup_session", lambda sid: "fake-sock")
-    monkeypatch.setattr(gate_client, "send_gate_request", lambda sock, payload: verdict)
+    monkeypatch.setattr(
+        "traceforge.gate.registry.lookup_endpoint", lambda sid: ("fake-sock", "tok")
+    )
+    monkeypatch.setattr(gate_client, "send_gate_request", lambda sock, payload, token=None: verdict)
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(_EVENT)))
 
     code = 0
@@ -136,7 +138,7 @@ def test_agent_dialect_preserves_fail_closed(monkeypatch, capsys) -> None:
     def boom(session_id):
         raise RuntimeError("registry database is locked")
 
-    monkeypatch.setattr("traceforge.gate.registry.lookup_session", boom)
+    monkeypatch.setattr("traceforge.gate.registry.lookup_endpoint", boom)
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(_EVENT)))
 
     with pytest.raises(SystemExit) as excinfo:

--- a/tests/unit/test_gate_client_failclosed.py
+++ b/tests/unit/test_gate_client_failclosed.py
@@ -54,8 +54,10 @@ def _assert_deny(verdict: dict, fmt: str) -> str:
 def test_missing_decision_key_denies(monkeypatch, capsys, fmt: str) -> None:
     """An IPC verdict with no ``decision`` key must DENY, not default to allow."""
     event = {"tool_name": "rm", "tool_input": {"path": "/"}, "session_id": "s1"}
-    monkeypatch.setattr("traceforge.gate.registry.lookup_session", lambda sid: "fake-sock")
-    monkeypatch.setattr(gate_client, "send_gate_request", lambda sock, payload: {})
+    monkeypatch.setattr(
+        "traceforge.gate.registry.lookup_endpoint", lambda sid: ("fake-sock", "tok")
+    )
+    monkeypatch.setattr(gate_client, "send_gate_request", lambda sock, payload, token=None: {})
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
 
     gate_from_stdin(format=fmt)
@@ -74,7 +76,7 @@ def test_registry_lookup_error_denies(monkeypatch, capsys, fmt: str) -> None:
         raise RuntimeError("registry database is locked")
 
     event = {"tool_name": "rm", "tool_input": {}, "session_id": "s1"}
-    monkeypatch.setattr("traceforge.gate.registry.lookup_session", boom)
+    monkeypatch.setattr("traceforge.gate.registry.lookup_endpoint", boom)
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
 
     gate_from_stdin(format=fmt)  # must not raise
@@ -90,11 +92,13 @@ def test_unexpected_send_error_denies(monkeypatch, capsys) -> None:
     fail-closed wrapper, which emits a deny verdict.
     """
 
-    def boom(sock, payload):
+    def boom(sock, payload, token=None):
         raise ValueError("unexpected relay failure")
 
     event = {"tool_name": "rm", "tool_input": {}, "session_id": "s1"}
-    monkeypatch.setattr("traceforge.gate.registry.lookup_session", lambda sid: "fake-sock")
+    monkeypatch.setattr(
+        "traceforge.gate.registry.lookup_endpoint", lambda sid: ("fake-sock", "tok")
+    )
     monkeypatch.setattr(gate_client, "send_gate_request", boom)
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(event)))
 

--- a/tests/unit/test_gate_ipc_auth.py
+++ b/tests/unit/test_gate_ipc_auth.py
@@ -1,0 +1,298 @@
+"""PART G — gate IPC hardening: socket auth + concurrency safety.
+
+The gate IPC server had no request authentication: any local process that could
+reach the socket (or poison a session's registry row) could drive enforcement or
+hijack a session. And the shield's shared per-session ``SessionState`` was mutated
+without synchronization, so concurrent preflight requests could lose updates.
+
+These tests pin the fixes:
+
+* **Socket perms** — the AF_UNIX socket is created ``0600`` (owner-only). POSIX-only;
+  skipped on Windows, which uses loopback TCP with no file mode.
+* **Per-request auth token** — the server generates a per-process secret, stores it in
+  the session's registry row, and REQUIRES + constant-time VALIDATES it on every
+  request *before* touching gate state. A missing/invalid token — including one read
+  from a poisoned/foreign row — is rejected and fails closed (DENY).
+* **Concurrency** — concurrent preflight/completion on one shared ``SessionState``
+  keeps the tool-call counter and denial counter consistent (no lost updates).
+
+The auth-layer tests drive :meth:`GateServer._handle_conn` directly through an
+in-memory fake connection, so they are fast, hermetic, and cross-platform (no real
+socket, no ML scorer).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import struct
+import sys
+import threading
+
+import pytest
+
+from traceforge.gate.registry import lookup_endpoint, register_session
+from traceforge.gate.server import GateServer
+from traceforge.governance.persistence import SystemStore
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.verdict import Verdict
+
+
+# ── in-memory connection double for _handle_conn ────────────────────────────────
+
+
+class _FakeConn:
+    """A length-prefixed request feeder + response capture for ``_handle_conn``.
+
+    Frames ``request_obj`` exactly like the real client (4-byte big-endian length
+    prefix + JSON body) and records whatever the server writes back.
+    """
+
+    def __init__(self, request_obj: object) -> None:
+        body = json.dumps(request_obj).encode("utf-8")
+        self._buf = bytearray(struct.pack("!I", len(body)) + body)
+        self.sent = bytearray()
+        self.closed = False
+
+    def settimeout(self, _timeout: float) -> None:  # noqa: D401 - test double
+        pass
+
+    def recv(self, n: int) -> bytes:
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.extend(data)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def response(self) -> dict:
+        """Decode the single length-prefixed verdict the server wrote back."""
+        assert len(self.sent) >= 4, "server wrote no framed response"
+        (length,) = struct.unpack("!I", bytes(self.sent[:4]))
+        return json.loads(bytes(self.sent[4 : 4 + length]))
+
+
+def _server_with_stubbed_processing() -> tuple[GateServer, list]:
+    """A GateServer whose gate processing is replaced by a call-recording stub.
+
+    Lets the auth-layer tests assert *whether* processing ran without invoking the
+    real scorer, and confirm that rejection happens strictly before any gate work.
+    """
+    server = GateServer(pipeline=object(), sock_path="unused-for-handle-conn.sock")
+    processed: list = []
+
+    def _record(payload: dict) -> dict:
+        processed.append(payload)
+        return {"decision": "allow", "reason": "", "score": 0, "level": "low"}
+
+    server._process_gate_request = _record  # type: ignore[assignment]
+    return server, processed
+
+
+# ── token primitive ─────────────────────────────────────────────────────────────
+
+
+def test_verify_token_accepts_only_the_servers_secret() -> None:
+    server = GateServer(pipeline=object(), sock_path="unused.sock")
+
+    assert server._verify_token(server.token) is True
+    assert server._verify_token("not-the-token") is False
+    assert server._verify_token("") is False
+    assert server._verify_token(None) is False
+    assert server._verify_token(12345) is False  # non-str
+
+
+def test_each_server_gets_a_distinct_token() -> None:
+    a = GateServer(pipeline=object(), sock_path="a.sock")
+    b = GateServer(pipeline=object(), sock_path="b.sock")
+
+    assert a.token and b.token
+    assert a.token != b.token
+    assert len(a.token) >= 32  # secrets.token_hex(32) → 64 hex chars
+
+
+# ── request auth on _handle_conn (fail-closed) ──────────────────────────────────
+
+
+def test_request_without_token_is_rejected_before_processing() -> None:
+    """A request carrying no token is DENIED and never reaches gate processing."""
+    server, processed = _server_with_stubbed_processing()
+    conn = _FakeConn({"payload": {"tool_name": "rm", "tool_input": {}, "session_id": "s1"}})
+
+    server._handle_conn(conn)
+
+    resp = conn.response()
+    assert resp["decision"] == "deny"
+    assert "unauthorized" in resp["reason"]
+    assert "fail-closed" in resp["reason"]
+    assert processed == []  # rejected before any state-mutating gate work
+    assert conn.closed
+
+
+def test_request_with_invalid_token_is_rejected_before_processing() -> None:
+    """A request with the WRONG token is DENIED and never reaches processing."""
+    server, processed = _server_with_stubbed_processing()
+    conn = _FakeConn(
+        {
+            "payload": {"tool_name": "rm", "tool_input": {}, "session_id": "s1"},
+            "token": "attacker-guessed-token",
+        }
+    )
+
+    server._handle_conn(conn)
+
+    resp = conn.response()
+    assert resp["decision"] == "deny"
+    assert "unauthorized" in resp["reason"]
+    assert processed == []
+
+
+def test_request_with_valid_token_is_processed() -> None:
+    """A request bearing the server's own token is authenticated and processed."""
+    server, processed = _server_with_stubbed_processing()
+    payload = {"tool_name": "read_file", "tool_input": {}, "session_id": "s1"}
+    conn = _FakeConn({"payload": payload, "token": server.token})
+
+    server._handle_conn(conn)
+
+    resp = conn.response()
+    assert resp["decision"] == "allow"
+    assert processed == [payload]  # authenticated → gate work ran exactly once
+
+
+# ── registry token round-trip + poisoned-row rejection ──────────────────────────
+
+
+def test_registry_round_trips_the_auth_token(tmp_path) -> None:
+    """``register_session`` persists the per-server token and ``lookup_endpoint``
+    returns it, so the client can present it on each request."""
+    db = tmp_path / "system.db"
+    SystemStore(str(db)).close()  # create schema at HEAD (incl. token column)
+
+    register_session("sess-1", "/tmp/gate.sock", token="server-secret", db_path=str(db))
+
+    assert lookup_endpoint("sess-1", db_path=str(db)) == ("/tmp/gate.sock", "server-secret")
+
+
+def test_poisoned_registry_row_token_is_rejected(tmp_path) -> None:
+    """Threat model: another local user overwrites a session's registry row with a
+    token they control. A client that trusts the row presents that poisoned token —
+    which the real server (holding a different secret) rejects, failing closed."""
+    db = tmp_path / "system.db"
+    SystemStore(str(db)).close()
+
+    server = GateServer(pipeline=object(), sock_path="victim.sock")  # holds real secret
+
+    # Attacker poisons the victim's row with a token that isn't the server's.
+    register_session("victim", server.sock_path, token="attacker-poison", db_path=str(db))
+    sock_path, row_token = lookup_endpoint("victim", db_path=str(db))
+    assert row_token == "attacker-poison"
+
+    # A client forwarding the poisoned row's token is rejected by the real server.
+    conn = _FakeConn(
+        {
+            "payload": {"tool_name": "rm", "tool_input": {}, "session_id": "victim"},
+            "token": row_token,
+        }
+    )
+    server._handle_conn(conn)
+
+    resp = conn.response()
+    assert resp["decision"] == "deny"
+    assert "unauthorized" in resp["reason"]
+
+
+# ── socket permissions (POSIX-only) ─────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="unix-socket 0600 perms are POSIX-only; Windows uses loopback TCP (no file mode).",
+)
+def test_unix_socket_is_created_owner_only_0600(tmp_path) -> None:
+    """The AF_UNIX socket is created with 0600 (owner-only) perms so another local
+    user cannot connect to poison the registry or hijack the session's gate."""
+    sock_path = tmp_path / "gate.sock"
+    server = GateServer(pipeline=object(), sock_path=str(sock_path))
+    server.start()
+    try:
+        assert sock_path.exists()
+        mode = stat.S_IMODE(os.stat(sock_path).st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    finally:
+        server.stop()
+
+
+# ── concurrency: shared SessionState stays consistent ───────────────────────────
+
+
+def _allow_all(request, ctx) -> Verdict:
+    return Verdict.allow()
+
+
+def _deny_all(request, ctx) -> Verdict:
+    return Verdict.deny("blocked")
+
+
+def test_concurrent_completions_do_not_lose_counter_updates() -> None:
+    """N threads each run an allowed preflight then observe completion on ONE
+    shared session; the tool-call counter must equal N (no lost increments)."""
+    pipeline = GovernancePipeline.create(policy=GatePolicy().preflight(_allow_all))
+    session_id = "shared-allow"
+    n = 64
+    barrier = threading.Barrier(n)
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            payload = {"tool_name": "read_file", "tool_input": {}, "session_id": session_id}
+            trace, verdict = pipeline._score_and_gate_preflight(payload)
+            assert verdict.allowed
+            barrier.wait()  # release all threads together to maximize contention
+            pipeline._enforce_postflight(trace, session_id=session_id, output={"r": "ok"})
+        except BaseException as exc:  # noqa: BLE001 - surface worker failures
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors
+    state = pipeline._shield._ensure_gate_state(session_id)
+    assert state.tool_call_count == n
+
+
+def test_concurrent_denials_do_not_lose_denied_count() -> None:
+    """N concurrent denied preflights on one shared session must book exactly N
+    denials (no lost denial-counter updates)."""
+    pipeline = GovernancePipeline.create(policy=GatePolicy().preflight(_deny_all))
+    session_id = "shared-deny"
+    n = 64
+    barrier = threading.Barrier(n)
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            payload = {"tool_name": "rm", "tool_input": {}, "session_id": session_id}
+            barrier.wait()
+            _, verdict = pipeline._score_and_gate_preflight(payload)
+            assert verdict.denied
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors
+    state = pipeline._shield._ensure_gate_state(session_id)
+    assert state.denied_count == n

--- a/tests/unit/test_watch_gating.py
+++ b/tests/unit/test_watch_gating.py
@@ -1,0 +1,243 @@
+"""PART E — enforce-by-default UX: config-declared GatePolicy + inactive warning.
+
+``traceforge watch`` starts the gate IPC server; with **no** policy the gate runs
+in allow-all mode and silently enforces nothing. These tests pin the two fixes:
+
+* :func:`build_policy_from_config` turns a config-declared policy — an ordered
+  preflight CHAIN (dotted in-process gates + external deciders), a postflight
+  chain, and an ``external:`` bucket — into a live :class:`GatePolicy`, enforces
+  it through a real pipeline, and returns ``None`` when nothing is declared so the
+  caller can warn.
+* the watch daemon emits a LOUD "enforcement INACTIVE (allow-all)" banner when the
+  resolved policy does not actually gate anything.
+
+The dotted gates below are module-level so the config loader can import them by
+their ``tests.unit.test_watch_gating.<name>`` dotted path — exactly how a real
+deployment references its own ``myapp.policies.<gate>`` callables.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from traceforge.cli.watch import _policy_is_enforcing, _warn_gating_inactive
+from traceforge.gate.external import HttpGate, SubprocessGate
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.governance.shield import build_policy_from_config
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.gate_types import PostflightAction, PostflightVerdict
+from traceforge.sdk.verdict import Verdict
+
+_DENY_MARKER = "blocked by dotted preflight gate"
+_SUPPRESS_MARKER = "stripped by dotted postflight gate"
+
+
+# ── dotted gates referenced from config (imported via importlib) ────────────────
+
+
+def deny_rm(request, ctx) -> Verdict:
+    """In-process preflight gate: DENY the destructive ``rm`` tool, else ALLOW."""
+    if "rm" in request.tool:
+        return Verdict.deny(_DENY_MARKER)
+    return Verdict.allow()
+
+
+def allow_everything(request, ctx) -> Verdict:
+    """In-process preflight gate that allows every call."""
+    return Verdict.allow()
+
+
+def suppress_postflight(result, ctx) -> PostflightVerdict:
+    """In-process postflight gate that suppresses output."""
+    return PostflightVerdict(action=PostflightAction.SUPPRESS, reason=_SUPPRESS_MARKER)
+
+
+# ── build_policy_from_config: nothing declared → None ───────────────────────────
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        None,
+        {},
+        {"governance": None},
+        {"governance": {}},
+        {"governance": {"gate_policy": {}}},
+        {"governance": {"gate_policy": {"preflight": [], "postflight": [], "external": []}}},
+    ],
+)
+def test_no_policy_config_returns_none(config) -> None:
+    """A config that declares no gates yields ``None`` (allow-all → caller warns)."""
+    assert build_policy_from_config(config) is None
+
+
+# ── build_policy_from_config: full policy loads all gate kinds ───────────────────
+
+
+def test_full_policy_loads_preflight_chain_postflight_and_external() -> None:
+    """A full ``gate_policy`` block loads a preflight CHAIN (dotted + http +
+    external subprocess), a postflight chain, and the ``external:`` bucket."""
+    config = {
+        "governance": {
+            "gate_policy": {
+                "preflight": [
+                    "tests.unit.test_watch_gating.deny_rm",  # dotted in-process
+                    {  # inline external HTTP decider
+                        "type": "http",
+                        "endpoint": "http://127.0.0.1:8181/v1/data/traceforge/gate",
+                    },
+                ],
+                "postflight": ["tests.unit.test_watch_gating.suppress_postflight"],
+                "external": [  # convenience bucket, appended to the preflight chain
+                    {"type": "subprocess", "command": "opa eval -I -f raw data.gate.deny"},
+                ],
+            }
+        }
+    }
+
+    policy = build_policy_from_config(config)
+
+    assert policy is not None
+    assert policy.has_preflight and policy.has_postflight
+    # preflight chain = dotted + http + subprocess(external bucket) = 3, in order.
+    pre = policy.preflight_gates
+    assert len(pre) == 3
+    assert pre[0] is deny_rm
+    assert isinstance(pre[1], HttpGate)
+    assert isinstance(pre[2], SubprocessGate)
+    # postflight chain = the one dotted gate.
+    post = policy.postflight_gates
+    assert len(post) == 1
+    assert post[0] is suppress_postflight
+
+
+def test_full_policy_external_gates_are_fail_closed_by_default() -> None:
+    """External gates built from config inherit the fail-CLOSED default posture."""
+    config = {
+        "governance": {
+            "gate_policy": {
+                "preflight": [
+                    {"type": "http", "endpoint": "http://127.0.0.1:9/x"},
+                    {"type": "subprocess", "command": "decide.sh"},
+                ]
+            }
+        }
+    }
+
+    http_gate, subprocess_gate = build_policy_from_config(config).preflight_gates
+
+    assert http_gate.fail_open is False
+    assert subprocess_gate.fail_open is False
+
+
+# ── build_policy_from_config: the loaded policy actually ENFORCES ────────────────
+
+
+def test_config_policy_enforces_preflight_and_postflight() -> None:
+    """A config-declared dotted preflight + postflight policy enforces end to end
+    through a real pipeline: preflight DENIES ``rm``, ALLOWS reads, and the
+    postflight gate's action is applied."""
+    config = {
+        "governance": {
+            "gate_policy": {
+                "preflight": ["tests.unit.test_watch_gating.deny_rm"],
+                "postflight": ["tests.unit.test_watch_gating.suppress_postflight"],
+            }
+        }
+    }
+    policy = build_policy_from_config(config)
+    pipeline = GovernancePipeline.create(policy=policy)
+
+    # Preflight DENY on the destructive tool.
+    _, deny_v = pipeline._score_and_gate_preflight(
+        {"tool_name": "rm", "tool_input": {"path": "/"}, "session_id": "s1"}
+    )
+    assert deny_v.denied
+    assert _DENY_MARKER in deny_v.reason
+
+    # Preflight ALLOW on a benign tool, then the postflight gate suppresses output.
+    trace, allow_v = pipeline._score_and_gate_preflight(
+        {"tool_name": "read_file", "tool_input": {"path": "/tmp/x"}, "session_id": "s1"}
+    )
+    assert allow_v.allowed
+    pv = pipeline._enforce_postflight(trace, session_id="s1", output={"result": "secret"})
+    assert pv.action == PostflightAction.SUPPRESS
+    assert _SUPPRESS_MARKER in pv.reason
+
+
+def test_external_gate_from_config_enforces_and_fails_closed() -> None:
+    """An external subprocess gate declared in config is wired into enforcement
+    and DENIES fail-closed on a broken decider (empty command → no spawn).
+
+    This proves the *external* leg of a config policy enforces, deterministically
+    and cross-platform, with no network and no child process."""
+    config = {
+        "governance": {
+            "gate_policy": {
+                # empty command → SubprocessGate can't launch → fail-closed DENY.
+                "external": [{"type": "subprocess", "command": ""}],
+            }
+        }
+    }
+    policy = build_policy_from_config(config)
+    assert isinstance(policy.preflight_gates[0], SubprocessGate)
+
+    pipeline = GovernancePipeline.create(policy=policy)
+    _, verdict = pipeline._score_and_gate_preflight(
+        {"tool_name": "read_file", "tool_input": {}, "session_id": "s1"}
+    )
+    assert verdict.denied
+    assert "fail-closed" in verdict.reason
+
+
+def test_legacy_single_field_forms_still_honored() -> None:
+    """Back-compat: the legacy ``tool_preflight_gate`` (dotted) single-field form is
+    still honored when no ``gate_policy`` block is present."""
+    config = {"governance": {"tool_preflight_gate": "tests.unit.test_watch_gating.deny_rm"}}
+
+    policy = build_policy_from_config(config)
+
+    assert policy is not None
+    assert policy.preflight_gates == (deny_rm,)
+
+
+def test_malformed_policy_raises_rather_than_silently_allowing() -> None:
+    """A *declared but broken* policy must fail loudly (so watch refuses to start),
+    never silently degrade to allow-all."""
+    config = {
+        "governance": {
+            "gate_policy": {"preflight": ["tests.unit.test_watch_gating.does_not_exist"]}
+        }
+    }
+    with pytest.raises((ImportError, AttributeError)):
+        build_policy_from_config(config)
+
+
+# ── enforce-by-default warning ──────────────────────────────────────────────────
+
+
+def test_policy_is_enforcing_reflects_registered_gates() -> None:
+    """``_policy_is_enforcing`` is True iff the policy gates something."""
+    assert _policy_is_enforcing(None) is False
+    assert _policy_is_enforcing(GatePolicy()) is False  # empty policy = allow-all
+    assert _policy_is_enforcing(GatePolicy().preflight(allow_everything)) is True
+    assert _policy_is_enforcing(GatePolicy().postflight(suppress_postflight)) is True
+
+
+def test_no_policy_config_is_not_enforcing() -> None:
+    """The no-policy config path resolves to a non-enforcing (warn) state."""
+    assert _policy_is_enforcing(build_policy_from_config({})) is False
+
+
+def test_warn_gating_inactive_emits_loud_banner(capsys: pytest.CaptureFixture) -> None:
+    """The inactive-gating warning is a prominent stderr banner that names the
+    allow-all risk and tells the operator how to enable enforcement."""
+    _warn_gating_inactive()  # must not raise
+
+    err = capsys.readouterr().err
+    assert "INACTIVE" in err
+    assert "allow-all" in err
+    assert "ALLOWED" in err
+    # Actionable: points at the config key that turns enforcement on.
+    assert "gate_policy" in err
+    assert "preflight" in err


### PR DESCRIPTION
Combined owner PR for audit fixes **PR-E** (watch gating UX + config-declared policy, S1-3 High) and **PR-G** (gate IPC hardening, S1-4 Med-High + X-3 concurrency). Bundled because both edit `governance/shield.py`. Branched off latest `main` and rebased onto it after #131–#134 landed (clean — no overlap with the files those PRs own).

## PART E — enforce-by-default warnings + config-declared GatePolicy
- **`cli/watch.py`**: when the gate IPC server starts with **no enforcing policy** it now emits a LOUD stderr banner (`click.echo(err=True)` + `logger.warning`) stating enforcement is INACTIVE (allow-all) and how to enable it. A config that *declares* a policy but is **broken** now fails fast (`sys.exit(1)`) instead of silently degrading to allow-all.
- **`governance/shield.py`**: new `build_policy_from_config(config)` turns a `governance.gate_policy` block into a live `GatePolicy` — an ordered **preflight CHAIN** (dotted in-process gates + inline external http/subprocess deciders), a **postflight** chain, and an **external** bucket. Legacy single-field `tool_preflight_gate` / `preflight_gate` forms are still honored.
- **`cli/init_cmd.py`**: one-line hint after each per-agent writer that a gate policy must be configured for the injected hook to actually enforce. Per-agent writers and their tests are untouched.

## PART G — gate IPC hardening
- **`gate/server.py`**: AF_UNIX socket created **0600** (owner-only; POSIX only — the win32 loopback-TCP branch is unchanged). Each server generates a per-server auth **token** (`secrets.token_hex(32)`), stores it in the session's registry row, and **requires + constant-time validates** (`hmac.compare_digest`) it on EVERY request **before** touching gate state. Missing/invalid token → rejected + **fails closed**.
- **`gate/registry.py`**: `register_session(*, token=...)` persists the token; new `lookup_endpoint() -> (sock_path, token)`; `lookup_session()` kept as a back-compat wrapper.
- **`gate/client.py`**: forwards the per-request token on the transport **envelope only** (`{"payload":…, "token":…}`). Missing/invalid token fails closed. The **#127 fail-closed wrapper** and the **#130 per-agent deny-output rendering** are preserved **exactly** — only the request/transport side changed.
- **`governance/shield.py`**: widened the shield lock over the shared `SessionState` read-modify-write updates (counter/budget, denial, allow, context snapshot) so concurrent preflight on one session can't lose updates (X-3).
- **migrations**: nullable `token` column added to `gate_endpoints`, folded into `0001_initial` + `models.py` (pre-alpha, no new migration).

## Tests — +25 new (unit suite 2040 → +25; **1 skipped on Windows**, runs on Linux CI)
- `tests/unit/test_watch_gating.py` (15): no-policy → warning/no-enforce, full config policy loads chain+postflight+external and enforces all, external fail-closed default, legacy single-field honored, malformed policy raises, banner content.
- `tests/unit/test_gate_ipc_auth.py` (10): token accepted only for the real secret, distinct per server, no/invalid token rejected **before** processing + fails closed, registry token round-trip, poisoned/foreign-row rejection, socket **0600** (POSIX-guarded / skipped on Windows), concurrent completions & denials with no lost updates (N=64 + barrier).
- Updated existing `test_gate_client_failclosed.py`, `test_gate_agent_dialects.py`, `test_gate_registry.py`, `tests/e2e/test_gate_ipc_e2e.py` for the new `(sock_path, token)` signatures.

Full unit suite green after rebase (**2084 passed, 1 skipped**), gate/watch/init e2e green, ruff 0.15.20 check + format clean.

## Assumptions flagged for review
1. **Schema edits outside the strict-6 file list**: `migrations/versions/0001_initial.py` + `migrations/models.py` got a nullable `token` column — necessary storage for the registry auth token, folded into `0001` per the pre-alpha "no phantom legacy" rule (no new migration/ALTER). Not owned by the parallel PRs (which own `pipeline.py` / `sdk/pipeline.py`).
2. **`governance.gate_policy` config shape is introduced here** (watch reads the raw dict; `config/models.py` was out of scope). Inline external entries still get Pydantic validation via `TypeAdapter(ExternalGateConfig)`.

**Do NOT merge — holding for coordinator review.** Constraints honored: only the 6 target files (+ tests, + the two schema files above) touched; `pipeline.py` / `sdk/pipeline.py` untouched; #127 fail-closed + #130 deny rendering preserved exactly; POSIX 0600 guarded on Windows; deterministic, no network at import.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>