### PR TITLE
feat(adapters): symmetric ungate_* teardown for in-process gating (PR-L)

### DIFF
--- a/src/traceforge/governance/pipeline.py
+++ b/src/traceforge/governance/pipeline.py
@@ -64,6 +64,12 @@ _UNSET = object()
 # CrewAI's hook-clearing API) to permit re-installation. Keep the name stable.
 _CREWAI_HOOKS_INSTALLED = False
 
+# Handle to the exact ``(before_hook, after_hook)`` traceforge registered, so
+# ``ungate_crewai`` can deregister just those (via CrewAI's targeted
+# ``unregister_*_tool_call_hook``) rather than clearing every hook in the process.
+# ``None`` when CrewAI gating is not installed.
+_CREWAI_INSTALLED_HOOKS: tuple | None = None
+
 
 class GovernancePipeline:
     """Composition-root facade for the governance subsystem.
@@ -365,7 +371,7 @@ class GovernancePipeline:
         hooks are registered exactly once per process, even if a second
         ``GovernancePipeline`` also calls ``gate_crewai``.
         """
-        global _CREWAI_HOOKS_INSTALLED
+        global _CREWAI_HOOKS_INSTALLED, _CREWAI_INSTALLED_HOOKS
         if _CREWAI_HOOKS_INSTALLED:
             return
         _CREWAI_HOOKS_INSTALLED = True
@@ -422,6 +428,43 @@ class GovernancePipeline:
             elif pv.action == PostflightAction.REDACT and isinstance(output, str):
                 ctx.output = pipeline._apply_postflight_to_output(pv, output)
 
+        # Stash the exact hooks we registered so ``ungate_crewai`` can deregister
+        # only these. CrewAI's bare ``@before/after_tool_call`` register and return
+        # the original function object, so these references match the registry.
+        _CREWAI_INSTALLED_HOOKS = (_traceforge_hook, _traceforge_postflight)
+
+    def ungate_crewai(self) -> None:
+        """Reverse :meth:`gate_crewai`: deregister the process-global hooks.
+
+        Removes exactly the before/after tool-call hooks traceforge registered (via
+        CrewAI's targeted ``unregister_*_tool_call_hook``) and resets the module-level
+        ``_CREWAI_HOOKS_INSTALLED`` guard so a later :meth:`gate_crewai` re-installs.
+        Idempotent + safe: a harmless no-op when CrewAI gating was never installed,
+        and never raises.
+        """
+        global _CREWAI_HOOKS_INSTALLED, _CREWAI_INSTALLED_HOOKS
+        if not _CREWAI_HOOKS_INSTALLED:
+            return
+        hooks = _CREWAI_INSTALLED_HOOKS
+        # Reset the module state up front so a second call (or a failed unregister)
+        # is a clean no-op and a later re-gate re-installs.
+        _CREWAI_INSTALLED_HOOKS = None
+        _CREWAI_HOOKS_INSTALLED = False
+        if hooks is None:
+            return
+        before_hook, after_hook = hooks
+        try:
+            from crewai.hooks import (
+                unregister_after_tool_call_hook,
+                unregister_before_tool_call_hook,
+            )
+
+            unregister_before_tool_call_hook(before_hook)
+            unregister_after_tool_call_hook(after_hook)
+        except Exception:
+            # Best-effort: the module guard is already reset, so re-gate still works.
+            pass
+
     def gate_langchain(self, tool):
         """Wrap a LangChain tool's ``_run`` and ``_arun`` with traceforge gating.
 
@@ -437,6 +480,8 @@ class GovernancePipeline:
 
         pipeline = self
         original_run = tool._run
+        # Stash the true original so ``ungate_langchain`` can restore it (teardown).
+        tool._traceforge_original_run = original_run
 
         def _guarded_run(*args, config=None, run_manager=None, **kwargs):
             import time
@@ -513,6 +558,8 @@ class GovernancePipeline:
             _native_async = type(tool)._arun is not BaseTool._arun
         if _native_async and hasattr(tool, "_arun"):
             original_arun = tool._arun
+            # Stash so ``ungate_langchain`` restores the async path too (teardown).
+            tool._traceforge_original_arun = original_arun
 
             async def _guarded_arun(*args, config=None, run_manager=None, **kwargs):
                 import time
@@ -575,7 +622,47 @@ class GovernancePipeline:
 
             tool._arun = _guarded_arun
 
+        # Stash the prior ``handle_tool_error`` so teardown restores it exactly
+        # (a ``_UNSET`` stash value means "was absent" -> ungate deletes it).
+        tool._traceforge_prev_handle_tool_error = getattr(tool, "handle_tool_error", _UNSET)
         tool.handle_tool_error = True
+        return tool
+
+    def ungate_langchain(self, tool):
+        """Reverse :meth:`gate_langchain`: restore the tool's original callables.
+
+        Restores both the sync (``_run``) and async (``_arun``, when it was wrapped)
+        callables from the stashes recorded at gate time, restores the prior
+        ``handle_tool_error`` value, and clears ``tool._traceforge_gated`` so a later
+        :meth:`gate_langchain` re-wraps cleanly. Idempotent + safe: a no-op when the
+        tool was never gated, and never raises. Returns the tool.
+        """
+        if not getattr(tool, "_traceforge_gated", False):
+            return tool
+
+        original_run = getattr(tool, "_traceforge_original_run", _UNSET)
+        if original_run is not _UNSET:
+            tool._run = original_run
+            del tool._traceforge_original_run
+
+        original_arun = getattr(tool, "_traceforge_original_arun", _UNSET)
+        if original_arun is not _UNSET:
+            tool._arun = original_arun
+            del tool._traceforge_original_arun
+
+        if hasattr(tool, "_traceforge_prev_handle_tool_error"):
+            prev = tool._traceforge_prev_handle_tool_error
+            if prev is _UNSET:
+                # The attribute did not exist before gating -> remove what we added.
+                try:
+                    del tool.handle_tool_error
+                except AttributeError:
+                    pass
+            else:
+                tool.handle_tool_error = prev
+            del tool._traceforge_prev_handle_tool_error
+
+        tool._traceforge_gated = False
         return tool
 
     def gate_langgraph(self, tools):
@@ -663,7 +750,34 @@ class GovernancePipeline:
                 )
             return result
 
-        return ToolNode(tools, wrap_tool_call=_traceforge_wrapper)
+        node = ToolNode(tools, wrap_tool_call=_traceforge_wrapper)
+        # Mark the produced node so ``ungate_langgraph`` can detect and neutralize
+        # it. This adapter installs nothing on a caller-owned object -- the gate
+        # lives inside the returned node's ``wrap_tool_call`` -- so teardown operates
+        # on the node itself.
+        node._traceforge_gated = True
+        return node
+
+    def ungate_langgraph(self, tool_node=None) -> None:
+        """Reverse :meth:`gate_langgraph` on a produced ``ToolNode``.
+
+        Unlike the in-place adapters, ``gate_langgraph`` installs nothing on a
+        caller-owned object: it *returns* a fresh gated ``ToolNode``. Teardown
+        therefore operates on that returned node -- it clears the traceforge
+        tool-call wrapper (``_wrap_tool_call`` / ``_awrap_tool_call``), after which
+        the node executes tools ungated -- and clears the node's guard flag.
+        Idempotent + safe: a no-op when ``tool_node`` is ``None`` or was not produced
+        by :meth:`gate_langgraph`, and never raises.
+        """
+        if tool_node is None or not getattr(tool_node, "_traceforge_gated", False):
+            return
+        # In LangGraph's ToolNode, ``_wrap_tool_call``/``_awrap_tool_call`` being
+        # ``None`` means "execute the tool directly" (ungated).
+        if hasattr(tool_node, "_wrap_tool_call"):
+            tool_node._wrap_tool_call = None
+        if hasattr(tool_node, "_awrap_tool_call"):
+            tool_node._awrap_tool_call = None
+        tool_node._traceforge_gated = False
 
     def gate_semantic_kernel(self, kernel) -> None:
         """Register traceforge as a Semantic Kernel auto function invocation filter.
@@ -726,6 +840,35 @@ class GovernancePipeline:
                     value=redacted,
                 )
 
+        # Stash the registered filter so ``ungate_semantic_kernel`` can remove
+        # exactly it. ``kernel.filter`` registers and returns the same function
+        # object, keyed in the kernel by ``id(filter)``.
+        kernel._traceforge_sk_filter = _traceforge_filter
+
+    def ungate_semantic_kernel(self, kernel) -> None:
+        """Reverse :meth:`gate_semantic_kernel`: remove the registered filter.
+
+        Removes the auto-function-invocation filter traceforge registered (matched by
+        ``id(filter)`` via ``kernel.remove_filter``) and clears
+        ``kernel._traceforge_gated`` so a later :meth:`gate_semantic_kernel`
+        re-registers. Idempotent + safe: a no-op when the kernel was never gated, and
+        never raises.
+        """
+        if not getattr(kernel, "_traceforge_gated", False):
+            return
+        filt = getattr(kernel, "_traceforge_sk_filter", _UNSET)
+        if filt is not _UNSET:
+            try:
+                kernel.remove_filter(
+                    filter_type="auto_function_invocation",
+                    filter_id=id(filt),
+                )
+            except Exception:
+                # Best-effort: still clear the guard below so re-gate works.
+                pass
+            del kernel._traceforge_sk_filter
+        kernel._traceforge_gated = False
+
     def gate_maf(self):
         """Return a FunctionMiddleware for Microsoft Agent Framework (MAF).
 
@@ -785,6 +928,18 @@ class GovernancePipeline:
 
         return TraceforgeMiddleware()
 
+    def ungate_maf(self) -> None:
+        """Reverse of :meth:`gate_maf` -- a documented no-op.
+
+        LIMITATION: ``gate_maf`` installs nothing on a shared/caller object and sets
+        no guard flag -- it *returns* a standalone ``FunctionMiddleware`` instance the
+        caller attaches to their own agent. traceforge holds no handle to that
+        attachment point, so there is genuinely no process/global state to reverse
+        here. To remove MAF gating, drop the returned middleware from your agent's
+        middleware list. Provided for API symmetry; idempotent and always safe.
+        """
+        return None
+
     def gate_smolagents(self, agent_cls=None):
         """Return a TraceforgeAgent subclass that gates tool calls for smolagents.
 
@@ -840,6 +995,17 @@ class GovernancePipeline:
                 return result
 
         return _TraceforgeAgent
+
+    def ungate_smolagents(self) -> None:
+        """Reverse of :meth:`gate_smolagents` -- a documented no-op.
+
+        LIMITATION: ``gate_smolagents`` installs nothing on a shared object and sets
+        no guard flag -- it *returns* a gated agent *subclass*. There is no per-object
+        install to reverse; to stop gating, instantiate the original agent class
+        instead of the returned subclass. Provided for API symmetry; idempotent and
+        always safe.
+        """
+        return None
 
     def gate_pydantic_ai(self, agent) -> None:
         """Gate a Pydantic AI agent's tool calls via a wrapping toolset.
@@ -899,10 +1065,42 @@ class GovernancePipeline:
 
         # Wrap every leaf toolset the agent will assemble into its run toolset, then
         # mark gated only after wrapping succeeds (no half-gated state on failure).
+        # Stash the originals first so ``ungate_pydantic_ai`` restores them exactly.
+        # Stash the list *references* (not copies): the gate reassigns each attribute
+        # to a fresh list below, so the originals are otherwise dropped, and restoring
+        # the exact original objects is the truest teardown.
+        agent._traceforge_original_function_toolset = agent._function_toolset
+        agent._traceforge_original_user_toolsets = agent._user_toolsets
+        agent._traceforge_original_dynamic_toolsets = agent._dynamic_toolsets
         agent._function_toolset = _TraceforgeGateToolset(agent._function_toolset)
         agent._user_toolsets = [_TraceforgeGateToolset(ts) for ts in agent._user_toolsets]
         agent._dynamic_toolsets = [_TraceforgeGateToolset(ts) for ts in agent._dynamic_toolsets]
         agent._traceforge_gated = True
+
+    def ungate_pydantic_ai(self, agent) -> None:
+        """Reverse :meth:`gate_pydantic_ai`: unwrap the agent's leaf toolsets.
+
+        Restores ``_function_toolset`` / ``_user_toolsets`` / ``_dynamic_toolsets``
+        from the stashes recorded at gate time (removing the ``WrapperToolset`` gate
+        layer) and clears ``agent._traceforge_gated`` so a later
+        :meth:`gate_pydantic_ai` re-wraps cleanly. Idempotent + safe: a no-op when the
+        agent was never gated, and never raises.
+        """
+        if not getattr(agent, "_traceforge_gated", False):
+            return
+        orig_fn = getattr(agent, "_traceforge_original_function_toolset", _UNSET)
+        if orig_fn is not _UNSET:
+            agent._function_toolset = orig_fn
+            del agent._traceforge_original_function_toolset
+        orig_user = getattr(agent, "_traceforge_original_user_toolsets", _UNSET)
+        if orig_user is not _UNSET:
+            agent._user_toolsets = orig_user
+            del agent._traceforge_original_user_toolsets
+        orig_dyn = getattr(agent, "_traceforge_original_dynamic_toolsets", _UNSET)
+        if orig_dyn is not _UNSET:
+            agent._dynamic_toolsets = orig_dyn
+            del agent._traceforge_original_dynamic_toolsets
+        agent._traceforge_gated = False
 
     def gate_openai_agents(self, agent):
         """Gate an OpenAI Agents SDK agent's tool calls per-tool.
@@ -934,6 +1132,8 @@ class GovernancePipeline:
             if getattr(tool, "_traceforge_gated", False):
                 return
             original_invoke = tool.on_invoke_tool
+            # Stash so ``ungate_openai_agents`` restores each tool's invoker (teardown).
+            tool._traceforge_original_on_invoke_tool = original_invoke
             tool_name = getattr(tool, "name", None) or "unknown"
 
             async def _guarded_invoke(ctx, input_str):
@@ -984,4 +1184,30 @@ class GovernancePipeline:
 
         # Mark gated only after wrapping succeeds (no half-gated state on failure).
         agent._traceforge_gated = True
+        return agent
+
+    def ungate_openai_agents(self, agent):
+        """Reverse :meth:`gate_openai_agents`: restore each tool's ``on_invoke_tool``.
+
+        For every ``FunctionTool`` traceforge wrapped, restores the original
+        ``on_invoke_tool`` from its per-tool stash and clears the per-tool
+        ``_traceforge_gated`` marker, then clears ``agent._traceforge_gated`` so a
+        later :meth:`gate_openai_agents` re-wraps cleanly. Idempotent + safe: a no-op
+        when the agent was never gated, and never raises. Returns the agent.
+
+        Mirrors the gate's shared-tool model: a ``FunctionTool`` shared across agents
+        is wrapped exactly once, so restoring it here ungates it for every agent that
+        shares it (there is no per-agent refcount to consult).
+        """
+        if not getattr(agent, "_traceforge_gated", False):
+            return agent
+        for tool in list(getattr(agent, "tools", None) or []):
+            if not getattr(tool, "_traceforge_gated", False):
+                continue
+            original_invoke = getattr(tool, "_traceforge_original_on_invoke_tool", _UNSET)
+            if original_invoke is not _UNSET:
+                tool.on_invoke_tool = original_invoke
+                del tool._traceforge_original_on_invoke_tool
+            tool._traceforge_gated = False
+        agent._traceforge_gated = False
         return agent

--- a/src/traceforge/sdk/pipeline.py
+++ b/src/traceforge/sdk/pipeline.py
@@ -253,6 +253,43 @@ class Pipeline:
         """Gate an OpenAI Agents SDK agent."""
         return self._governance.gate_openai_agents(agent)
 
+    # ---- teardown / ungate layer (PR-L; reverses the gate_* installs) ------
+    # Each ungate_* is a thin lazy delegator to the governance engine, mirroring
+    # the gate_* facade above. All are idempotent + safe: calling one when the
+    # target was never gated (or twice) is a harmless no-op and never raises.
+
+    def ungate_crewai(self) -> None:
+        """Remove the process-global CrewAI gating hooks."""
+        return self._governance.ungate_crewai()
+
+    def ungate_langchain(self, tool):
+        """Restore a LangChain tool's original ``_run``/``_arun``. Returns the tool."""
+        return self._governance.ungate_langchain(tool)
+
+    def ungate_langgraph(self, tool_node=None) -> None:
+        """Neutralize a gated LangGraph tool node produced by ``gate_langgraph``."""
+        return self._governance.ungate_langgraph(tool_node)
+
+    def ungate_semantic_kernel(self, kernel) -> None:
+        """Remove the Semantic Kernel gating filter."""
+        return self._governance.ungate_semantic_kernel(kernel)
+
+    def ungate_maf(self) -> None:
+        """Reverse of ``gate_maf`` (documented no-op; drop the returned middleware)."""
+        return self._governance.ungate_maf()
+
+    def ungate_smolagents(self) -> None:
+        """Reverse of ``gate_smolagents`` (documented no-op; use the original class)."""
+        return self._governance.ungate_smolagents()
+
+    def ungate_pydantic_ai(self, agent) -> None:
+        """Unwrap a Pydantic AI agent's gated toolsets."""
+        return self._governance.ungate_pydantic_ai(agent)
+
+    def ungate_openai_agents(self, agent):
+        """Restore an OpenAI Agents SDK agent's original tool invokers. Returns the agent."""
+        return self._governance.ungate_openai_agents(agent)
+
     # ---- in-process observation auto-subscriber (PR-J phase 1) -------------
     # Additive, self-contained facade over ``traceforge.sdk.observe``: subscribe to a
     # framework's NATIVE global bus/processor, map native events through the existing

--- a/tests/unit/test_adapter_ungate_teardown.py
+++ b/tests/unit/test_adapter_ungate_teardown.py
@@ -1,0 +1,760 @@
+"""Deterministic unit tests for symmetric ``ungate_*`` adapter teardown (PR-L).
+
+Every in-process ``gate_*`` adapter in ``GovernancePipeline`` now has a symmetric
+``ungate_*`` that reverses the install. These tests exercise each one WITHOUT the
+real frameworks installed, by faking the tiny framework surface each adapter
+touches (``sys.modules`` injection + duck-typed objects), matching the style of
+``tests/unit/test_adapter_gating_hardening.py``.
+
+For each adapter we assert the four teardown correctness properties:
+
+  (a) ungate restores the original callable / removes the hook or filter,
+  (b) the guard flag is cleared,
+  (c) gate -> ungate -> gate re-gates successfully (the KEY property), and
+  (d) ungate-when-not-gated (or twice) is a harmless no-op that never raises.
+
+The two "detached factory" adapters (``maf`` returns a standalone middleware,
+``smolagents`` returns a gated subclass) have no persistent per-object install to
+reverse, so their ``ungate_*`` is a documented no-op; for those we assert the
+no-op is safe and that gate -> ungate -> gate still yields a working gate.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import traceforge.governance.pipeline as gp
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.verdict import Verdict
+
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+
+def _make_pipeline(preflight=None, postflight=None) -> GovernancePipeline:
+    policy = GatePolicy()
+    if preflight:
+        policy.preflight(preflight)
+    if postflight:
+        policy.postflight(postflight)
+    return GovernancePipeline.create(policy=policy)
+
+
+def _allow_all(request, ctx) -> Verdict:
+    return Verdict.allow()
+
+
+def _deny_all(request, ctx) -> Verdict:
+    return Verdict.deny("blocked by test policy")
+
+
+@pytest.fixture(autouse=True)
+def _reset_crewai_state():
+    """Isolate the CrewAI module-global guard + stashed-hooks handle per test."""
+    gp._CREWAI_HOOKS_INSTALLED = False
+    gp._CREWAI_INSTALLED_HOOKS = None
+    yield
+    gp._CREWAI_HOOKS_INSTALLED = False
+    gp._CREWAI_INSTALLED_HOOKS = None
+
+
+# ─── CrewAI (process-global hooks) ────────────────────────────────────────────
+
+
+def _install_fake_crewai(monkeypatch):
+    """Fake ``crewai.hooks`` with register + targeted unregister semantics.
+
+    Extends the hardening test's fake with ``unregister_before/after_tool_call_hook``
+    so ``ungate_crewai`` can deregister exactly the hooks it installed.
+    """
+    registry = {"before": [], "after": []}
+
+    decorators = types.ModuleType("crewai.hooks.decorators")
+
+    def before_tool_call(fn):
+        registry["before"].append(fn)
+        return fn
+
+    def after_tool_call(fn):
+        registry["after"].append(fn)
+        return fn
+
+    decorators.before_tool_call = before_tool_call
+    decorators.after_tool_call = after_tool_call
+
+    hooks = types.ModuleType("crewai.hooks")
+    hooks.decorators = decorators
+
+    def unregister_before_tool_call_hook(fn):
+        if fn in registry["before"]:
+            registry["before"].remove(fn)
+            return True
+        return False
+
+    def unregister_after_tool_call_hook(fn):
+        if fn in registry["after"]:
+            registry["after"].remove(fn)
+            return True
+        return False
+
+    hooks.unregister_before_tool_call_hook = unregister_before_tool_call_hook
+    hooks.unregister_after_tool_call_hook = unregister_after_tool_call_hook
+
+    root = types.ModuleType("crewai")
+    root.hooks = hooks
+
+    monkeypatch.setitem(sys.modules, "crewai", root)
+    monkeypatch.setitem(sys.modules, "crewai.hooks", hooks)
+    monkeypatch.setitem(sys.modules, "crewai.hooks.decorators", decorators)
+    return registry
+
+
+class TestCrewAIUngate:
+    def test_ungate_removes_hooks_and_resets_flag(self, monkeypatch):
+        registry = _install_fake_crewai(monkeypatch)
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_crewai()
+        assert len(registry["before"]) == 1
+        assert len(registry["after"]) == 1
+        assert gp._CREWAI_HOOKS_INSTALLED is True
+        assert gp._CREWAI_INSTALLED_HOOKS is not None
+
+        pipeline.ungate_crewai()
+
+        # (a) the exact process-global hooks were deregistered
+        assert registry["before"] == []
+        assert registry["after"] == []
+        # (b) the module guard + stash are reset
+        assert gp._CREWAI_HOOKS_INSTALLED is False
+        assert gp._CREWAI_INSTALLED_HOOKS is None
+
+    def test_gate_ungate_gate_reinstalls(self, monkeypatch):
+        registry = _install_fake_crewai(monkeypatch)
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_crewai()
+        first_before = registry["before"][0]
+        pipeline.ungate_crewai()
+        pipeline.gate_crewai()  # (c) re-gate after teardown
+
+        assert len(registry["before"]) == 1
+        assert len(registry["after"]) == 1
+        assert gp._CREWAI_HOOKS_INSTALLED is True
+        # A genuinely fresh hook was registered on re-gate.
+        assert registry["before"][0] is not first_before
+
+    def test_ungate_when_not_gated_is_noop(self, monkeypatch):
+        _install_fake_crewai(monkeypatch)
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        # (d) never gated -> no-op, no raise
+        pipeline.ungate_crewai()
+        assert gp._CREWAI_HOOKS_INSTALLED is False
+
+        pipeline.gate_crewai()
+        pipeline.ungate_crewai()
+        pipeline.ungate_crewai()  # twice -> still safe
+        assert gp._CREWAI_HOOKS_INSTALLED is False
+
+
+# ─── LangChain (monkeypatched _run / _arun) ───────────────────────────────────
+
+
+def _install_fake_langchain(monkeypatch):
+    base = types.ModuleType("langchain_core.tools.base")
+
+    class ToolException(Exception):
+        pass
+
+    class BaseTool:
+        async def _arun(self, *args, **kwargs):
+            raise NotImplementedError
+
+    base.ToolException = ToolException
+    base.BaseTool = BaseTool
+
+    tools_mod = types.ModuleType("langchain_core.tools")
+    tools_mod.base = base
+    root = types.ModuleType("langchain_core")
+    root.tools = tools_mod
+
+    monkeypatch.setitem(sys.modules, "langchain_core", root)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
+    monkeypatch.setitem(sys.modules, "langchain_core.tools.base", base)
+    return ToolException
+
+
+class _FakeAsyncTool:
+    """A native-async LangChain-style tool (non-None ``coroutine`` slot)."""
+
+    def __init__(self, name="rm"):
+        self.name = name
+        self.coroutine = self._arun
+
+    def _run(self, *args, config=None, run_manager=None, **kwargs):
+        return f"ran:{self.name}"
+
+    async def _arun(self, *args, config=None, run_manager=None, **kwargs):
+        return f"aran:{self.name}"
+
+    async def ainvoke(self, tool_input, config=None):
+        return await self._arun(config=config, **tool_input)
+
+
+class TestLangChainUngate:
+    def test_ungate_restores_both_run_and_arun(self, monkeypatch):
+        _install_fake_langchain(monkeypatch)
+        tool = _FakeAsyncTool()
+        original_run = tool._run
+        original_arun = tool._arun
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_langchain(tool)
+        # Sanity: gate replaced both callables (instance-attr closures).
+        assert tool._run is not original_run
+        assert tool._arun is not original_arun
+        assert tool._traceforge_gated is True
+
+        pipeline.ungate_langchain(tool)
+
+        # (a) BOTH sync and async originals restored
+        assert tool._run == original_run
+        assert tool._arun == original_arun
+        # stash attrs removed
+        assert not hasattr(tool, "_traceforge_original_run")
+        assert not hasattr(tool, "_traceforge_original_arun")
+        # (b) guard cleared
+        assert tool._traceforge_gated is False
+
+    def test_handle_tool_error_absent_is_removed_on_ungate(self, monkeypatch):
+        _install_fake_langchain(monkeypatch)
+        tool = _FakeAsyncTool()
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        assert not hasattr(tool, "handle_tool_error")
+        pipeline.gate_langchain(tool)
+        assert tool.handle_tool_error is True  # gate set it
+        pipeline.ungate_langchain(tool)
+
+        # Restored to "absent" because it did not exist before gating.
+        assert not hasattr(tool, "handle_tool_error")
+        assert not hasattr(tool, "_traceforge_prev_handle_tool_error")
+
+    def test_handle_tool_error_prior_value_restored(self, monkeypatch):
+        _install_fake_langchain(monkeypatch)
+        tool = _FakeAsyncTool()
+        sentinel = object()
+        tool.handle_tool_error = sentinel
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_langchain(tool)
+        pipeline.ungate_langchain(tool)
+
+        assert tool.handle_tool_error is sentinel
+
+    async def test_gate_ungate_gate_regates_and_blocks(self, monkeypatch):
+        tool_exc = _install_fake_langchain(monkeypatch)
+        tool = _FakeAsyncTool()
+
+        # gate (deny) -> ungate -> gate (deny) must still block async calls.
+        pipeline = _make_pipeline(preflight=_deny_all)
+        pipeline.gate_langchain(tool)
+        pipeline.ungate_langchain(tool)
+        pipeline.gate_langchain(tool)  # (c) re-gate
+
+        assert tool._traceforge_gated is True
+        with pytest.raises(tool_exc, match="Denied"):
+            await tool._arun(path="/x")
+
+    async def test_ungated_tool_runs_freely(self, monkeypatch):
+        _install_fake_langchain(monkeypatch)
+        tool = _FakeAsyncTool()
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        pipeline.gate_langchain(tool)
+        pipeline.ungate_langchain(tool)
+
+        # After teardown the original callable runs with no gating.
+        assert await tool._arun(path="/x") == "aran:rm"
+        assert tool._run() == "ran:rm"
+
+    def test_ungate_when_not_gated_is_noop(self, monkeypatch):
+        _install_fake_langchain(monkeypatch)
+        tool = _FakeAsyncTool()
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        # (d) never gated -> no-op, no raise, no attrs added.
+        result = pipeline.ungate_langchain(tool)
+        assert result is tool
+        assert not hasattr(tool, "_traceforge_gated") or tool._traceforge_gated is False
+
+        pipeline.gate_langchain(tool)
+        pipeline.ungate_langchain(tool)
+        pipeline.ungate_langchain(tool)  # twice -> safe
+        assert tool._traceforge_gated is False
+
+
+# ─── LangGraph (produced ToolNode) ────────────────────────────────────────────
+
+
+class _FakeToolMessage:
+    def __init__(self, content=None, tool_call_id=None, name=None, status=None):
+        self.content = content
+        self.tool_call_id = tool_call_id
+        self.name = name
+        self.status = status
+
+
+class _FakeToolNode:
+    """Minimal stand-in for LangGraph's ToolNode wrap_tool_call behavior.
+
+    Models the real node's contract: when ``_wrap_tool_call`` is None the tool
+    executes directly (ungated); otherwise execution routes through the wrapper.
+    """
+
+    def __init__(self, tools, wrap_tool_call=None):
+        self.tools = tools
+        self._wrap_tool_call = wrap_tool_call
+        self._awrap_tool_call = None
+
+    def run(self, request, execute):
+        if self._wrap_tool_call is not None:
+            return self._wrap_tool_call(request, execute)
+        return execute(request)
+
+
+class _FakeRequest:
+    def __init__(self, name="rm", args=None, call_id="c1"):
+        self.tool_call = {"name": name, "args": args or {}, "id": call_id}
+
+
+def _install_fake_langgraph(monkeypatch):
+    prebuilt = types.ModuleType("langgraph.prebuilt")
+    prebuilt.ToolNode = _FakeToolNode
+    root = types.ModuleType("langgraph")
+    root.prebuilt = prebuilt
+
+    messages = types.ModuleType("langchain_core.messages")
+    messages.ToolMessage = _FakeToolMessage
+    lc_root = types.ModuleType("langchain_core")
+    lc_root.messages = messages
+
+    monkeypatch.setitem(sys.modules, "langgraph", root)
+    monkeypatch.setitem(sys.modules, "langgraph.prebuilt", prebuilt)
+    monkeypatch.setitem(sys.modules, "langchain_core", lc_root)
+    monkeypatch.setitem(sys.modules, "langchain_core.messages", messages)
+
+
+class TestLangGraphUngate:
+    def test_ungate_neutralizes_wrapper_and_flag(self, monkeypatch):
+        _install_fake_langgraph(monkeypatch)
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        node = pipeline.gate_langgraph([])
+        assert node._wrap_tool_call is not None
+        assert node._traceforge_gated is True
+
+        pipeline.ungate_langgraph(node)
+
+        # (a) tool-call wrapper cleared; (b) guard cleared
+        assert node._wrap_tool_call is None
+        assert node._awrap_tool_call is None
+        assert node._traceforge_gated is False
+
+    def test_ungated_node_executes_directly(self, monkeypatch):
+        _install_fake_langgraph(monkeypatch)
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        node = pipeline.gate_langgraph([])
+        # Gated: deny returns a denial ToolMessage without executing.
+        denied = node.run(_FakeRequest(), lambda req: "EXECUTED")
+        assert isinstance(denied, _FakeToolMessage)
+        assert "Denied" in denied.content
+
+        pipeline.ungate_langgraph(node)
+        # Ungated: executes straight through.
+        assert node.run(_FakeRequest(), lambda req: "EXECUTED") == "EXECUTED"
+
+    def test_gate_ungate_gate_produces_working_node(self, monkeypatch):
+        _install_fake_langgraph(monkeypatch)
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        node1 = pipeline.gate_langgraph([])
+        pipeline.ungate_langgraph(node1)
+        node2 = pipeline.gate_langgraph([])  # (c) re-gate -> fresh node
+
+        assert node2._traceforge_gated is True
+        denied = node2.run(_FakeRequest(), lambda req: "EXECUTED")
+        assert isinstance(denied, _FakeToolMessage)
+        assert "Denied" in denied.content
+
+    def test_ungate_when_not_gated_is_noop(self, monkeypatch):
+        _install_fake_langgraph(monkeypatch)
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        # (d) None / never-gated node -> no-op, no raise
+        pipeline.ungate_langgraph(None)
+        plain = _FakeToolNode([])
+        pipeline.ungate_langgraph(plain)
+        assert plain._wrap_tool_call is None
+
+        node = pipeline.gate_langgraph([])
+        pipeline.ungate_langgraph(node)
+        pipeline.ungate_langgraph(node)  # twice -> safe
+        assert node._traceforge_gated is False
+
+
+# ─── Semantic Kernel (auto-function-invocation filter) ────────────────────────
+
+
+class _FakeKernel:
+    """Stand-in kernel modeling id-keyed filter registration + removal."""
+
+    def __init__(self):
+        # Keyed by (filter_type, id(fn)) to mirror Semantic Kernel's registry.
+        self.filters = {}
+
+    def filter(self, filter_type=None):
+        def _decorator(fn):
+            self.filters[(filter_type, id(fn))] = fn
+            return fn
+
+        return _decorator
+
+    def remove_filter(self, filter_type=None, filter_id=None):
+        self.filters.pop((filter_type, filter_id), None)
+
+
+class TestSemanticKernelUngate:
+    def test_ungate_removes_filter_and_clears_flag(self):
+        kernel = _FakeKernel()
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_semantic_kernel(kernel)
+        assert len(kernel.filters) == 1
+        assert kernel._traceforge_gated is True
+        assert hasattr(kernel, "_traceforge_sk_filter")
+
+        pipeline.ungate_semantic_kernel(kernel)
+
+        # (a) filter removed; stash deleted; (b) guard cleared
+        assert len(kernel.filters) == 0
+        assert not hasattr(kernel, "_traceforge_sk_filter")
+        assert kernel._traceforge_gated is False
+
+    def test_gate_ungate_gate_reregisters(self):
+        kernel = _FakeKernel()
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_semantic_kernel(kernel)
+        first = next(iter(kernel.filters.values()))
+        pipeline.ungate_semantic_kernel(kernel)
+        pipeline.gate_semantic_kernel(kernel)  # (c) re-gate
+
+        assert len(kernel.filters) == 1
+        assert kernel._traceforge_gated is True
+        assert next(iter(kernel.filters.values())) is not first
+
+    def test_ungate_when_not_gated_is_noop(self):
+        kernel = _FakeKernel()
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        # (d) never gated -> no-op, no raise
+        pipeline.ungate_semantic_kernel(kernel)
+        assert len(kernel.filters) == 0
+
+        pipeline.gate_semantic_kernel(kernel)
+        pipeline.ungate_semantic_kernel(kernel)
+        pipeline.ungate_semantic_kernel(kernel)  # twice -> safe
+        assert kernel._traceforge_gated is False
+
+
+# ─── Pydantic AI (wrapped leaf toolsets) ──────────────────────────────────────
+
+
+def _install_fake_pydantic_ai(monkeypatch):
+    toolsets = types.ModuleType("pydantic_ai.toolsets")
+
+    class WrapperToolset:
+        def __init__(self, wrapped):
+            self.wrapped = wrapped
+
+        async def call_tool(self, name, tool_args, ctx, tool):
+            return await self.wrapped.call_tool(name, tool_args, ctx, tool)
+
+    toolsets.WrapperToolset = WrapperToolset
+    root = types.ModuleType("pydantic_ai")
+    root.toolsets = toolsets
+
+    monkeypatch.setitem(sys.modules, "pydantic_ai", root)
+    monkeypatch.setitem(sys.modules, "pydantic_ai.toolsets", toolsets)
+    return WrapperToolset
+
+
+class _FakeLeafToolset:
+    def __init__(self, name):
+        self.name = name
+        self.calls = []
+
+    async def call_tool(self, name, tool_args, ctx, tool):
+        self.calls.append((name, tool_args))
+        return f"ran:{name}"
+
+
+class _FakePydAgent:
+    def __init__(self):
+        self._function_toolset = _FakeLeafToolset("fn")
+        self._user_toolsets = [_FakeLeafToolset("u1")]
+        self._dynamic_toolsets = [_FakeLeafToolset("d1")]
+
+
+class _FakeRunCtx:
+    def __init__(self, run_id="r1"):
+        self.run_id = run_id
+        self.tool_call_id = "tc1"
+
+
+class TestPydanticAIUngate:
+    def test_ungate_restores_original_toolsets_and_flag(self, monkeypatch):
+        _install_fake_pydantic_ai(monkeypatch)
+        agent = _FakePydAgent()
+        orig_fn = agent._function_toolset
+        orig_user = agent._user_toolsets
+        orig_dyn = agent._dynamic_toolsets
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_pydantic_ai(agent)
+        assert agent._function_toolset is not orig_fn  # wrapped
+        assert agent._traceforge_gated is True
+
+        pipeline.ungate_pydantic_ai(agent)
+
+        # (a) exact original leaf toolsets restored
+        assert agent._function_toolset is orig_fn
+        assert agent._user_toolsets is orig_user
+        assert agent._dynamic_toolsets is orig_dyn
+        # stash attrs removed
+        assert not hasattr(agent, "_traceforge_original_function_toolset")
+        assert not hasattr(agent, "_traceforge_original_user_toolsets")
+        assert not hasattr(agent, "_traceforge_original_dynamic_toolsets")
+        # (b) guard cleared
+        assert agent._traceforge_gated is False
+
+    async def test_gate_ungate_gate_reblocks(self, monkeypatch):
+        _install_fake_pydantic_ai(monkeypatch)
+        agent = _FakePydAgent()
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        pipeline.gate_pydantic_ai(agent)
+        pipeline.ungate_pydantic_ai(agent)
+        pipeline.gate_pydantic_ai(agent)  # (c) re-gate
+
+        assert agent._traceforge_gated is True
+        # Re-gated toolset still blocks on deny.
+        with pytest.raises(RuntimeError, match="Denied"):
+            await agent._function_toolset.call_tool("rm", {}, _FakeRunCtx(), None)
+
+    async def test_ungated_toolset_runs_freely(self, monkeypatch):
+        _install_fake_pydantic_ai(monkeypatch)
+        agent = _FakePydAgent()
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        pipeline.gate_pydantic_ai(agent)
+        pipeline.ungate_pydantic_ai(agent)
+
+        # Restored leaf toolset executes with no gate.
+        assert await agent._function_toolset.call_tool("rm", {}, _FakeRunCtx(), None) == "ran:rm"
+
+    def test_ungate_when_not_gated_is_noop(self, monkeypatch):
+        _install_fake_pydantic_ai(monkeypatch)
+        agent = _FakePydAgent()
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        # (d) never gated -> no-op, no raise
+        pipeline.ungate_pydantic_ai(agent)
+
+        pipeline.gate_pydantic_ai(agent)
+        pipeline.ungate_pydantic_ai(agent)
+        pipeline.ungate_pydantic_ai(agent)  # twice -> safe
+        assert agent._traceforge_gated is False
+
+
+# ─── OpenAI Agents (per-tool on_invoke_tool) ──────────────────────────────────
+
+
+class _FakeFunctionTool:
+    def __init__(self, name="rm", output="tool-output"):
+        self.name = name
+        self._output = output
+        self.invoked_with = []
+
+        async def _invoke(ctx, input_str):
+            self.invoked_with.append((ctx, input_str))
+            return self._output
+
+        self.on_invoke_tool = _invoke
+
+
+class _FakeAgent:
+    def __init__(self, name="agent", tools=None):
+        self.name = name
+        self.tools = list(tools) if tools else []
+
+
+class TestOpenAIAgentsUngate:
+    def test_ungate_restores_invokers_and_flags(self):
+        tool = _FakeFunctionTool(name="rm")
+        original = tool.on_invoke_tool
+        agent = _FakeAgent(tools=[tool])
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_openai_agents(agent)
+        assert tool.on_invoke_tool is not original  # wrapped
+        assert tool._traceforge_gated is True
+        assert agent._traceforge_gated is True
+
+        pipeline.ungate_openai_agents(agent)
+
+        # (a) original invoker restored; stash removed
+        assert tool.on_invoke_tool is original
+        assert not hasattr(tool, "_traceforge_original_on_invoke_tool")
+        # (b) per-tool + agent guards cleared
+        assert tool._traceforge_gated is False
+        assert agent._traceforge_gated is False
+
+    async def test_gate_ungate_gate_reblocks(self):
+        tool = _FakeFunctionTool(name="rm")
+        agent = _FakeAgent(tools=[tool])
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        pipeline.gate_openai_agents(agent)
+        pipeline.ungate_openai_agents(agent)
+        pipeline.gate_openai_agents(agent)  # (c) re-gate
+
+        assert agent._traceforge_gated is True
+        with pytest.raises(RuntimeError, match="Denied"):
+            await tool.on_invoke_tool(None, "{}")
+        assert tool.invoked_with == []  # body never ran
+
+    async def test_ungated_tool_runs_freely(self):
+        tool = _FakeFunctionTool(name="rm", output="ok")
+        agent = _FakeAgent(tools=[tool])
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        pipeline.gate_openai_agents(agent)
+        pipeline.ungate_openai_agents(agent)
+
+        out = await tool.on_invoke_tool(None, "{}")
+        assert out == "ok"
+        assert tool.invoked_with  # original body ran, ungated
+
+    def test_ungate_when_not_gated_is_noop(self):
+        tool = _FakeFunctionTool()
+        agent = _FakeAgent(tools=[tool])
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        # (d) never gated -> no-op, no raise
+        result = pipeline.ungate_openai_agents(agent)
+        assert result is agent
+
+        pipeline.gate_openai_agents(agent)
+        pipeline.ungate_openai_agents(agent)
+        pipeline.ungate_openai_agents(agent)  # twice -> safe
+        assert agent._traceforge_gated is False
+
+
+# ─── MAF (detached middleware factory -> documented no-op) ────────────────────
+
+
+def _install_fake_agent_framework(monkeypatch):
+    mod = types.ModuleType("agent_framework")
+
+    class FunctionMiddleware:
+        pass
+
+    class MiddlewareTermination(Exception):
+        pass
+
+    mod.FunctionMiddleware = FunctionMiddleware
+    mod.MiddlewareTermination = MiddlewareTermination
+    monkeypatch.setitem(sys.modules, "agent_framework", mod)
+    return mod
+
+
+class _FakeMafFunction:
+    def __init__(self, name="rm"):
+        self.name = name
+
+
+class _FakeMafContext:
+    def __init__(self, name="rm"):
+        self.function = _FakeMafFunction(name)
+        self.arguments = {}
+        self.session = None
+        self.call_id = "c1"
+        self.result = None
+
+
+class TestMafUngate:
+    def test_ungate_is_safe_noop(self, monkeypatch):
+        _install_fake_agent_framework(monkeypatch)
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        # gate returns a standalone middleware; nothing is installed to reverse.
+        pipeline.gate_maf()
+        # (d) no-op, returns None, never raises (even repeated / never-gated).
+        assert pipeline.ungate_maf() is None
+        assert pipeline.ungate_maf() is None
+
+    async def test_gate_ungate_gate_still_produces_working_gate(self, monkeypatch):
+        _install_fake_agent_framework(monkeypatch)
+        term = sys.modules["agent_framework"].MiddlewareTermination
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        pipeline.gate_maf()
+        pipeline.ungate_maf()
+        mw = pipeline.gate_maf()  # (c) re-gate -> fresh, working middleware
+
+        async def _call_next(ctx):  # should never run on deny
+            ctx.result = "EXECUTED"
+
+        with pytest.raises(term, match="Denied"):
+            await mw.process(_FakeMafContext(), _call_next)
+
+
+# ─── smolagents (gated subclass factory -> documented no-op) ──────────────────
+
+
+class _FakeSmolBase:
+    def __init__(self):
+        self.session_id = "s1"
+
+    def execute_tool_call(self, tool_name, arguments):
+        return f"ran:{tool_name}"
+
+
+class TestSmolagentsUngate:
+    def test_ungate_is_safe_noop(self):
+        pipeline = _make_pipeline(preflight=_allow_all)
+
+        pipeline.gate_smolagents(_FakeSmolBase)
+        # (d) no-op, returns None, never raises (even repeated / never-gated).
+        assert pipeline.ungate_smolagents() is None
+        assert pipeline.ungate_smolagents() is None
+
+    def test_gate_ungate_gate_still_produces_working_gate(self):
+        pipeline = _make_pipeline(preflight=_deny_all)
+
+        pipeline.gate_smolagents(_FakeSmolBase)
+        pipeline.ungate_smolagents()
+        gated_cls = pipeline.gate_smolagents(_FakeSmolBase)  # (c) re-gate
+
+        agent = gated_cls()
+        # Re-gated subclass still blocks on deny (returns denial observation).
+        out = agent.execute_tool_call("rm", {"path": "/x"})
+        assert out.startswith("[BLOCKED]")


### PR DESCRIPTION
## Summary

Audit item **S2-6 (Med)**: the 8 in-process gating adapters in `governance/pipeline.py` (`gate_crewai`, `gate_langchain`, `gate_langgraph`, `gate_semantic_kernel`, `gate_maf`, `gate_smolagents`, `gate_pydantic_ai`, `gate_openai_agents`) were all **one-way** — they monkeypatch, register process-global hooks, or install kernel filters with no way to undo. There was no `ungate_*` for any of them, so governance could not be cleanly detached from a framework object once attached.

This PR makes every in-process adapter **symmetric**: each `gate_*` now stashes the original callable/handle on the object at install time, and a new `ungate_*` restores it. Existing gate behavior (preflight / postflight / fail-closed) is preserved byte-for-byte apart from the added stashing.

## Per-adapter teardown

**Full symmetric restore** (stash original at gate → restore at ungate → clear guard):
- **langchain** — stashes `_traceforge_original_run` / `_traceforge_original_arun` (+ prior `handle_tool_error`); `ungate_langchain` restores **both** callables, restores/removes `handle_tool_error`, clears `_traceforge_gated`.
- **openai_agents** — stashes per-tool `_traceforge_original_on_invoke_tool`; `ungate_openai_agents` restores each `FunctionTool`'s invoker, clears per-tool + agent guards.
- **semantic_kernel** — stashes the registered filter; `ungate_semantic_kernel` calls `kernel.remove_filter(filter_type="auto_function_invocation", filter_id=id(filter))`, clears the guard.
- **pydantic_ai** — stashes the original function/user/dynamic toolsets; `ungate_pydantic_ai` unwraps them, clears the guard.
- **crewai** (process-global) — stashes the exact hooks in module-global `_CREWAI_INSTALLED_HOOKS`; `ungate_crewai` deregisters them via `unregister_before/after_tool_call_hook` and resets `_CREWAI_HOOKS_INSTALLED = False` so a later re-gate re-installs.

**Produced-object teardown:**
- **langgraph** — `gate_langgraph` returns a fresh gated `ToolNode`; it is now marked, and `ungate_langgraph(node)` clears the node's `_wrap_tool_call` / `_awrap_tool_call` so it executes ungated.

**Detached factories → documented idempotent no-op (see limitation below):**
- **maf** — `gate_maf` returns a standalone `FunctionMiddleware`; traceforge holds no handle to where the caller attaches it.
- **smolagents** — `gate_smolagents` returns a gated agent *subclass*; there is no per-object install to reverse.

## Facade

`sdk/pipeline.py` gains thin lazy `ungate_*` delegators mirroring the existing `gate_*` style. **`push()` is untouched** (frozen seam). No existing `gate_*` return types/signatures changed (skipped the optional `.remove()` handle — it wasn't clean).

## Known limitation (reported to coordinator)

`ungate_maf` and `ungate_smolagents` are **best-effort no-ops**: those adapters install nothing on a shared/caller object and set no guard flag — they return a detached middleware / subclass. There is genuinely no process/global state to reverse. To remove gating, drop the returned middleware from the agent's middleware list, or instantiate the original agent class. Each has an in-code note. Gate→ungate→gate still produces a working gate for both.

## Guarantees
- **Idempotent + safe:** every `ungate_*` is a harmless no-op when not gated (or called twice), and never raises.
- **Re-gate works:** install → uninstall → install again yields a working gate (explicitly tested per adapter — the key correctness property).

## Tests
New `tests/unit/test_adapter_ungate_teardown.py` (28 tests, deterministic, no network, faked framework surfaces matching `test_adapter_gating_hardening.py`). Per adapter: (a) original restored / hook/filter removed, (b) guard cleared, (c) gate→ungate→gate re-gates, (d) ungate-when-not-gated is a no-op. Explicitly covers `ungate_crewai` removing the process-global hooks + resetting `_CREWAI_HOOKS_INSTALLED`, and langchain restoring **both** `_run` and `_arun`.

## Verification
- `ruff check .` ✅ and `ruff format --check .` ✅ (ruff 0.15.20)
- Full unit suite: **2088 passed, 0 failed, 0 skipped** (135.84s)
- Confirmed untouched: `Pipeline.push()`, `governance/shield.py`, `gate/*`, `cli/*`

## Files
- `src/traceforge/governance/pipeline.py` — stashing in each `gate_*` + 8 `ungate_*` methods
- `src/traceforge/sdk/pipeline.py` — 8 `ungate_*` facade delegators
- `tests/unit/test_adapter_ungate_teardown.py` — new

🔒 **Hold for coordinator review — do NOT merge.**