### PR TITLE
feat(sources): managed live-SDK sources for Copilot and Claude (U1b)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,12 @@ dev = [
 s3 = [
     "boto3>=1.28",
 ]
+copilot = [
+    "github-copilot-sdk>=0.3,<0.4",
+]
+claude = [
+    "claude-agent-sdk>=0.1",
+]
 
 [project.scripts]
 traceforge = "traceforge.cli:main"

--- a/src/traceforge/sources/__init__.py
+++ b/src/traceforge/sources/__init__.py
@@ -3,6 +3,7 @@ from traceforge.sources.file_poll import FilePollSource
 from traceforge.sources.file_watch import FileWatchSource
 from traceforge.sources.http_poll import HttpPollSource
 from traceforge.sources.replay import ReplaySource
+from traceforge.sources.sdk_live import SdkClaudeSource, SdkCopilotSource
 from traceforge.sources.sqlite import SqliteSource
 from traceforge.sources.sse import SSESource
 
@@ -12,6 +13,8 @@ __all__ = [
     "HttpPollSource",
     "RawRecord",
     "ReplaySource",
+    "SdkClaudeSource",
+    "SdkCopilotSource",
     "SqliteSource",
     "SSESource",
     "Source",

--- a/src/traceforge/sources/sdk_live.py
+++ b/src/traceforge/sources/sdk_live.py
@@ -1,0 +1,403 @@
+"""Managed live-SDK sources — stream events from vendor agent SDKs.
+
+Unlike the file/poll/watch sources, these sources own the ingest loop: they pull
+events from a live vendor agent SDK stream and emit ``RawRecord``s that the
+EXISTING mapped-JSON adapter + YAML mappings (``copilot.yaml`` / ``claude.yaml``)
+turn into SessionEvents — identical to the file-watch path for equivalent input.
+
+Vendor SDKs are OPTIONAL dependencies, imported lazily so ``import traceforge``
+never requires them; a missing extra yields a clear install hint rather than an
+import crash. Translation is THIN: native SDK events become the same wire-format
+dicts the file path carries. There are NO new mappings here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterable, AsyncIterator
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from types import TracebackType
+from typing import Any
+
+from traceforge.sources.base import RawRecord, Source
+from traceforge.types import IngestionMode
+
+# ─── Optional-extras: lazy vendor imports ────────────────────────────────────
+
+
+def _require_copilot_sdk():
+    """Import and return the GitHub Copilot SDK, raising a helpful error if missing."""
+    try:
+        import copilot
+
+        return copilot
+    except ImportError:
+        raise ImportError(
+            "github-copilot-sdk is required for SdkCopilotSource. "
+            "Install it with: pip install traceforge-toolkit[copilot]"
+        ) from None
+
+
+def _require_claude_sdk():
+    """Import and return the Claude Agent SDK, raising a helpful error if missing."""
+    try:
+        import claude_agent_sdk
+
+        return claude_agent_sdk
+    except ImportError:
+        raise ImportError(
+            "claude-agent-sdk is required for SdkClaudeSource. "
+            "Install it with: pip install traceforge-toolkit[claude]"
+        ) from None
+
+
+# ─── Serialization helpers ───────────────────────────────────────────────────
+
+
+def _jsonable(value: Any) -> Any:
+    """Best-effort conversion of a native SDK object into JSON-able data.
+
+    Handles pydantic models (``model_dump``), dataclasses, mappings, sequences,
+    datetimes, and objects exposing ``__dict__``. Scalars pass through untouched;
+    anything else degrades to ``str`` so serialization never crashes the loop.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _jsonable(model_dump(mode="json", by_alias=True, exclude_none=True))
+        except TypeError:
+            try:
+                return _jsonable(model_dump())
+            except Exception:
+                pass
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            return _jsonable(asdict(value))
+        except Exception:
+            pass
+    if isinstance(value, datetime):
+        return value.isoformat()
+    obj_dict = getattr(value, "__dict__", None)
+    if isinstance(obj_dict, dict):
+        return {str(k): _jsonable(v) for k, v in obj_dict.items() if not str(k).startswith("_")}
+    return str(value)
+
+
+def _attr(obj: Any, name: str) -> Any:
+    """Read ``name`` from a mapping (``.get``) or an object (``getattr``)."""
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _iso(value: Any) -> Any:
+    """Normalize a timestamp to an ISO-8601 string, leaving strings untouched."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+# ─── Base managed live source ────────────────────────────────────────────────
+
+
+class _SdkLiveSource(Source):
+    """Shared managed ingest loop for live vendor-SDK sources.
+
+    Consumes an async iterable of *native* vendor events, translates each into
+    the framework's wire-format dict via ``_to_wire``, and emits a ``RawRecord``
+    (``mode="stream"``) carrying the serialized wire dict. The SAME downstream
+    ``MappedJsonAdapter`` (loaded from the framework YAML) maps those records
+    into SessionEvents — the thin-translation contract. Translation that yields
+    ``None`` skips the event (e.g. an unmapped native message type).
+    """
+
+    mode: IngestionMode = "stream"
+
+    def __init__(self, name: str, events: AsyncIterable[Any]) -> None:
+        self.name = name
+        self._events = events
+        self._sequence = 0
+        self._iterating = False
+        self._entered = False
+        self._aiter: AsyncIterator[Any] | None = None
+
+    async def __aenter__(self) -> "_SdkLiveSource":
+        self._entered = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self._entered = False
+        aiter = self._aiter
+        self._aiter = None
+        aclose = getattr(aiter, "aclose", None)
+        if callable(aclose):
+            try:
+                await aclose()
+            except Exception:
+                pass
+
+    async def _iter_records(self) -> AsyncIterator[RawRecord]:
+        if not self._entered:
+            raise RuntimeError(f"{type(self).__name__} must be entered before iteration")
+        if self._iterating:
+            raise RuntimeError(f"{type(self).__name__} does not support concurrent iteration")
+        self._iterating = True
+        try:
+            aiter = self._events.__aiter__()
+            self._aiter = aiter
+            while True:
+                try:
+                    native = await aiter.__anext__()
+                except StopAsyncIteration:
+                    break
+                wire = self._to_wire(native)
+                if wire is None:
+                    continue
+                yield RawRecord(
+                    payload=json.dumps(wire, default=str),
+                    source_name=self.name,
+                    mode=self.mode,
+                    sequence=self._sequence,
+                    received_at=datetime.now(timezone.utc),
+                )
+                self._sequence += 1
+        finally:
+            self._iterating = False
+
+    def __aiter__(self) -> AsyncIterator[RawRecord]:
+        return self._iter_records()
+
+    def _to_wire(self, native: Any) -> dict[str, Any] | None:
+        """Translate a native vendor event into a wire-format dict (or None to skip)."""
+        raise NotImplementedError
+
+
+# ─── Copilot ─────────────────────────────────────────────────────────────────
+
+
+def _copilot_data(data: Any) -> dict[str, Any]:
+    """Normalize a Copilot event's ``data`` payload to a plain dict."""
+    if data is None:
+        return {}
+    if isinstance(data, dict):
+        return data
+    result = _jsonable(data)
+    return result if isinstance(result, dict) else {"value": result}
+
+
+class SdkCopilotSource(_SdkLiveSource):
+    """Live source over the GitHub Copilot agent SDK event stream.
+
+    The Copilot SDK surfaces session events whose shape already mirrors the file
+    wire format (``event.type`` + typed ``event.data``), so translation is
+    near-identity: re-serialize ``type`` / ``id`` / ``timestamp`` / ``data`` into
+    the dict the ``copilot.yaml`` mapping consumes.
+
+    Construct directly with an async iterable of native events, or via
+    :meth:`from_session` to bridge a live SDK ``session`` push stream.
+    """
+
+    framework = "copilot"
+
+    def _to_wire(self, event: Any) -> dict[str, Any] | None:
+        event_type = _attr(event, "type")
+        if event_type is None:
+            return None
+        wire: dict[str, Any] = {"type": str(event_type)}
+        event_id = _attr(event, "id")
+        if event_id is not None:
+            wire["id"] = event_id
+        timestamp = _attr(event, "timestamp")
+        if timestamp is not None:
+            wire["timestamp"] = _iso(timestamp)
+        wire["data"] = _copilot_data(_attr(event, "data"))
+        return wire
+
+    @classmethod
+    def from_session(cls, name: str, session: Any) -> "SdkCopilotSource":
+        """Build a source that bridges a live Copilot ``session`` push stream."""
+        return cls(name, copilot_event_stream(session))
+
+
+async def copilot_event_stream(session: Any) -> AsyncIterator[Any]:
+    """Bridge a Copilot ``session``'s push callbacks into an async iterator.
+
+    The Copilot SDK delivers events through ``session.on(callback)`` (a push
+    model). This adapts that into the pull-based async stream the source's
+    managed loop consumes, marshalling callbacks onto the running loop. Requires
+    the ``copilot`` extra; the returned unsubscribe (if any) is called on exit.
+    """
+    _require_copilot_sdk()
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+
+    def _on_event(event: Any) -> None:
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, event)
+        except RuntimeError:
+            pass
+
+    unsubscribe = session.on(_on_event)
+    try:
+        while True:
+            yield await queue.get()
+    finally:
+        if callable(unsubscribe):
+            try:
+                unsubscribe()
+            except Exception:
+                pass
+
+
+# ─── Claude ──────────────────────────────────────────────────────────────────
+
+_CLAUDE_RESULT_FIELDS = (
+    "subtype",
+    "duration_ms",
+    "duration_api_ms",
+    "is_error",
+    "num_turns",
+    "session_id",
+    "total_cost_usd",
+    "result",
+)
+
+
+class SdkClaudeSource(_SdkLiveSource):
+    """Live source over the Claude Agent SDK message stream.
+
+    Unlike Copilot, the Claude SDK yields typed dataclass ``Message`` objects
+    (``AssistantMessage``, ``UserMessage``, ``ResultMessage``, ...) whose content
+    is a list of typed blocks. These are explicitly translated back into the
+    ``{type, message: {content: [...]}}`` / ``{type: "result", ...}`` wire dicts
+    that ``claude.yaml`` (via its ``claude`` preprocessor) consumes. Dispatch is
+    by class name so the real SDK classes are never imported.
+
+    Construct directly with an async iterable of native messages, or via
+    :meth:`from_query` over a ``query(prompt, options)`` message stream.
+    """
+
+    framework = "claude"
+
+    def _to_wire(self, message: Any) -> dict[str, Any] | None:
+        type_name = type(message).__name__
+        msg_type = _attr(message, "type")
+
+        if type_name == "UserMessage" or msg_type == "user":
+            return {
+                "type": "user",
+                "message": {"content": self._content(_attr(message, "content"))},
+            }
+
+        if type_name == "AssistantMessage" or msg_type == "assistant":
+            blocks = [self._block(b) for b in (_attr(message, "content") or [])]
+            wire: dict[str, Any] = {"type": "assistant", "message": {"content": blocks}}
+            model = _attr(message, "model")
+            if model is not None:
+                wire["message"]["model"] = model
+            return wire
+
+        if type_name == "ResultMessage" or msg_type == "result":
+            return self._result(message)
+
+        if type_name == "SystemMessage" or msg_type == "system":
+            system: dict[str, Any] = {"type": "system"}
+            subtype = _attr(message, "subtype")
+            if subtype is not None:
+                system["subtype"] = subtype
+            data = _attr(message, "data")
+            if data is not None:
+                system["data"] = _jsonable(data)
+            return system
+
+        return None
+
+    def _content(self, content: Any) -> Any:
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return [self._block(b) for b in content]
+        if content is None:
+            return ""
+        return str(content)
+
+    def _block(self, block: Any) -> dict[str, Any]:
+        if isinstance(block, dict):
+            return block
+        type_name = type(block).__name__
+        if type_name == "TextBlock":
+            return {"type": "text", "text": _attr(block, "text")}
+        if type_name == "ThinkingBlock":
+            return {
+                "type": "thinking",
+                "thinking": _attr(block, "thinking"),
+                "signature": _attr(block, "signature"),
+            }
+        if type_name == "ToolUseBlock":
+            return {
+                "type": "tool_use",
+                "id": _attr(block, "id"),
+                "name": _attr(block, "name"),
+                "input": _jsonable(_attr(block, "input")),
+            }
+        if type_name == "ToolResultBlock":
+            result: dict[str, Any] = {
+                "type": "tool_result",
+                "tool_use_id": _attr(block, "tool_use_id"),
+                "content": _jsonable(_attr(block, "content")),
+            }
+            is_error = _attr(block, "is_error")
+            if is_error is not None:
+                result["is_error"] = is_error
+            return result
+        # Unknown block: degrade to a jsonable dict, preserving a type hint.
+        data = _jsonable(block)
+        if isinstance(data, dict):
+            data.setdefault("type", _attr(block, "type") or "unknown")
+            return data
+        return {"type": _attr(block, "type") or "unknown", "value": data}
+
+    def _result(self, message: Any) -> dict[str, Any]:
+        wire: dict[str, Any] = {"type": "result"}
+        for field_name in _CLAUDE_RESULT_FIELDS:
+            value = _attr(message, field_name)
+            if value is not None:
+                wire[field_name] = value
+        usage = _attr(message, "usage")
+        if usage is not None:
+            wire["usage"] = usage if isinstance(usage, dict) else _jsonable(usage)
+        return wire
+
+    @classmethod
+    def from_query(cls, name: str, prompt: Any, options: Any = None) -> "SdkClaudeSource":
+        """Build a source over a Claude ``query(prompt, options)`` message stream."""
+        return cls(name, claude_event_stream(prompt, options))
+
+
+async def claude_event_stream(prompt: Any, options: Any = None) -> AsyncIterator[Any]:
+    """Yield native Claude ``Message`` objects from the Agent SDK ``query`` API.
+
+    Requires the ``claude`` extra. ``options`` is forwarded verbatim when given,
+    so callers control the underlying ``ClaudeAgentOptions`` without this layer
+    taking a dependency on the SDK's option types.
+    """
+    sdk = _require_claude_sdk()
+    if options is not None:
+        stream = sdk.query(prompt=prompt, options=options)
+    else:
+        stream = sdk.query(prompt=prompt)
+    async for message in stream:
+        yield message

--- a/tests/unit/test_sdk_live_sources.py
+++ b/tests/unit/test_sdk_live_sources.py
@@ -1,0 +1,503 @@
+"""Golden-equivalence + lifecycle tests for managed live-SDK sources.
+
+The SDK sources must produce the SAME SessionEvents as the existing file path
+does for equivalent input. Vendor SDKs are FAKED here — no network, no real SDK,
+fully deterministic. We drive fake native events that mirror the golden JSONL
+fixtures and assert the resulting SessionEvents match the file-watch path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from traceforge.adapters.mapped_json import MappedJsonAdapter
+from traceforge.sources import SdkClaudeSource, SdkCopilotSource
+from traceforge.sources.sdk_live import (
+    _require_claude_sdk,
+    _require_copilot_sdk,
+    copilot_event_stream,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+MAPPINGS_DIR = Path(__file__).resolve().parents[2] / "src" / "traceforge" / "mappings"
+
+COPILOT_LINES = [
+    line for line in (FIXTURES / "copilot_session.jsonl").read_text().splitlines() if line.strip()
+]
+CLAUDE_LINES = [
+    line for line in (FIXTURES / "claude_session.jsonl").read_text().splitlines() if line.strip()
+]
+COPILOT_FIXTURE = [json.loads(line) for line in COPILOT_LINES]
+CLAUDE_FIXTURE = [json.loads(line) for line in CLAUDE_LINES]
+
+
+# ─── Test helpers ────────────────────────────────────────────────────────────
+
+
+async def _agen(items: list[Any]):
+    for item in items:
+        yield item
+
+
+async def _collect(source) -> list:
+    records = []
+    async with source:
+        async for record in source:
+            records.append(record)
+    return records
+
+
+def _parse_all(yaml_name: str, lines: list[str]) -> list:
+    adapter = MappedJsonAdapter.from_yaml(str(MAPPINGS_DIR / yaml_name), session_id="test-session")
+    events = []
+    for line in lines:
+        events.extend(adapter.parse(line))
+    return events
+
+
+def _norm(events: list) -> list:
+    """Reduce SessionEvents to stable, comparable tuples.
+
+    Excludes the per-event uuid ``id``, the ``now()`` ``timestamp``, ``raw_event``
+    (the SDK legitimately drops wire-envelope-only fields like Claude's cwd), and
+    motivation ``source_event_ids`` (uuid-based) — none of which are meaningful for
+    equivalence. Everything else that defines the event is compared.
+    """
+    out = []
+    for e in events:
+        meta = e.metadata
+        motivation = None
+        if meta is not None and meta.motivation is not None:
+            motivation = (meta.motivation.intent, meta.motivation.reasoning)
+        out.append(
+            (
+                e.kind,
+                e.session_id,
+                json.dumps(e.payload, sort_keys=True, default=str),
+                meta.source_framework if meta else None,
+                meta.ingestion_mode if meta else None,
+                meta.raw_kind if meta else None,
+                motivation,
+            )
+        )
+    return out
+
+
+# ─── Fake Copilot SDK surface ────────────────────────────────────────────────
+
+
+@dataclass
+class FakeCopilotEvent:
+    """Mirrors a github-copilot-sdk session event (``.type`` + typed ``.data``)."""
+
+    type: str
+    id: str | None = None
+    timestamp: str | None = None
+    data: Any = None
+
+
+def _copilot_events_from_fixture() -> list[FakeCopilotEvent]:
+    return [
+        FakeCopilotEvent(
+            type=d["type"],
+            id=d.get("id"),
+            timestamp=d.get("timestamp"),
+            data=d.get("data"),
+        )
+        for d in COPILOT_FIXTURE
+    ]
+
+
+# ─── Fake Claude SDK surface (typed dataclass Messages/blocks) ────────────────
+
+
+@dataclass
+class TextBlock:
+    text: str
+
+
+@dataclass
+class ThinkingBlock:
+    thinking: str
+    signature: str = ""
+
+
+@dataclass
+class ToolUseBlock:
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass
+class ToolResultBlock:
+    tool_use_id: str
+    content: Any
+    is_error: bool = False
+
+
+@dataclass
+class UserMessage:
+    content: Any
+
+
+@dataclass
+class AssistantMessage:
+    content: list
+    model: str | None = None
+
+
+@dataclass
+class ResultMessage:
+    subtype: str
+    duration_ms: int
+    duration_api_ms: int
+    is_error: bool
+    num_turns: int
+    session_id: str
+    total_cost_usd: float
+    usage: dict
+    result: str | None = None
+
+
+def _claude_messages() -> list[Any]:
+    """Native Claude Messages equivalent to claude_session.jsonl (line for line)."""
+    model = "claude-sonnet-4-20250514"
+    return [
+        UserMessage(content="Read the contents of main.py and fix any bugs"),
+        AssistantMessage(
+            content=[
+                TextBlock(text="I'll read main.py first to check for bugs."),
+                ToolUseBlock(id="tu-1", name="read_file", input={"path": "main.py"}),
+            ],
+            model=model,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(
+                    tool_use_id="tu-1",
+                    content="def add(a, b):\n    return a - b\n",
+                    is_error=False,
+                )
+            ],
+            model=model,
+        ),
+        AssistantMessage(
+            content=[
+                TextBlock(
+                    text="I found a bug: the add function subtracts instead of adding. "
+                    "Let me fix it."
+                ),
+                ToolUseBlock(
+                    id="tu-2",
+                    name="write_file",
+                    input={"path": "main.py", "content": "def add(a, b):\n    return a + b\n"},
+                ),
+            ],
+            model=model,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(
+                    tool_use_id="tu-2", content="File written successfully", is_error=False
+                )
+            ],
+            model=model,
+        ),
+        AssistantMessage(
+            content=[
+                TextBlock(
+                    text="I've fixed the bug in main.py. The add function was using "
+                    "subtraction (-) instead of addition (+)."
+                )
+            ],
+            model=model,
+        ),
+        UserMessage(content="Thanks, run the tests now"),
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="tu-3", name="bash", input={"command": "python -m pytest tests/"})
+            ],
+            model=model,
+        ),
+        AssistantMessage(
+            content=[
+                ToolResultBlock(
+                    tool_use_id="tu-3",
+                    content=[{"type": "text", "text": "===== 3 passed in 0.5s ====="}],
+                    is_error=False,
+                )
+            ],
+            model=model,
+        ),
+        AssistantMessage(
+            content=[
+                ThinkingBlock(thinking="The tests all pass now.", signature="sig123"),
+                TextBlock(text="All 3 tests pass. The fix is working correctly."),
+            ],
+            model=model,
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=12500,
+            duration_api_ms=10200,
+            is_error=False,
+            num_turns=4,
+            session_id="claude-sess-456",
+            total_cost_usd=0.0089,
+            usage={
+                "input_tokens": 3500,
+                "output_tokens": 450,
+                "cache_read_input_tokens": 2000,
+                "cache_creation_input_tokens": 100,
+            },
+        ),
+    ]
+
+
+# ─── Copilot: golden equivalence ─────────────────────────────────────────────
+
+
+class TestCopilotGoldenEquivalence:
+    async def test_wire_dicts_match_fixture_exactly(self):
+        source = SdkCopilotSource("copilot-live", _agen(_copilot_events_from_fixture()))
+        records = await _collect(source)
+        assert [json.loads(r.payload) for r in records] == COPILOT_FIXTURE
+
+    async def test_session_events_match_file_path(self):
+        source = SdkCopilotSource("copilot-live", _agen(_copilot_events_from_fixture()))
+        records = await _collect(source)
+
+        file_events = _parse_all("copilot.yaml", COPILOT_LINES)
+        sdk_events = _parse_all("copilot.yaml", [r.payload for r in records])
+
+        assert len(sdk_events) == len(file_events) == 15
+        assert _norm(sdk_events) == _norm(file_events)
+
+    async def test_ingestion_mode_comes_from_mapping_not_stream(self):
+        source = SdkCopilotSource("copilot-live", _agen(_copilot_events_from_fixture()))
+        records = await _collect(source)
+        # The source emits stream-mode RawRecords ...
+        assert all(r.mode == "stream" for r in records)
+        # ... but the mapping stamps ingestion_mode=file_watch, so equivalence holds.
+        sdk_events = _parse_all("copilot.yaml", [r.payload for r in records])
+        assert all(e.metadata.ingestion_mode == "file_watch" for e in sdk_events)
+
+    async def test_pydantic_style_data_is_serialized(self):
+        class _Model:
+            def __init__(self, data: dict) -> None:
+                self._data = data
+
+            def model_dump(self, **_kwargs: Any) -> dict:
+                return dict(self._data)
+
+        event = FakeCopilotEvent(
+            type="user.message",
+            id="e1",
+            timestamp="2024-06-01T10:00:05Z",
+            data=_Model({"content": "hi"}),
+        )
+        source = SdkCopilotSource("copilot-live", _agen([event]))
+        records = await _collect(source)
+        assert json.loads(records[0].payload) == {
+            "type": "user.message",
+            "id": "e1",
+            "timestamp": "2024-06-01T10:00:05Z",
+            "data": {"content": "hi"},
+        }
+
+
+# ─── Claude: golden equivalence ──────────────────────────────────────────────
+
+
+class TestClaudeGoldenEquivalence:
+    async def test_session_events_match_file_path(self):
+        source = SdkClaudeSource("claude-live", _agen(_claude_messages()))
+        records = await _collect(source)
+
+        # One RawRecord per native message; the adapter's preprocessor expands
+        # assistant content blocks into multiple SessionEvents (as the file does).
+        assert len(records) == len(CLAUDE_LINES)
+
+        file_events = _parse_all("claude.yaml", CLAUDE_LINES)
+        sdk_events = _parse_all("claude.yaml", [r.payload for r in records])
+
+        assert len(file_events) > 0
+        assert len(sdk_events) == len(file_events)
+        assert _norm(sdk_events) == _norm(file_events)
+
+    async def test_ingestion_mode_comes_from_mapping_not_stream(self):
+        source = SdkClaudeSource("claude-live", _agen(_claude_messages()))
+        records = await _collect(source)
+        assert all(r.mode == "stream" for r in records)
+        sdk_events = _parse_all("claude.yaml", [r.payload for r in records])
+        assert all(e.metadata.ingestion_mode == "file_watch" for e in sdk_events)
+
+    async def test_tool_result_list_content_flattens(self):
+        # Line 9 of the fixture: tool_result whose content is a list of text blocks.
+        messages = [
+            AssistantMessage(
+                content=[
+                    ToolResultBlock(
+                        tool_use_id="tu-3",
+                        content=[{"type": "text", "text": "===== 3 passed in 0.5s ====="}],
+                        is_error=False,
+                    )
+                ],
+                model="claude-sonnet-4-20250514",
+            )
+        ]
+        source = SdkClaudeSource("claude-live", _agen(messages))
+        records = await _collect(source)
+        sdk_events = _parse_all("claude.yaml", [r.payload for r in records])
+        assert len(sdk_events) == 1
+        assert sdk_events[0].kind == "tool.call.completed"
+        assert sdk_events[0].payload["result"] == "===== 3 passed in 0.5s ====="
+        assert sdk_events[0].payload["success"] is True
+
+
+# ─── Lifecycle ───────────────────────────────────────────────────────────────
+
+
+class TestLifecycle:
+    async def test_sequence_and_mode(self):
+        events = [
+            FakeCopilotEvent(type="user.message", id="e0", data={"content": "a"}),
+            FakeCopilotEvent(type="user.message", id="e1", data={"content": "b"}),
+            FakeCopilotEvent(type="user.message", id="e2", data={"content": "c"}),
+        ]
+        records = await _collect(SdkCopilotSource("copilot-live", _agen(events)))
+        assert [r.sequence for r in records] == [0, 1, 2]
+        assert all(r.mode == "stream" for r in records)
+        assert all(r.source_name == "copilot-live" for r in records)
+
+    async def test_iterate_before_enter_raises(self):
+        source = SdkCopilotSource("copilot-live", _agen([FakeCopilotEvent(type="x")]))
+        iterator = source.__aiter__()
+        with pytest.raises(RuntimeError, match="must be entered"):
+            await iterator.__anext__()
+
+    async def test_concurrent_iteration_raises(self):
+        events = [
+            FakeCopilotEvent(type="user.message", id="e0", data={"content": "a"}),
+            FakeCopilotEvent(type="user.message", id="e1", data={"content": "b"}),
+        ]
+        source = SdkCopilotSource("copilot-live", _agen(events))
+        async with source:
+            first = source.__aiter__()
+            await first.__anext__()
+            second = source.__aiter__()
+            with pytest.raises(RuntimeError, match="concurrent"):
+                await second.__anext__()
+
+    async def test_aexit_closes_underlying_stream(self):
+        class _ClosableStream:
+            def __init__(self, items: list[Any]) -> None:
+                self._items = items
+                self.closed = False
+
+            def __aiter__(self):
+                self._it = iter(self._items)
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self._it)
+                except StopIteration:
+                    raise StopAsyncIteration from None
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        stream = _ClosableStream([FakeCopilotEvent(type="user.message", data={"content": "a"})])
+        source = SdkCopilotSource("copilot-live", stream)
+        async with source:
+            iterator = source.__aiter__()
+            await iterator.__anext__()
+        assert stream.closed is True
+
+    async def test_unknown_claude_message_is_skipped(self):
+        @dataclass
+        class MysteryMessage:
+            foo: str
+
+        source = SdkClaudeSource("claude-live", _agen([MysteryMessage(foo="bar")]))
+        records = await _collect(source)
+        assert records == []
+
+
+# ─── Copilot push-model bridge ───────────────────────────────────────────────
+
+
+class _FakeCopilotSession:
+    """Mimics the SDK push model: ``session.on(cb)`` returns an unsubscribe."""
+
+    def __init__(self) -> None:
+        self.callback = None
+        self.unsubscribed = False
+
+    def on(self, callback):
+        self.callback = callback
+        return self._unsubscribe
+
+    def _unsubscribe(self) -> None:
+        self.unsubscribed = True
+
+
+class TestPushBridge:
+    async def test_from_session_bridges_push_events(self):
+        session = _FakeCopilotSession()
+        with patch("traceforge.sources.sdk_live._require_copilot_sdk", return_value=None):
+            source = SdkCopilotSource.from_session("copilot-live", session)
+            await source.__aenter__()
+            iterator = source.__aiter__()
+            pending = asyncio.ensure_future(iterator.__anext__())
+            await asyncio.sleep(0)  # let the bridge register session.on
+
+            assert session.callback is not None
+            session.callback(
+                FakeCopilotEvent(
+                    type="user.message",
+                    id="e1",
+                    timestamp="2024-06-01T10:00:05Z",
+                    data={"content": "hi"},
+                )
+            )
+            record = await asyncio.wait_for(pending, timeout=1.0)
+            assert json.loads(record.payload)["type"] == "user.message"
+            assert record.mode == "stream"
+
+            await source.__aexit__(None, None, None)
+            await iterator.aclose()
+        assert session.unsubscribed is True
+
+    async def test_copilot_event_stream_requires_extra(self):
+        session = _FakeCopilotSession()
+        stream = copilot_event_stream(session)
+        with patch("builtins.__import__", side_effect=ImportError("No module named 'copilot'")):
+            with pytest.raises(ImportError, match=r"traceforge-toolkit\[copilot\]"):
+                await stream.__anext__()
+
+
+# ─── Optional-extras: graceful degradation ───────────────────────────────────
+
+
+class TestOptionalExtras:
+    def test_require_copilot_sdk_missing(self):
+        with patch("builtins.__import__", side_effect=ImportError("No module named 'copilot'")):
+            with pytest.raises(ImportError, match=r"traceforge-toolkit\[copilot\]"):
+                _require_copilot_sdk()
+
+    def test_require_claude_sdk_missing(self):
+        with patch(
+            "builtins.__import__", side_effect=ImportError("No module named 'claude_agent_sdk'")
+        ):
+            with pytest.raises(ImportError, match=r"traceforge-toolkit\[claude\]"):
+                _require_claude_sdk()

--- a/uv.lock
+++ b/uv.lock
@@ -664,6 +664,24 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.2.113"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/d7/e119e2e0748bf857e71b46ed35459385ec82c7df0f8511a4f83c734e2949/claude_agent_sdk-0.2.113.tar.gz", hash = "sha256:b78bbd5b4562b65ea80c3c843f247213fc6052c32b1b3ebbe80883dabdf7b719", size = 268643, upload-time = "2026-07-08T00:40:56.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/12/579286d15ce3e72ecb1cfdf1916efdba9d4c2716c7089e869fb9a4727807/claude_agent_sdk-0.2.113-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f972f64dfd0c3aad69ffdc957f4bcd75541e42797cb02cb7038bd48dde0bb7c7", size = 69361517, upload-time = "2026-07-08T00:41:00.091Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1d/022befebf13782cfdf2796e76ef28a3e834c647dcaaf22876bce1a3e81c3/claude_agent_sdk-0.2.113-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:d9e46d55c3e82b76a0ea6377a3ece6f4982500b558ec106fecb1ba4629b629cb", size = 74261638, upload-time = "2026-07-08T00:41:03.319Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/df/c05ece7ae69d9da9735c343527862eb79c34b4f797790beb6a1641f018a0/claude_agent_sdk-0.2.113-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:fc28895a5c5cdb320517b7de1f1d2c852c5f67744baadde4db011b6ccc70af44", size = 79295536, upload-time = "2026-07-08T00:41:08.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0b/0ff95d4a52ac3931b985504f73bf5181097b615d61705bbe6bbfb518ce3d/claude_agent_sdk-0.2.113-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:f172fe8bd16a0ee2cab95e3cdc5a8b0bbcab6558443d5dc9edebb4fe2db2bbe4", size = 80331694, upload-time = "2026-07-08T00:41:11.402Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a7/17423a498b413d6ae3f5928224cf8c68f0612819c054d1450fbc047bf03b/claude_agent_sdk-0.2.113-py3-none-win_amd64.whl", hash = "sha256:a47253141b1ec946cfe6be99fe24ef55a14b585cd7018f89d11d8f1c9e8c2926", size = 79842831, upload-time = "2026-07-08T00:41:15.026Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1096,6 +1114,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload-time = "2024-05-15T22:08:49.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload-time = "2024-05-15T22:08:47.056Z" },
+]
+
+[[package]]
+name = "github-copilot-sdk"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/d7/3d71064646a24d633c9dec035ff8b5b6d72c11d3aad765e54efd71737f0f/github_copilot_sdk-0.3.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:ed8f27989158824c754d7febb473bdf25744a1e6bc07a06f114f7e7deebd2c22", size = 58566984, upload-time = "2026-04-24T16:05:37.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/439854722b951a2f213c23cc731e9a31d46c8b1e2f1b1de080745c03c798/github_copilot_sdk-0.3.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7e241d9b00ebf8bb4d10b2d6101c75fcef38de04d144d729e07fa48394270ee1", size = 55318729, upload-time = "2026-04-24T16:05:41.734Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/931a65b17ad36d3b8987d8cb9bd2835f759c79ae1799fdc34d1252c38b6f/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f4d98a67b8f038885ddd38bd7033d1ac20c3010f04c72ee0fc74ba4984b69ffa", size = 61452705, upload-time = "2026-04-24T16:05:45.225Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e5/7e275fc76a7f9cc3240da393ed631d9647c346a36d6392ea4b0ed56326f6/github_copilot_sdk-0.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b591546d789f9f8243fb59ca71b08cb0bb1dbec818fbef060c3830c6787de2c8", size = 59646875, upload-time = "2026-04-24T16:05:48.832Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/67/00e3bf21842b0c418aad6ce233ec8cd7e8ca91859e4f7e571fc47c682ed9/github_copilot_sdk-0.3.0-py3-none-win_amd64.whl", hash = "sha256:c5712d57a2c6291b805c79e039c55c48d858034b1a37fc8e1653925403a028e9", size = 54165496, upload-time = "2026-04-24T16:05:52.712Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1c/76bb5159018a1c0d44b17ded340c91085fb48dd3dc912eb349781c54c200/github_copilot_sdk-0.3.0-py3-none-win_arm64.whl", hash = "sha256:93b07c46f60cebbbb003d5bddba22eab886849b1d052b98037b52b6434a5bc07", size = 52103138, upload-time = "2026-04-24T16:05:56.329Z" },
 ]
 
 [[package]]
@@ -4167,6 +4202,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+claude = [
+    { name = "claude-agent-sdk" },
+]
+copilot = [
+    { name = "github-copilot-sdk" },
+]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -4198,7 +4239,9 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.28" },
+    { name = "claude-agent-sdk", marker = "extra == 'claude'", specifier = ">=0.1" },
     { name = "click", specifier = ">=8.1" },
+    { name = "github-copilot-sdk", marker = "extra == 'copilot'", specifier = ">=0.3,<0.4" },
     { name = "httpx", specifier = ">=0.25" },
     { name = "joblib", specifier = ">=1.3" },
     { name = "litellm", specifier = ">=1.0" },
@@ -4223,7 +4266,7 @@ requires-dist = [
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "watchdog", specifier = ">=4.0" },
 ]
-provides-extras = ["dev", "s3"]
+provides-extras = ["dev", "s3", "copilot", "claude"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
> **HOLD — do not merge.** Complete and green; awaiting coordinator review (U1b slice of the CodePlane-upstream epic).

## What this adds
Managed live sources `SdkCopilotSource` and `SdkClaudeSource` that stream events from the vendor agent SDKs into the pipeline as **thin translation over the EXISTING mapping machinery**. "Managed" = traceforge owns the ingest loop (vs the file/poll/watch sources).

Both sources emit `stream`-mode `RawRecord`s carrying the **same wire-format dicts the file path produces**, so the existing `MappedJsonAdapter` (loaded from `copilot.yaml` / `claude.yaml`) maps them into **identical `SessionEvent`s**. There are **zero new mappings**.

## Files
| File | Change |
| --- | --- |
| `src/traceforge/sources/sdk_live.py` | **new** — `_SdkLiveSource` base + `SdkCopilotSource` + `SdkClaudeSource`, lazy `_require_copilot_sdk`/`_require_claude_sdk`, `copilot_event_stream` (push→async-iter bridge), `claude_event_stream` (`query(...)`) |
| `src/traceforge/sources/__init__.py` | export `SdkCopilotSource`, `SdkClaudeSource` |
| `pyproject.toml` | add `copilot` + `claude` optional extras (s3 style) |
| `uv.lock` | lockfile sync for the two extras (see scope note) |
| `tests/unit/test_sdk_live_sources.py` | **new** — 16 deterministic tests |

## Extras added (`[project.optional-dependencies]`)
```toml
copilot = ["github-copilot-sdk>=0.3,<0.4"]
claude  = ["claude-agent-sdk>=0.1"]
```
Imported **lazily** inside the source (never at module top) — `import traceforge` never requires them; a missing extra raises a clear `pip install traceforge-toolkit[copilot|claude]` error (mirrors `sinks/s3.py` `_require_boto3`).

## Tests — golden-event equivalence (faked SDKs, no network)
16 tests, all deterministic. The core assertion: the SDK source produces the **same `SessionEvent`s as the file path** for equivalent input (compared on kind, session_id, payload, source_framework, ingestion_mode, raw_kind, motivation intent/reasoning — excluding volatile uuid `id`/`now()`-timestamp/`source_event_ids`).
- **Copilot** golden: emitted wire dicts match `copilot_session.jsonl` **exactly** (15/15), and SessionEvents match the file path.
- **Claude** golden: fake typed dataclass Messages/blocks mirroring `claude_session.jsonl` → SessionEvents match the file path.
- Proves `ingestion_mode` comes from the **mapping** (`file_watch`) even though the source's `RawRecord.mode` is `stream` — the key to equivalence.
- Lifecycle: sequence increments, `stream` mode, concurrent-iteration guard, enter-before-iterate guard, `aclose` on exit, unknown-message skip.
- Push bridge (`from_session` over a fake `session.on`), and both `_require_*` ImportError paths.

**Full `tests/unit`: 2128 passed, 1 skipped.** `ruff check .` + `ruff format --check .` (pinned 0.15.20): clean.

## Confirmations
- ✅ **Zero new mappings** — reuses `copilot.yaml` / `claude.yaml` + `MappedJsonAdapter` unchanged.
- ✅ **`sdk/pipeline.py` `push()` untouched.** Enricher, governance/*, and all other sources untouched (only `sources/__init__.py` registration added).
- ✅ No `auto_detect` wiring (out of scope).

## Fork to flag — translation asymmetry (in scope; light normalization only)
- **Copilot**: SDK events already mirror the wire shape (`event.type` + typed `event.data`) → **near-identity** re-serialize.
- **Claude**: SDK yields typed dataclass `Message`/block objects → **explicit per-type translation** back to wire dicts, dispatched by class `__name__` so the real SDK classes are never imported.

Both remain thin translation; neither required touching a mapping.

## Scope note — `uv.lock`
Adding the two extras necessarily updates `uv.lock` (adds `github-copilot-sdk` 0.3.0, `claude-agent-sdk`, and the `copilot`/`claude` groups; **no existing pins changed**; `uv lock --check` passes). CI uses `uv sync` (not `--locked`), so this is a hygiene sync tightly coupled to the allowed `pyproject.toml` change — flagged here for transparency.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>