### PR TITLE
feat(sources): in-memory QueueSource for programmatic push (U1a)

### DIFF
--- a/src/traceforge/sources/__init__.py
+++ b/src/traceforge/sources/__init__.py
@@ -2,6 +2,7 @@ from traceforge.sources.base import RawRecord, Source
 from traceforge.sources.file_poll import FilePollSource
 from traceforge.sources.file_watch import FileWatchSource
 from traceforge.sources.http_poll import HttpPollSource
+from traceforge.sources.queue import QueueSource
 from traceforge.sources.replay import ReplaySource
 from traceforge.sources.sqlite import SqliteSource
 from traceforge.sources.sse import SSESource
@@ -10,6 +11,7 @@ __all__ = [
     "FilePollSource",
     "FileWatchSource",
     "HttpPollSource",
+    "QueueSource",
     "RawRecord",
     "ReplaySource",
     "SqliteSource",

--- a/src/traceforge/sources/queue.py
+++ b/src/traceforge/sources/queue.py
@@ -1,0 +1,132 @@
+"""In-memory queue source for pushing records into the pipeline programmatically.
+
+``QueueSource`` is a general-purpose primitive: it wraps an :class:`asyncio.Queue`
+so a caller can *push* raw payloads into the ingestion pipeline by hand, rather
+than reading them from a file, socket, or database. Each pushed payload is wrapped
+into a :class:`~traceforge.sources.base.RawRecord` with a monotonic sequence — the
+same shape every other source yields — so it plugs into the existing driver
+without any special-casing.
+
+Ordering and shutdown are FIFO and deterministic: records drain in push order, and
+``close()`` enqueues an end-of-stream sentinel so a consumer iterating the source
+sees every already-pushed record and then a clean ``StopAsyncIteration``. The queue
+is single-loop by design (like the rest of the pipeline); push/put/close must be
+called from the same event loop that drives iteration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from types import TracebackType
+from typing import Final
+
+from traceforge.sources.base import RawRecord, Source
+from traceforge.types import IngestionMode
+
+# Unique end-of-stream marker enqueued by ``close()``. Its identity (not value)
+# is what the drain loop checks, so it can never collide with a real payload.
+_CLOSE: Final = object()
+
+
+class QueueSource(Source):
+    """A :class:`~traceforge.sources.base.Source` fed by programmatic pushes.
+
+    Callers enqueue raw payload strings with :meth:`push` (non-blocking) or
+    :meth:`put` (awaitable); iterating the source drains them in FIFO order as
+    :class:`~traceforge.sources.base.RawRecord` instances until :meth:`close` (or
+    ``__aexit__``) signals end-of-stream.
+    """
+
+    def __init__(self, name: str, *, mode: IngestionMode = "stream") -> None:
+        self.name = name
+        self.mode: IngestionMode = mode
+        self._queue: asyncio.Queue[object] = asyncio.Queue()
+        self._sequence = 0
+        self._closed = False
+        self._iterating = False
+
+    @property
+    def closed(self) -> bool:
+        """True once :meth:`close` has been called."""
+        return self._closed
+
+    def qsize(self) -> int:
+        """Number of items currently buffered (includes a pending close sentinel)."""
+        return self._queue.qsize()
+
+    def push(self, payload: str) -> None:
+        """Enqueue a raw payload without blocking.
+
+        The queue is unbounded, so this never waits. Raises :class:`RuntimeError`
+        if the source has been closed.
+        """
+        if self._closed:
+            raise RuntimeError("cannot push to a closed QueueSource")
+        self._queue.put_nowait(payload)
+
+    async def put(self, payload: str) -> None:
+        """Enqueue a raw payload, awaiting if a bounded queue were full.
+
+        The awaitable counterpart to :meth:`push`, mirroring
+        :meth:`asyncio.Queue.put`. Raises :class:`RuntimeError` if the source has
+        been closed.
+        """
+        if self._closed:
+            raise RuntimeError("cannot put to a closed QueueSource")
+        await self._queue.put(payload)
+
+    def close(self) -> None:
+        """Signal end-of-stream. Idempotent.
+
+        Enqueues a sentinel behind any already-pushed payloads so a consumer
+        drains everything pushed before the close and then stops cleanly.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._queue.put_nowait(_CLOSE)
+
+    async def __aenter__(self) -> "QueueSource":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        # Guarantee a blocked consumer wakes and terminates when the context exits.
+        self.close()
+        self._iterating = False
+
+    async def _iter_records(self) -> AsyncIterator[RawRecord]:
+        if self._iterating:
+            raise RuntimeError("QueueSource does not support concurrent iteration")
+        self._iterating = True
+        try:
+            while True:
+                item = await self._queue.get()
+                try:
+                    if item is _CLOSE:
+                        return
+                    yield self._make_record(item)
+                finally:
+                    self._queue.task_done()
+        finally:
+            self._iterating = False
+
+    def __aiter__(self) -> AsyncIterator[RawRecord]:
+        return self._iter_records()
+
+    def _make_record(self, payload: str) -> RawRecord:
+        record = RawRecord(
+            payload=payload,
+            source_name=self.name,
+            mode=self.mode,
+            sequence=self._sequence,
+            received_at=datetime.now(timezone.utc),
+        )
+        self._sequence += 1
+        return record

--- a/tests/unit/test_queue_source.py
+++ b/tests/unit/test_queue_source.py
@@ -1,0 +1,179 @@
+"""Unit tests for :class:`traceforge.sources.queue.QueueSource`.
+
+``QueueSource`` is an in-memory primitive: a caller pushes raw payloads and the
+source drains them into the pipeline as ``RawRecord`` instances. These tests are
+fully deterministic — they use no network, no wallclock ``sleep`` for correctness,
+and drive the queue with explicit push/close ordering. Where a test must prove a
+consumer *blocks* on an empty queue (rather than busy-spinning or ending early),
+it yields control with ``asyncio.sleep(0)`` and asserts on observable state, never
+on elapsed time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+
+from traceforge.sources import QueueSource
+from traceforge.sources.base import RawRecord
+
+
+async def _drain(source: QueueSource) -> list[RawRecord]:
+    return [record async for record in source]
+
+
+async def _yield_until(predicate, *, spins: int = 100) -> None:
+    """Yield control to the loop until ``predicate()`` holds (deterministic, no sleep)."""
+    for _ in range(spins):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("predicate never became true while yielding to the event loop")
+
+
+async def test_push_then_drain_yields_records_in_order() -> None:
+    source = QueueSource(name="q")
+    for payload in ("alpha", "beta", "gamma"):
+        source.push(payload)
+    source.close()
+
+    records = await _drain(source)
+
+    assert [r.payload for r in records] == ["alpha", "beta", "gamma"]
+    assert [r.sequence for r in records] == [0, 1, 2]  # monotonic record sequence
+    assert all(r.source_name == "q" for r in records)
+    assert all(r.mode == "stream" for r in records)  # default ingestion mode
+
+
+async def test_close_terminates_iteration_cleanly() -> None:
+    source = QueueSource(name="q")
+    source.push("one")
+    source.push("two")
+    source.close()
+
+    stream = source.__aiter__()
+    first = await stream.__anext__()
+    second = await stream.__anext__()
+    assert (first.payload, second.payload) == ("one", "two")
+
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+    assert source.closed is True
+
+
+async def test_empty_queue_then_close_yields_nothing() -> None:
+    source = QueueSource(name="q")
+    source.close()  # closed with nothing ever pushed
+
+    assert await _drain(source) == []
+
+
+async def test_empty_queue_blocks_until_push_then_close() -> None:
+    source = QueueSource(name="q")
+    stream = source.__aiter__()
+
+    pull = asyncio.ensure_future(stream.__anext__())
+    # Let the consumer reach its blocking ``await queue.get()`` on the empty queue.
+    await _yield_until(lambda: source._iterating)
+    assert not pull.done()  # nothing to yield yet: the consumer is parked, not spinning
+
+    source.push("late")
+    record = await asyncio.wait_for(pull, timeout=1.0)
+    assert record.payload == "late"
+
+    source.close()
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+
+
+async def test_aexit_signals_shutdown_for_in_flight_consumer() -> None:
+    source = QueueSource(name="q")
+    async with source:
+        source.push("inside")
+        stream = source.__aiter__()
+        record = await stream.__anext__()
+        assert record.payload == "inside"
+    # __aexit__ closed the source; the still-open iterator now ends cleanly.
+    assert source.closed is True
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()
+
+
+async def test_put_async_enqueue_is_drained() -> None:
+    source = QueueSource(name="q")
+    await source.put("a")
+    await source.put("b")
+    source.close()
+
+    records = await _drain(source)
+    assert [r.payload for r in records] == ["a", "b"]
+    assert [r.sequence for r in records] == [0, 1]
+
+
+async def test_push_and_put_after_close_raise() -> None:
+    source = QueueSource(name="q")
+    source.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        source.push("nope")
+    with pytest.raises(RuntimeError, match="closed"):
+        await source.put("nope")
+
+
+async def test_close_is_idempotent() -> None:
+    source = QueueSource(name="q")
+    source.push("only")
+    source.close()
+    source.close()  # second close must not enqueue a second sentinel
+
+    records = await _drain(source)
+    assert [r.payload for r in records] == ["only"]
+
+
+async def test_concurrent_iteration_is_rejected() -> None:
+    source = QueueSource(name="q")
+    first = source.__aiter__()
+    pull = asyncio.ensure_future(first.__anext__())
+    await _yield_until(lambda: source._iterating)  # first iterator is now active
+
+    second = source.__aiter__()
+    with pytest.raises(RuntimeError, match="concurrent iteration"):
+        await second.__anext__()
+
+    pull.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await pull
+
+
+async def test_mode_is_configurable() -> None:
+    source = QueueSource(name="q", mode="replay")
+    source.push("x")
+    source.close()
+
+    records = await _drain(source)
+    assert [r.mode for r in records] == ["replay"]
+
+
+async def test_interleaved_push_and_drain_preserves_order() -> None:
+    source = QueueSource(name="q")
+    stream: AsyncIterator[RawRecord] = source.__aiter__()
+
+    source.push("first")
+    r0 = await stream.__anext__()
+    assert r0.payload == "first"
+    assert source.qsize() == 0  # consumed everything buffered so far
+
+    source.push("second")
+    source.push("third")
+    assert source.qsize() == 2
+    r1 = await stream.__anext__()
+    r2 = await stream.__anext__()
+    assert [r1.payload, r2.payload] == ["second", "third"]
+    assert [r0.sequence, r1.sequence, r2.sequence] == [0, 1, 2]
+
+    source.close()
+    with pytest.raises(StopAsyncIteration):
+        await stream.__anext__()


### PR DESCRIPTION
## Summary

Slice **U1a** of the *CodePlane upstream* epic: a general-purpose in-memory `QueueSource` that lets a caller push events into the ingestion pipeline programmatically. Nothing CodePlane-specific.

`QueueSource` wraps an `asyncio.Queue`. A caller enqueues raw payloads and iterating the source drains them as `RawRecord`s — the exact shape every other source yields — so it plugs into the existing driver with no special-casing.

## API

- `push(payload)` — non-blocking enqueue (`put_nowait`); the queue is unbounded so it never waits.
- `async put(payload)` — awaitable counterpart, mirroring `asyncio.Queue.put`.
- `close()` — idempotent; enqueues an end-of-stream **sentinel** behind any already-pushed payloads, so a consumer drains everything pushed before the close and then stops cleanly (FIFO). `__aexit__` also calls it, so a blocked consumer wakes and terminates on context exit.
- `closed` / `qsize()` helpers.
- Records carry a monotonic `sequence`, `source_name=name`, and a configurable `mode` (default `"stream"`), built by a `_make_record` helper that mirrors `replay.py` / `sse.py` / `file_watch.py`.

Single-loop by design (like the rest of the pipeline): push/put/close are called from the same event loop that drives iteration.

## Files changed

- `src/traceforge/sources/queue.py` *(new)* — the source.
- `src/traceforge/sources/__init__.py` — export `QueueSource` (import + `__all__`), following the existing pattern.
- `tests/unit/test_queue_source.py` *(new)* — 11 deterministic tests.

## Tests

`tests/unit/test_queue_source.py` (11 tests): push→drain order + monotonic sequence, clean close/`StopAsyncIteration`, `__aexit__` shutdown of an in-flight consumer, empty-queue-then-close yields nothing, empty-queue **blocks** until push (asserts parked state via `sleep(0)` — no wallclock sleeps), `put()` path, push/put-after-close raise, idempotent close, concurrent-iteration guard, configurable mode, interleaved push/drain.

Verification (Windows, Python 3.12.10):
- `ruff check .` → clean; `ruff format --check .` → clean (ruff 0.15.20).
- Full `tests/unit` suite: **2121 passed, 3 skipped** (the 3 are pre-existing platform skips).

## Scope

Touched only the three files above. No changes to other sources, the enricher, `sdk/pipeline.py` (the `push()` seam is untouched), governance, or any mapping.

## ⚠️ HOLD — do not merge

Opening for coordinator review. Please review and merge; I am not merging this myself.