### PR TITLE
fix(enricher): bound the tool-pairing buffer with TTL + max-size (U9b)

### DIFF
--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -19,6 +19,14 @@ from traceforge.types import EventKind, EventMetadata, SessionEvent
 
 logger = logging.getLogger(__name__)
 
+#: Default cap on the number of simultaneously buffered unpaired tool-starts the
+#: Enricher retains while awaiting their matching completion. When exceeded, the
+#: oldest buffered start is evicted as an orphan (never dropped) so a stream with
+#: many never-completed starts cannot grow the pairing buffer without bound.
+#: Generous enough that realistic workloads never evict a live start; pass
+#: ``max_pending=None`` to disable the size cap.
+_DEFAULT_MAX_PENDING = 4096
+
 
 class Enricher:
     """Stateful per-session enricher that pairs tool events and classifies them."""
@@ -28,6 +36,9 @@ class Enricher:
         custom_classifications: dict[str, Classification] | None = None,
         config: ClassifyConfig | None = None,
         config_path: Path | str | None = None,
+        pairing_ttl_s: float | None = None,
+        max_pending: int | None = _DEFAULT_MAX_PENDING,
+        flush_on_session_end: bool = True,
     ) -> None:
         """
         Args:
@@ -36,9 +47,37 @@ class Enricher:
             config: Optional pre-built ClassifyConfig (takes priority over config_path).
             config_path: Optional path to a YAML config file. If neither config nor
                 config_path is provided, the default discovery chain is used.
+            pairing_ttl_s: Bounded-buffer policy — evict a buffered tool-start as an
+                orphan once it is older than this many seconds in *stream time*
+                (age measured against the timestamp of the event being processed,
+                not wallclock, so eviction stays deterministic). ``None`` (default)
+                disables TTL eviction. Must be > 0 when set.
+            max_pending: Bounded-buffer policy — cap on the number of simultaneously
+                buffered unpaired tool-starts. When exceeded, the oldest start is
+                evicted as an orphan until the buffer is back within the cap.
+                ``None`` disables the size cap. Must be >= 1 when set. Defaults to
+                ``_DEFAULT_MAX_PENDING`` so a stream of never-completed starts cannot
+                grow the buffer without bound.
+            flush_on_session_end: When True (default — the historical behavior), a
+                SESSION_ENDED event drains that session's still-buffered starts as
+                orphans before the session-ended event is emitted. When False the
+                starts stay buffered (still subject to the bounds above and the final
+                :meth:`flush`) and are never dropped.
+
+        Raises:
+            ValueError: if ``pairing_ttl_s`` is set and not > 0, or if
+                ``max_pending`` is set and not >= 1.
         """
+        if pairing_ttl_s is not None and pairing_ttl_s <= 0:
+            raise ValueError(f"pairing_ttl_s must be > 0 when set, got {pairing_ttl_s!r}")
+        if max_pending is not None and max_pending < 1:
+            raise ValueError(f"max_pending must be >= 1 when set, got {max_pending!r}")
+
         self._custom_classifications = custom_classifications
         self._pending: dict[tuple[str, str], SessionEvent] = {}
+        self._pairing_ttl_s = pairing_ttl_s
+        self._max_pending = max_pending
+        self._flush_on_session_end = flush_on_session_end
 
         # Build engine eagerly so config errors surface at construction time
         if config is not None:
@@ -51,7 +90,9 @@ class Enricher:
     def process(self, event: SessionEvent) -> SessionEvent | list[SessionEvent] | None:
         """Enrich a single event. Returns None if event is buffered (tool_start waiting
         for its tool_complete pair). Returns enriched event when ready. May return a list
-        if a displaced orphan start needs to be emitted alongside buffering a new start."""
+        when unpaired starts are flushed as orphans alongside the primary result — either a
+        displaced duplicate start, or starts evicted by the bounded-buffer policy
+        (``pairing_ttl_s`` / ``max_pending``)."""
         if event.metadata is None:
             # Defensive: SessionEvent defaults metadata to EventMetadata(), but a
             # model_construct-built event may carry None. Normalize up front so the
@@ -59,6 +100,13 @@ class Enricher:
             # push the raw event straight to sinks and bypass the exactly-once
             # tool-call pairing guarantee the downstream governance stage relies on.
             event = event.model_copy(update={"metadata": EventMetadata()})
+
+        # Stream time drives TTL eviction: the timestamp of the event currently
+        # being processed is "now". Using stream time (not wallclock) keeps bounded
+        # eviction deterministic and lets callers control it purely via timestamps.
+        now = event.timestamp
+
+        result: SessionEvent | list[SessionEvent] | None
         if event.kind == EventKind.TOOL_CALL_STARTED:
             event = self._classify(event)
             event = self._set_visibility(event)
@@ -80,12 +128,13 @@ class Enricher:
                         event.session_id,
                         tool_call_id,
                     )
-                    orphan_metadata = displaced.metadata.model_copy(update={"duration_ms": None})
-                    return [displaced.model_copy(update={"metadata": orphan_metadata})]
-                return None
-            return event
+                    result = [_as_orphan(displaced)]
+                else:
+                    result = None
+            else:
+                result = event
 
-        if event.kind == EventKind.TOOL_CALL_COMPLETED:
+        elif event.kind == EventKind.TOOL_CALL_COMPLETED:
             tool_call_id = _extract_tool_call_id(event)
             start_event = (
                 self._pending.get((event.session_id, tool_call_id)) if tool_call_id else None
@@ -113,9 +162,9 @@ class Enricher:
                 event = self._set_visibility(event)
 
             event = self._set_phase(event)
-            return event
+            result = event
 
-        if event.kind == EventKind.SESSION_ENDED:
+        elif event.kind == EventKind.SESSION_ENDED:
             # Flush this session's still-buffered tool starts as orphans BEFORE the
             # session-ended event. A governance stage finalizes and evicts session
             # state on session.ended; without this, buffered unpaired starts would
@@ -129,24 +178,27 @@ class Enricher:
             # flushed+scored here, so the late completion would be observed a second
             # time into a resurrected state. We do not carry per-session tombstones
             # to dedup that case — it does not occur in well-formed input.
-            orphans = self._flush_session(event.session_id)
+            #
+            # ``flush_on_session_end`` (default True) gates this drain; disabling it
+            # leaves the starts pending, subject only to the size/TTL bounds and the
+            # final Enricher.flush — they are still never dropped.
+            orphans = self._flush_session(event.session_id) if self._flush_on_session_end else []
             event = self._set_visibility(event)
             event = self._set_phase(event)
-            return [*orphans, event] if orphans else event
+            result = [*orphans, event] if orphans else event
 
-        # Non-tool events: set visibility and phase, pass through
-        event = self._set_visibility(event)
-        event = self._set_phase(event)
-        return event
+        else:
+            # Non-tool events: set visibility and phase, pass through
+            event = self._set_visibility(event)
+            event = self._set_phase(event)
+            result = event
+
+        return self._enforce_bounds(now, result)
 
     def flush(self) -> list[SessionEvent]:
         """Emit any buffered events (unpaired tool_starts) with duration_ms=None.
         Call at session end."""
-        buffered = list(self._pending.values())
-        result: list[SessionEvent] = []
-        for event in buffered:
-            new_metadata = event.metadata.model_copy(update={"duration_ms": None})
-            result.append(event.model_copy(update={"metadata": new_metadata}))
+        result = [_as_orphan(event) for event in self._pending.values()]
         self._pending.clear()
         return result
 
@@ -159,10 +211,67 @@ class Enricher:
         result: list[SessionEvent] = []
         for key, event in list(self._pending.items()):
             if event.session_id == session_id:
-                new_metadata = event.metadata.model_copy(update={"duration_ms": None})
-                result.append(event.model_copy(update={"metadata": new_metadata}))
+                result.append(_as_orphan(event))
                 del self._pending[key]
         return result
+
+    def _enforce_bounds(
+        self, now: datetime, result: SessionEvent | list[SessionEvent] | None
+    ) -> SessionEvent | list[SessionEvent] | None:
+        """Apply the bounded-buffer policy after an event is handled and splice any
+        evicted starts (as orphans) ahead of ``result``.
+
+        Runs *after* the per-kind handling above, so a completion has already
+        consumed (and removed) its matching start and a just-buffered start is both
+        the newest entry and age-zero — with ``pairing_ttl_s > 0`` / ``max_pending
+        >= 1`` neither bound can evict the very start being processed, so pairing is
+        never broken by same-tick eviction. Both bounds *emit* — never drop — an
+        unpaired start through the same orphan path as session-end flush, preserving
+        the downstream governance pairing guarantee within the configured bounds.
+        When nothing is evicted the original ``result`` is returned unchanged, so an
+        unbounded/under-cap stream behaves exactly as before.
+        """
+        orphans = self._evict_expired(now)
+        orphans.extend(self._evict_over_cap())
+        if not orphans:
+            return result
+        if result is None:
+            return orphans
+        if isinstance(result, list):
+            return [*orphans, *result]
+        return [*orphans, result]
+
+    def _evict_expired(self, now: datetime) -> list[SessionEvent]:
+        """Evict pending starts whose stream-time age exceeds ``pairing_ttl_s``.
+
+        Age is ``now - start.timestamp`` where ``now`` is the timestamp of the
+        event currently being processed. Each evicted start is returned as an
+        orphan (``duration_ms=None``); returns an empty list when TTL is disabled.
+        """
+        if self._pairing_ttl_s is None:
+            return []
+        orphans: list[SessionEvent] = []
+        for key, start_event in list(self._pending.items()):
+            if (now - start_event.timestamp).total_seconds() > self._pairing_ttl_s:
+                orphans.append(_as_orphan(start_event))
+                del self._pending[key]
+        return orphans
+
+    def _evict_over_cap(self) -> list[SessionEvent]:
+        """Evict oldest pending starts (insertion order) beyond ``max_pending``.
+
+        Each evicted start is returned as an orphan; returns an empty list when the
+        size cap is disabled or not exceeded. The buffer preserves insertion order,
+        so ``next(iter(...))`` is the oldest start and the just-buffered start (the
+        newest) survives any eviction as long as the cap is at least 1.
+        """
+        if self._max_pending is None:
+            return []
+        orphans: list[SessionEvent] = []
+        while len(self._pending) > self._max_pending:
+            oldest_key = next(iter(self._pending))
+            orphans.append(_as_orphan(self._pending.pop(oldest_key)))
+        return orphans
 
     # --- Private helpers ---
 
@@ -518,6 +627,18 @@ def _refine_scope_from_payload(cls: Classification, payload: dict) -> Classifica
         binaries=cls.binaries,
         phase_map=new_phase_map,
     )
+
+
+def _as_orphan(event: SessionEvent) -> SessionEvent:
+    """Re-stamp a still-buffered tool-start as an orphan (``duration_ms=None``).
+
+    Every exit that flushes an unpaired start — duplicate displacement,
+    session-end flush, pipeline-close flush, and bounded (TTL / size) eviction —
+    routes through this one shape, so the downstream governance stage sees an
+    identical orphan regardless of why the start was flushed.
+    """
+    orphan_metadata = event.metadata.model_copy(update={"duration_ms": None})
+    return event.model_copy(update={"metadata": orphan_metadata})
 
 
 def _compute_duration_ms(start: datetime, end: datetime) -> float:

--- a/tests/unit/test_enricher_pairing_bounds.py
+++ b/tests/unit/test_enricher_pairing_bounds.py
@@ -1,0 +1,346 @@
+"""Tests for the Enricher's bounded tool-pairing buffer (U9b).
+
+The pairing buffer (``Enricher._pending``) holds TOOL_CALL_STARTED events waiting
+for their matching TOOL_CALL_COMPLETED. Left unbounded it leaks on a stream with
+many unpaired starts. These tests cover the two bounds that fix that —
+``pairing_ttl_s`` (stream-time TTL) and ``max_pending`` (size cap) — plus the
+``flush_on_session_end`` toggle for the pre-existing session-end drain.
+
+The invariant under test throughout: bounding must never *silently drop* a start.
+Every evicted start is re-emitted as an orphan (``duration_ms=None``) through the
+same path session-end flush uses, so the downstream governance stage keeps its
+tool-call pairing guarantee within the configured bounds. Time is controlled
+purely via event timestamps — no wallclock sleeps.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from traceforge import Enricher, EventKind, SessionEvent
+
+UTC = timezone.utc
+T0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+# --- Helpers (mirrors tests/unit/test_enricher.py) ---
+
+
+def _make_tool_start(
+    tool_call_id: str = "tc-1",
+    tool_name: str = "edit",
+    ts: datetime | None = None,
+    session_id: str = "sess-1",
+    **extra_payload,
+) -> SessionEvent:
+    return SessionEvent(
+        kind=EventKind.TOOL_CALL_STARTED,
+        session_id=session_id,
+        timestamp=ts or T0,
+        payload={"tool_call_id": tool_call_id, "tool_name": tool_name, **extra_payload},
+    )
+
+
+def _make_tool_complete(
+    tool_call_id: str = "tc-1",
+    tool_name: str = "edit",
+    ts: datetime | None = None,
+    session_id: str = "sess-1",
+    **extra_payload,
+) -> SessionEvent:
+    return SessionEvent(
+        kind=EventKind.TOOL_CALL_COMPLETED,
+        session_id=session_id,
+        timestamp=ts or (T0 + timedelta(seconds=5)),
+        payload={"tool_call_id": tool_call_id, "tool_name": tool_name, **extra_payload},
+    )
+
+
+def _make_event(
+    kind: EventKind, ts: datetime | None = None, session_id: str = "sess-1"
+) -> SessionEvent:
+    return SessionEvent(
+        kind=kind,
+        session_id=session_id,
+        timestamp=ts or T0,
+        payload={"content": "test"},
+    )
+
+
+def _emit(enricher: Enricher, event: SessionEvent) -> list[SessionEvent]:
+    """Normalize process() output (None | event | list) to a flat list."""
+    out = enricher.process(event)
+    if out is None:
+        return []
+    if isinstance(out, list):
+        return out
+    return [out]
+
+
+# =============================================================================
+# max_pending — size cap
+# =============================================================================
+
+
+class TestMaxPendingBound:
+    def test_over_cap_evicts_oldest_as_orphan(self):
+        enricher = Enricher(max_pending=2)
+
+        assert enricher.process(_make_tool_start(tool_call_id="a", tool_name="bash", ts=T0)) is None
+        assert (
+            enricher.process(
+                _make_tool_start(tool_call_id="b", tool_name="grep", ts=T0 + timedelta(seconds=1))
+            )
+            is None
+        )
+
+        # Third start pushes the buffer over the cap → oldest ("a") evicts as orphan.
+        out = enricher.process(
+            _make_tool_start(tool_call_id="c", tool_name="edit", ts=T0 + timedelta(seconds=2))
+        )
+        assert isinstance(out, list)
+        assert len(out) == 1
+        orphan = out[0]
+        assert orphan.kind == EventKind.TOOL_CALL_STARTED
+        assert orphan.payload["tool_call_id"] == "a"  # oldest, not newest
+        assert orphan.payload["tool_name"] == "bash"
+        assert orphan.metadata.duration_ms is None
+
+    def test_newest_survives_and_cap_is_respected(self):
+        enricher = Enricher(max_pending=2)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        enricher.process(_make_tool_start(tool_call_id="b", ts=T0 + timedelta(seconds=1)))
+        enricher.process(_make_tool_start(tool_call_id="c", ts=T0 + timedelta(seconds=2)))
+
+        # After eviction exactly max_pending starts remain buffered: b and c.
+        remaining = {e.payload["tool_call_id"] for e in enricher.flush()}
+        assert remaining == {"b", "c"}
+
+    def test_survivor_still_pairs_after_eviction(self):
+        enricher = Enricher(max_pending=1)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        # "b" evicts "a"; "b" stays buffered.
+        out = enricher.process(_make_tool_start(tool_call_id="b", ts=T0 + timedelta(seconds=1)))
+        assert [e.payload["tool_call_id"] for e in out] == ["a"]
+
+        paired = enricher.process(
+            _make_tool_complete(tool_call_id="b", ts=T0 + timedelta(seconds=4))
+        )
+        assert paired is not None
+        assert not isinstance(paired, list)
+        assert paired.kind == EventKind.TOOL_CALL_COMPLETED
+        assert paired.metadata.duration_ms == 3000.0  # 4s - 1s
+
+    def test_none_disables_cap(self):
+        enricher = Enricher(max_pending=None, pairing_ttl_s=None)
+        for i in range(50):
+            out = enricher.process(
+                _make_tool_start(tool_call_id=f"tc-{i}", ts=T0 + timedelta(seconds=i))
+            )
+            assert out is None  # buffered, never evicted
+        assert len(enricher.flush()) == 50
+
+    def test_eviction_only_at_the_triggering_event(self):
+        # A start that fits under the cap is never evicted by later, cap-obeying events.
+        enricher = Enricher(max_pending=5)
+        for i in range(3):
+            assert enricher.process(_make_tool_start(tool_call_id=f"tc-{i}", ts=T0)) is None
+        # A non-tool event does not grow the buffer, so it evicts nothing.
+        out = enricher.process(_make_event(EventKind.MESSAGE_USER, ts=T0 + timedelta(seconds=1)))
+        assert not isinstance(out, list)
+
+
+# =============================================================================
+# pairing_ttl_s — stream-time TTL
+# =============================================================================
+
+
+class TestTtlBound:
+    def test_ttl_evicts_start_overtaken_by_later_event(self):
+        enricher = Enricher(pairing_ttl_s=60, max_pending=None)
+        assert enricher.process(_make_tool_start(tool_call_id="a", tool_name="bash", ts=T0)) is None
+
+        # A later event 61s downstream proves "a" is stale → evict as orphan.
+        out = enricher.process(_make_event(EventKind.MESSAGE_USER, ts=T0 + timedelta(seconds=61)))
+        assert isinstance(out, list)
+        assert len(out) == 2
+        orphan, passthrough = out
+        assert orphan.kind == EventKind.TOOL_CALL_STARTED
+        assert orphan.payload["tool_call_id"] == "a"
+        assert orphan.metadata.duration_ms is None
+        assert passthrough.kind == EventKind.MESSAGE_USER  # orphan precedes the primary result
+        # Buffer is now empty — the start was removed, not just copied.
+        assert enricher.flush() == []
+
+    def test_start_within_ttl_is_not_evicted(self):
+        enricher = Enricher(pairing_ttl_s=60, max_pending=None)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        # 30s < 60s TTL: still buffered, nothing emitted.
+        out = enricher.process(_make_event(EventKind.MESSAGE_USER, ts=T0 + timedelta(seconds=30)))
+        assert not isinstance(out, list)
+        assert [e.payload["tool_call_id"] for e in enricher.flush()] == ["a"]
+
+    def test_ttl_is_stream_time_not_wallclock(self):
+        # Age is measured against the processed event's timestamp; a boundary event
+        # exactly at TTL does not evict (strictly-greater comparison).
+        enricher = Enricher(pairing_ttl_s=60, max_pending=None)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        out = enricher.process(_make_event(EventKind.MESSAGE_USER, ts=T0 + timedelta(seconds=60)))
+        assert not isinstance(out, list)  # age == ttl, not > ttl
+        assert len(enricher.flush()) == 1
+
+    def test_completion_still_pairs_when_not_overtaken(self):
+        # A late completion whose start was never overtaken by another event still
+        # pairs: pairing consumes the start before TTL eviction runs. Maximizes the
+        # pairing guarantee, and the quiet buffer was never leaking.
+        enricher = Enricher(pairing_ttl_s=10, max_pending=None)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        paired = enricher.process(
+            _make_tool_complete(tool_call_id="a", ts=T0 + timedelta(seconds=90))
+        )
+        assert paired is not None
+        assert not isinstance(paired, list)
+        assert paired.metadata.duration_ms == 90000.0
+
+    def test_ttl_eviction_is_global_across_sessions(self):
+        # One Enricher serves interleaved sessions; the bound guards total memory,
+        # so a stale start in session A evicts when session B advances the clock.
+        enricher = Enricher(pairing_ttl_s=60, max_pending=None)
+        enricher.process(_make_tool_start(tool_call_id="a", session_id="sess-A", ts=T0))
+        out = enricher.process(
+            _make_tool_start(tool_call_id="b", session_id="sess-B", ts=T0 + timedelta(seconds=61))
+        )
+        # sess-A's start evicts as an orphan; sess-B's start buffers (returns only orphan).
+        assert isinstance(out, list)
+        assert len(out) == 1
+        assert out[0].session_id == "sess-A"
+        assert out[0].metadata.duration_ms is None
+        assert [e.payload["tool_call_id"] for e in enricher.flush()] == ["b"]
+
+    def test_none_disables_ttl(self):
+        enricher = Enricher(pairing_ttl_s=None, max_pending=None)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        # A far-future event never evicts when TTL is disabled.
+        out = enricher.process(_make_event(EventKind.MESSAGE_USER, ts=T0 + timedelta(days=365)))
+        assert not isinstance(out, list)
+        assert len(enricher.flush()) == 1
+
+
+# =============================================================================
+# flush_on_session_end — the pre-existing session-end drain
+# =============================================================================
+
+
+class TestFlushOnSessionEnd:
+    def test_default_true_drains_session_starts_as_orphans(self):
+        enricher = Enricher()  # flush_on_session_end defaults True
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        out = enricher.process(_make_event(EventKind.SESSION_ENDED, ts=T0 + timedelta(seconds=1)))
+        assert isinstance(out, list)
+        assert len(out) == 2
+        orphan, ended = out
+        assert orphan.kind == EventKind.TOOL_CALL_STARTED
+        assert orphan.metadata.duration_ms is None
+        assert ended.kind == EventKind.SESSION_ENDED  # ended event stays last
+        assert enricher.flush() == []  # already drained
+
+    def test_false_leaves_starts_buffered_but_never_dropped(self):
+        enricher = Enricher(flush_on_session_end=False)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        out = enricher.process(_make_event(EventKind.SESSION_ENDED, ts=T0 + timedelta(seconds=1)))
+        # Session end does not drain — only the ended event comes out.
+        assert not isinstance(out, list)
+        assert out.kind == EventKind.SESSION_ENDED
+        # The start is still buffered and recoverable at pipeline-close flush.
+        flushed = enricher.flush()
+        assert [e.payload["tool_call_id"] for e in flushed] == ["a"]
+        assert flushed[0].metadata.duration_ms is None
+
+    def test_false_still_honors_size_bound(self):
+        # Disabling session-end flush must not disable the memory guard.
+        enricher = Enricher(flush_on_session_end=False, max_pending=1)
+        enricher.process(_make_tool_start(tool_call_id="a", ts=T0))
+        out = enricher.process(_make_tool_start(tool_call_id="b", ts=T0 + timedelta(seconds=1)))
+        assert [e.payload["tool_call_id"] for e in out] == ["a"]  # evicted as orphan
+
+
+# =============================================================================
+# Config validation (surfaced at construction, like the engine build)
+# =============================================================================
+
+
+class TestConfigValidation:
+    @pytest.mark.parametrize("bad", [0, -1, -0.5])
+    def test_non_positive_ttl_rejected(self, bad):
+        with pytest.raises(ValueError, match="pairing_ttl_s"):
+            Enricher(pairing_ttl_s=bad)
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_sub_one_max_pending_rejected(self, bad):
+        with pytest.raises(ValueError, match="max_pending"):
+            Enricher(max_pending=bad)
+
+    def test_disabling_values_are_accepted(self):
+        Enricher(pairing_ttl_s=None, max_pending=None)  # no raise
+        Enricher(pairing_ttl_s=0.001, max_pending=1)  # smallest valid
+
+
+# =============================================================================
+# The governance-relied-upon pairing guarantee holds within bounds
+# =============================================================================
+
+
+class TestPairingGuaranteeWithinBounds:
+    def test_normal_pairing_unchanged_under_default_bounds(self):
+        enricher = Enricher()  # default max_pending=4096, ttl disabled
+        assert enricher.process(_make_tool_start(ts=T0)) is None
+        paired = enricher.process(_make_tool_complete(ts=T0 + timedelta(seconds=5)))
+        assert paired is not None
+        assert not isinstance(paired, list)
+        assert paired.metadata.duration_ms == 5000.0
+
+    def test_every_start_accounted_for_exactly_once(self):
+        # Drive a bounded stream and prove each tool call surfaces exactly once —
+        # either paired (real duration) or orphaned (duration None) — never
+        # silently dropped and never double-counted, even as evictions fire.
+        enricher = Enricher(max_pending=2, pairing_ttl_s=None, flush_on_session_end=True)
+        emitted: list[SessionEvent] = []
+
+        emitted += _emit(enricher, _make_tool_start(tool_call_id="a", ts=T0))
+        emitted += _emit(enricher, _make_tool_start(tool_call_id="b", ts=T0 + timedelta(seconds=1)))
+        # "c" evicts oldest "a".
+        emitted += _emit(enricher, _make_tool_start(tool_call_id="c", ts=T0 + timedelta(seconds=2)))
+        # "b" pairs and leaves the buffer.
+        emitted += _emit(
+            enricher, _make_tool_complete(tool_call_id="b", ts=T0 + timedelta(seconds=3))
+        )
+        emitted += _emit(enricher, _make_tool_start(tool_call_id="d", ts=T0 + timedelta(seconds=4)))
+        # "e" evicts oldest surviving start "c".
+        emitted += _emit(enricher, _make_tool_start(tool_call_id="e", ts=T0 + timedelta(seconds=5)))
+        # Session end drains the rest ("d", "e") as orphans.
+        emitted += _emit(
+            enricher, _make_event(EventKind.SESSION_ENDED, ts=T0 + timedelta(seconds=6))
+        )
+
+        by_id: dict[str, list[SessionEvent]] = {}
+        for ev in emitted:
+            tcid = ev.payload.get("tool_call_id")
+            if tcid is not None:
+                by_id.setdefault(tcid, []).append(ev)
+
+        # Each of the five tool calls appears exactly once — nothing lost or duplicated.
+        assert set(by_id) == {"a", "b", "c", "d", "e"}
+        assert all(len(evs) == 1 for evs in by_id.values())
+
+        # "b" is the only one that got its completion → the only paired (non-None) event.
+        assert by_id["b"][0].kind == EventKind.TOOL_CALL_COMPLETED
+        assert by_id["b"][0].metadata.duration_ms == 2000.0
+        for orphan_id in ("a", "c", "d", "e"):
+            ev = by_id[orphan_id][0]
+            assert ev.kind == EventKind.TOOL_CALL_STARTED
+            assert ev.metadata.duration_ms is None
+
+        # Buffer fully drained by session end.
+        assert enricher.flush() == []


### PR DESCRIPTION
## U9b — Bound the enricher's tool-pairing buffer

**⚠️ HOLD — do not merge. Coordinator reviews.**

### Problem
`Enricher._pending: dict[(session_id, tool_call_id) -> SessionEvent]` buffers `TOOL_CALL_STARTED` events awaiting their matching `TOOL_CALL_COMPLETED`. It was **unbounded** — a stream with many never-completed starts grew it without limit (a real memory-leak risk in long-lived pipelines).

### Change (scope: `src/traceforge/enricher.py` + one new unit test file)
Adds a bounded-buffer policy via three new `Enricher.__init__` params (config style mirrors sibling `EventPipeline`: direct ctor params + module-level default constant, `int | None` with `None` disabling — no new dataclass, kept in-file):

| Param | Default | Behavior |
|---|---|---|
| `pairing_ttl_s: float \| None` | `None` (disabled) | Evict a start older than the TTL in **stream time** — age measured against the timestamp of the event being processed, **not wallclock**, so eviction is deterministic. Must be `> 0`. |
| `max_pending: int \| None` | `4096` (`_DEFAULT_MAX_PENDING`) | Cap buffer size; evict the **oldest** buffered start when exceeded. `None` disables. Must be `>= 1`. Mirrors `EventPipeline.max_sessions=4096`. |
| `flush_on_session_end: bool` | `True` | The **pre-existing** session-end drain, now a toggle. Default preserves current behavior. |

### How the pairing guarantee is preserved (the critical invariant)
The enricher notes that the downstream governance stage relies on the tool-call pairing guarantee, so bounding must **never silently drop** a start. This PR guarantees every buffered start has exactly one exit — it is either **paired** (its completion merges it) or **emitted as an orphan** (`duration_ms=None`):

- A new module helper `_as_orphan(event)` defines the single orphan shape. **All** unpaired-start exits now route through it: duplicate displacement, session-end flush (`_flush_session`), pipeline-close flush (`flush`), **and** the two new evictions — so bounded eviction produces byte-identical orphan output to session-end flush ("the same path").
- Eviction (`_enforce_bounds`) runs **after** the per-kind handling, so a completion has already consumed and removed its matching start, and a just-buffered start is both the newest entry and age-zero. With `ttl > 0` / `cap >= 1`, **neither bound can evict the very start being processed** — an in-progress pair is never broken by same-tick eviction.
- When nothing is evicted, `process()` returns its original value unchanged, so unbounded/under-cap streams behave exactly as before (all 123 pre-existing enricher tests pass untouched).

### Tests — `tests/unit/test_enricher_pairing_bounds.py` (new, +22 tests, deterministic, no sleeps)
Mirrors the existing `tests/unit/test_enricher.py` helpers. Covers: TTL eviction → orphan; TTL respects stream-time boundary; late completion still pairs when not overtaken; global (cross-session) TTL eviction; `max_pending` evicts oldest-as-orphan while newest survives and still pairs; `None` disables each bound; session-end flush preserved; `flush_on_session_end=False` leaves starts buffered (never dropped) yet still honors the size bound; config validation; and a **"every start accounted for exactly once"** guarantee test that drives a bounded stream through interleaved pairs + evictions + session-end and asserts each tool call surfaces exactly once (paired or orphan), never lost, never double-counted.

### Verification
- `ruff check .` ✅ and `ruff format --check .` ✅ (ruff `0.15.20`, 423 files).
- Full `tests/unit`: **2132 passed, 3 skipped**.

Conventional Commit with the required `Co-authored-by: Copilot App` trailer.