### PR TITLE
feat(governance): general policy primitives - trust grants, protected paths, cost-ceiling action, Assessor (U10)

### DIFF
--- a/src/traceforge/config/models.py
+++ b/src/traceforge/config/models.py
@@ -270,6 +270,46 @@ ExternalGateConfig = Annotated[
 ]
 
 
+class ProtectedPathsPolicyConfig(StrictModel):
+    """Policy-driven protected-path globs (general primitive; consumer supplies globs).
+
+    When a tool call touches a path matching any ``patterns`` glob, the configured
+    ``action`` is applied. This is an *explicit* policy matcher, distinct from the
+    IFC clearance heuristics: TraceForge infers nothing here — the consumer states
+    which path shapes are protected. Empty ``patterns`` (the default) never fires.
+    """
+
+    patterns: list[str] = Field(default_factory=list)
+    action: Literal["escalate", "deny"] = "escalate"
+
+
+class CostCeilingPolicyConfig(StrictModel):
+    """Policy-driven mapping from budget pressure to a governance action.
+
+    Budget tracking already computes a ``pressure`` flag from ``BudgetConfig``
+    thresholds but takes no action. This supplies the missing policy: the action
+    to take on pressure, plus an optional independent hard ceiling on the total
+    tool-call count. All fields default to off — with ``pressure_action`` unset
+    and ``hard_max_tool_calls`` unset the ceiling never fires.
+    """
+
+    pressure_action: Literal["escalate", "deny"] | None = None
+    hard_max_tool_calls: int | None = Field(default=None, ge=1)
+    hard_action: Literal["escalate", "deny"] = "deny"
+
+
+class PolicyConfig(StrictModel):
+    """General, default-off governance policy primitives (consumer supplies values).
+
+    Each nested primitive is a generic agent-governance mechanism whose *values*
+    (which globs, which ceilings, which action) the consumer configures. With the
+    defaults (no patterns, no ceiling) nothing here changes existing behavior.
+    """
+
+    protected_paths: ProtectedPathsPolicyConfig = Field(default_factory=ProtectedPathsPolicyConfig)
+    cost_ceiling: CostCeilingPolicyConfig = Field(default_factory=CostCeilingPolicyConfig)
+
+
 class GovernanceConfig(StrictModel):
     """Governance pipeline configuration.
 
@@ -311,6 +351,7 @@ class GovernanceConfig(StrictModel):
     pii_scanning: bool = True
     integrity_verification: bool = True  # content-hash tamper detection (baseline + drift)
     budget: BudgetConfig = Field(default_factory=BudgetConfig)
+    policy: PolicyConfig = Field(default_factory=PolicyConfig)
     tool_preflight_gate: str | None = None  # dotted import path (e.g. "myapp.policies.my_policy")
     preflight_gate: ExternalGateConfig | None = (
         None  # out-of-process external decider (http/subprocess)

--- a/src/traceforge/governance/assessor.py
+++ b/src/traceforge/governance/assessor.py
@@ -26,9 +26,11 @@ from traceforge.governance.results import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from traceforge.classify.config import ClassificationEngine
     from traceforge.governance.labeler import GovernanceLabeler, GovernanceResult
-    from traceforge.governance.rules import Rule
+    from traceforge.governance.rules import PolicyAssessor, Rule
     from traceforge.governance.state import SessionStateSnapshot
     from traceforge.governance.types import EnrichmentContext
 
@@ -68,10 +70,14 @@ class DefaultAssessor:
         labeler: "GovernanceLabeler",
         rules: "list[Rule]",
         engine: "ClassificationEngine",
+        policy_assessors: "Sequence[PolicyAssessor]" = (),
     ) -> None:
         self._labeler = labeler
         self._rules = rules
         self._engine = engine
+        # Pluggable, deterministic (non-LLM) policy checks. Empty by default so a
+        # consumer that registers nothing sees the exact base rule-engine behavior.
+        self._policy_assessors: tuple[PolicyAssessor, ...] = tuple(policy_assessors)
 
     def assess(self, ctx: "EnrichmentContext", snapshot: "SessionStateSnapshot") -> Assessment:
         """Label (Phase 2) then score/evaluate/evidence (Phase 3) against ``snapshot``."""
@@ -118,7 +124,11 @@ class DefaultAssessor:
         """Phase 3: risk assessment + rule evaluation + evidence + escalation context."""
         from traceforge.governance.canonical import compute_canonical_hash
         from traceforge.governance.risk_wrapper import assess_governance_risk
-        from traceforge.governance.rules import evaluate_rules
+        from traceforge.governance.rules import (
+            active_grant_keys,
+            apply_policy_overlay,
+            evaluate_rules,
+        )
 
         # Compute risk
         risk = assess_governance_risk(
@@ -131,6 +141,18 @@ class DefaultAssessor:
 
         # Evaluate rules
         rule_match = evaluate_rules(self._rules, result.classification, risk)
+
+        # Policy overlay (default-off extension point): fold in any registered
+        # PolicyAssessor decisions (protected paths, cost ceilings, consumer
+        # checks) and waive escalate/deny outcomes covered by an active trust
+        # grant. ``now`` comes from the event timestamp so TTL evaluation is fully
+        # deterministic. With no assessors and no active grants this returns the
+        # base ``rule_match`` unchanged — a guaranteed no-op for the empty policy.
+        now = ctx.event.timestamp
+        grant_keys = (
+            active_grant_keys(snapshot.trust_grants, now) if snapshot is not None else frozenset()
+        )
+        rule_match = apply_policy_overlay(rule_match, ctx, now, self._policy_assessors, grant_keys)
 
         if rule_match is None:
             return Phase3Result(risk_assessment=risk, recommendation_result=None)

--- a/src/traceforge/governance/budget.py
+++ b/src/traceforge/governance/budget.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING
 
+from traceforge.governance.rules import PolicyDecision, RecommendedAction
+
 if TYPE_CHECKING:
-    from traceforge.governance.state import SessionState
+    from traceforge.governance.state import BudgetSnapshot, SessionState
     from traceforge.governance.types import EnrichmentContext
 
 
@@ -57,3 +60,74 @@ class BudgetTracker:
         if self._thresholds.max_by_scope:
             thresholds_dict["max_by_scope"] = self._thresholds.max_by_scope
         return state.check_pressure(thresholds_dict)
+
+
+@dataclass(frozen=True)
+class CostCeiling:
+    """Maps a budget condition to a governance action — a general primitive.
+
+    Budget tracking already computes a ``pressure`` flag from ``BudgetThresholds``
+    but takes no action. A ``CostCeiling`` supplies the missing *policy*: which
+    action (typically ``ESCALATE`` or ``DENY``) a consumer wants when budget
+    pressure is reached, and an optional independent hard ceiling on the total
+    tool-call count. TraceForge provides the mechanism; the consumer supplies the
+    values (the actions and the ceiling) via config.
+
+    All fields default to *off*: with ``pressure_action=None`` and
+    ``hard_max_tool_calls=None`` the ceiling never fires, so existing behavior is
+    unchanged. This type never reads a clock or mutates state — it only maps an
+    already-computed snapshot to an optional action.
+    """
+
+    pressure_action: RecommendedAction | None = None
+    hard_max_tool_calls: int | None = None
+    hard_action: RecommendedAction = RecommendedAction.DENY
+
+
+def ceiling_action(
+    snapshot: "BudgetSnapshot",
+    ceiling: CostCeiling | None,
+) -> RecommendedAction | None:
+    """Map a budget ``snapshot`` to a governance action under ``ceiling``.
+
+    Returns ``None`` when no ceiling is configured, when neither condition is met,
+    or when the matched condition has no action — i.e. the safe default is always
+    "no action". The hard tool-call ceiling takes precedence over soft pressure
+    because it represents an explicit, absolute limit.
+
+    This consumes the existing ``snapshot.pressure`` flag and counters produced by
+    budget tracking; it does not re-evaluate thresholds itself.
+    """
+    if ceiling is None:
+        return None
+    if (
+        ceiling.hard_max_tool_calls is not None
+        and snapshot.total_tool_calls >= ceiling.hard_max_tool_calls
+    ):
+        return ceiling.hard_action
+    if snapshot.pressure and ceiling.pressure_action is not None:
+        return ceiling.pressure_action
+    return None
+
+
+@dataclass(frozen=True)
+class CostCeilingAssessor:
+    """Policy assessor that fires when budget pressure meets a cost ceiling.
+
+    A general primitive matching the ``PolicyAssessor`` shape: it reads the budget
+    snapshot the pipeline already computed and maps it, via :func:`ceiling_action`
+    and the consumer-supplied :class:`CostCeiling`, to an optional escalate/deny
+    decision. With no ceiling configured it never fires.
+    """
+
+    ceiling: CostCeiling | None = None
+    reason_code: str = "cost_ceiling"
+
+    def assess(self, ctx: "EnrichmentContext", now: datetime) -> PolicyDecision | None:
+        snapshot = ctx.session_state
+        if snapshot is None or self.ceiling is None:
+            return None
+        action = ceiling_action(snapshot.budget, self.ceiling)
+        if action is None:
+            return None
+        return PolicyDecision(action=action, reason_code=self.reason_code)

--- a/src/traceforge/governance/pipeline.py
+++ b/src/traceforge/governance/pipeline.py
@@ -21,12 +21,15 @@ from traceforge.governance.results import SessionMeta
 
 if TYPE_CHECKING:
     import traceforge.types
+    from collections.abc import Sequence
+    from datetime import datetime
 
     from traceforge.classify.config import ClassificationEngine
+    from traceforge.config.models import PolicyConfig
     from traceforge.governance.budget import BudgetTracker
     from traceforge.governance.labeler import GovernanceLabeler
     from traceforge.governance.persistence import SystemStore
-    from traceforge.governance.rules import Rule
+    from traceforge.governance.rules import PolicyAssessor, Rule
     from traceforge.governance.state import SessionState
     from traceforge.governance.types import (
         EnrichmentContext,
@@ -46,6 +49,46 @@ def _import_dotted(dotted_path: str):
 
     module = importlib.import_module(module_path)
     return getattr(module, attr_name)
+
+
+def _build_policy_assessors(policy_cfg: "PolicyConfig") -> "tuple[PolicyAssessor, ...]":
+    """Build the default-off policy assessors from a :class:`PolicyConfig`.
+
+    Returns an empty tuple when nothing is configured (no protected-path patterns
+    and no cost ceiling), so a default policy adds zero behavior. Each assessor is
+    a general primitive parameterized purely by consumer-supplied config values.
+    """
+    from traceforge.governance.budget import CostCeiling, CostCeilingAssessor
+    from traceforge.governance.rules import ProtectedPathAssessor, RecommendedAction
+
+    assessors: list[PolicyAssessor] = []
+
+    protected = policy_cfg.protected_paths
+    if protected.patterns:
+        assessors.append(
+            ProtectedPathAssessor(
+                patterns=tuple(protected.patterns),
+                action=RecommendedAction(protected.action),
+            )
+        )
+
+    ceiling_cfg = policy_cfg.cost_ceiling
+    if ceiling_cfg.pressure_action is not None or ceiling_cfg.hard_max_tool_calls is not None:
+        assessors.append(
+            CostCeilingAssessor(
+                ceiling=CostCeiling(
+                    pressure_action=(
+                        RecommendedAction(ceiling_cfg.pressure_action)
+                        if ceiling_cfg.pressure_action is not None
+                        else None
+                    ),
+                    hard_max_tool_calls=ceiling_cfg.hard_max_tool_calls,
+                    hard_action=RecommendedAction(ceiling_cfg.hard_action),
+                )
+            )
+        )
+
+    return tuple(assessors)
 
 
 # Sentinel for "attribute absent" checks where ``None`` is itself a meaningful value.
@@ -96,6 +139,7 @@ class GovernancePipeline:
         engine: "ClassificationEngine",
         project_root: str | None = None,
         policy: "GatePolicy | None" = None,
+        policy_assessors: "Sequence[PolicyAssessor]" = (),
     ) -> None:
         # ── Facade-observable state ──
         self._store = store
@@ -104,7 +148,7 @@ class GovernancePipeline:
 
         # ── Collaborator object graph (composition root; DIP wiring) ──
         self._registry = SessionRegistry(store)
-        self._assessor = DefaultAssessor(labeler, rules, engine)
+        self._assessor = DefaultAssessor(labeler, rules, engine, policy_assessors=policy_assessors)
         self._phase1 = Phase1(budget_tracker, labeler)
         self._codec = MetaCodec()
         self._context = ContextBuilder(engine, project_root)
@@ -208,6 +252,7 @@ class GovernancePipeline:
             rules=rules,
             engine=engine,
             policy=policy,
+            policy_assessors=_build_policy_assessors(config.policy),
         )
         instance._project_root = config.project_root
         return instance
@@ -278,6 +323,37 @@ class GovernancePipeline:
     def score_tool_call(self, payload: dict) -> "EventTrace":
         """Score a pending tool call against current session state (delegates to Scorer)."""
         return self._scorer.score_tool_call(payload)
+
+    def grant_trust(
+        self,
+        session_id: str,
+        key: str,
+        ttl_seconds: float,
+        *,
+        now: "datetime | None" = None,
+        reason: str = "",
+    ) -> None:
+        """Record a time-boxed trust grant for a session — a general primitive.
+
+        While active (for ``ttl_seconds`` from ``now``), a grant whose ``key`` equals
+        a policy decision's reason code waives that escalate/deny in the assessment
+        overlay (see :class:`~traceforge.governance.types.TrustGrant`). ``key`` is
+        opaque — TraceForge assigns it no meaning, so the consumer owns the
+        vocabulary (a policy label to waive, a tool name, a capability). ``now``
+        defaults to the current UTC time; pass it explicitly for deterministic
+        tests. The grant is written through to the durable store, so it survives a
+        reload and is consulted on both the observation and preflight-scoring paths.
+        """
+        from datetime import datetime, timezone
+
+        from traceforge.governance.types import TrustGrant
+
+        granted_at = now if now is not None else datetime.now(timezone.utc)
+        state = self._registry.get_or_create(session_id)
+        state.trust_grants.add(
+            TrustGrant(key=key, granted_at=granted_at, ttl_seconds=ttl_seconds, reason=reason)
+        )
+        state.persist()
 
     # ─── Central gate execution helpers ───────────────────────────────────────
 

--- a/src/traceforge/governance/rules.py
+++ b/src/traceforge/governance/rules.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import re
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
+from functools import lru_cache
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Protocol
 
 import yaml
 
@@ -17,6 +20,7 @@ from traceforge.governance.results import TransformSuggestion
 if TYPE_CHECKING:
     from traceforge.classify.core import Classification
     from traceforge.classify.risk import RiskAssessment
+    from traceforge.governance.types import EnrichmentContext, TrustGrant
 
 
 class RecommendedAction(StrEnum):
@@ -366,3 +370,373 @@ def _compare_score(score: int, op: str, threshold: int) -> bool:
     if op == "==":
         return score == threshold
     return False
+
+
+# ---------------------------------------------------------------------------
+# Protected-path glob predicate (general primitive; consumer supplies globs).
+#
+# This is an EXPLICIT, policy-driven matcher: it matches file paths carried by a
+# tool call against consumer-supplied glob patterns. It is deliberately distinct
+# from the IFC clearance heuristics in ``ifc.py`` (which *infer* data sensitivity
+# from a fixed built-in table): here TraceForge infers nothing — the consumer
+# states which path shapes are protected, and matching is plain glob equality.
+# ---------------------------------------------------------------------------
+
+# Ordered set of common argument keys that name a filesystem path. Parallels the
+# keys IFC reads, generalized to the shapes tools commonly use. Scalar and list
+# values are both supported. This is mechanism only: no key is consumer-specific.
+_PATH_ARG_KEYS: tuple[str, ...] = (
+    "path",
+    "file",
+    "filename",
+    "file_path",
+    "filepath",
+    "target",
+    "target_path",
+    "dest",
+    "destination",
+    "dst",
+    "src",
+    "source",
+    "dir",
+    "directory",
+    "cwd",
+    "paths",
+    "files",
+    "targets",
+)
+
+
+def normalize_path(path: str) -> str:
+    """Normalize a path for matching: backslashes → ``/``, collapsed, lowercased.
+
+    Matching is case-insensitive so a protected pattern cannot be bypassed purely
+    by changing case (the conservative failure mode for a security primitive), and
+    separator-normalized so the same pattern behaves identically across platforms.
+    """
+    return path.replace("\\", "/").strip().lower()
+
+
+@lru_cache(maxsize=512)
+def _compile_path_glob(pattern: str) -> re.Pattern[str]:
+    """Compile a glob ``pattern`` into a regex with standard path semantics.
+
+    ``**`` matches across directory separators, ``*`` matches within a single
+    segment, ``?`` matches a single non-separator character; everything else is
+    literal. Patterns are matched case-insensitively against normalized paths.
+    """
+    pat = normalize_path(pattern)
+    out: list[str] = ["(?s:"]
+    i, n = 0, len(pat)
+    while i < n:
+        c = pat[i]
+        if c == "*":
+            if pat[i : i + 2] == "**":
+                j = i + 2
+                if j < n and pat[j] == "/":
+                    # ``**/`` → zero or more leading directories
+                    out.append("(?:.*/)?")
+                    i = j + 1
+                    continue
+                out.append(".*")
+                i = j
+                continue
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    out.append(r")\Z")
+    return re.compile("".join(out))
+
+
+def path_matches_glob(path: str, pattern: str) -> bool:
+    """Whether ``path`` matches a single glob ``pattern``.
+
+    A pattern containing ``/`` is matched against the full normalized path; a
+    pattern without ``/`` is matched against the path's basename, so a bare
+    pattern such as ``*.pem`` or ``.env`` matches that file in any directory.
+    """
+    if not path or not pattern:
+        return False
+    npath = normalize_path(path)
+    rx = _compile_path_glob(pattern)
+    if "/" in pattern.replace("\\", "/"):
+        return rx.match(npath) is not None
+    basename = npath.rsplit("/", 1)[-1]
+    return rx.match(basename) is not None
+
+
+def first_matching_glob(paths: Iterable[str], patterns: Iterable[str]) -> str | None:
+    """Return the first ``pattern`` (in given order) matching any of ``paths``.
+
+    Returns ``None`` when nothing matches (the safe default). Iteration order is
+    preserved so the chosen pattern is deterministic.
+    """
+    pattern_list = list(patterns)
+    for path in paths:
+        for pattern in pattern_list:
+            if path_matches_glob(path, pattern):
+                return pattern
+    return None
+
+
+def extract_candidate_paths(tool_args_json: str) -> tuple[str, ...]:
+    """Collect candidate filesystem paths from a tool call's JSON arguments.
+
+    Reads a fixed, general set of common path-bearing argument keys (see
+    ``_PATH_ARG_KEYS``), accepting both scalar and list values. Returns a
+    de-duplicated tuple preserving first-seen order. Malformed JSON yields an
+    empty tuple — never raises.
+    """
+    try:
+        args = json.loads(tool_args_json)
+    except (json.JSONDecodeError, TypeError):
+        return ()
+    if not isinstance(args, Mapping):
+        return ()
+    seen: dict[str, None] = {}
+    for key in _PATH_ARG_KEYS:
+        if key not in args:
+            continue
+        value = args[key]
+        if isinstance(value, str):
+            candidates: tuple[object, ...] = (value,)
+        elif isinstance(value, (list, tuple)):
+            candidates = tuple(value)
+        else:
+            continue
+        for candidate in candidates:
+            if isinstance(candidate, str) and candidate and candidate not in seen:
+                seen[candidate] = None
+    return tuple(seen)
+
+
+# ---------------------------------------------------------------------------
+# Pluggable policy assessors — a small extension point over the non-LLM checks.
+#
+# A ``PolicyAssessor`` is any object that, given the read-only enrichment context
+# and a deterministic ``now``, returns an optional :class:`PolicyDecision` (an
+# action + a reason code) or ``None`` to abstain. This surfaces the built-in
+# deterministic checks (protected paths, cost ceilings) behind one general
+# protocol that a consumer can extend by registering additional assessors. It is
+# an *overlay*: with no assessors registered and no active trust grants, the base
+# rule decision is returned unchanged (proven zero behavior change).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """An action recommended by a policy assessor, with a reason code.
+
+    ``reason_code`` is the join key for trust grants: an active grant whose key
+    equals a decision's ``reason_code`` waives that decision (see
+    :func:`waive_by_grants`). Both fields are general — the consumer owns the
+    vocabulary of reason codes it escalates on and grants against.
+    """
+
+    action: RecommendedAction
+    reason_code: str
+
+
+class PolicyAssessor(Protocol):
+    """A pluggable, deterministic (non-LLM) policy check.
+
+    Implementations inspect the read-only ``ctx`` (event, state snapshot, project
+    root) at a caller-supplied ``now`` and return a :class:`PolicyDecision` to
+    raise an action, or ``None`` to abstain. ``now`` is always passed in so any
+    time-dependent check stays deterministic.
+    """
+
+    def assess(self, ctx: EnrichmentContext, now: datetime) -> PolicyDecision | None: ...
+
+
+# Severity lattice for combining decisions. ALLOW/TRANSFORM are non-elevating;
+# WARN < ESCALATE < DENY. Higher wins; ties keep the incumbent (base) decision.
+_ACTION_SEVERITY: dict[RecommendedAction, int] = {
+    RecommendedAction.ALLOW: 0,
+    RecommendedAction.TRANSFORM: 1,
+    RecommendedAction.WARN: 1,
+    RecommendedAction.ESCALATE: 2,
+    RecommendedAction.DENY: 3,
+}
+
+
+def combine_policy_decisions(
+    base: PolicyDecision | None,
+    overlay: Iterable[PolicyDecision | None],
+) -> PolicyDecision | None:
+    """Return the most severe of ``base`` and the ``overlay`` decisions.
+
+    ``base`` (the rule-engine outcome) is the incumbent: an overlay decision only
+    wins if it is strictly more severe, so equal-severity overlays never displace
+    the base and iteration order among overlays does not affect the result.
+    """
+    best = base
+    best_severity = _ACTION_SEVERITY.get(base.action, 0) if base is not None else -1
+    for decision in overlay:
+        if decision is None:
+            continue
+        severity = _ACTION_SEVERITY.get(decision.action, 0)
+        if severity > best_severity:
+            best = decision
+            best_severity = severity
+    return best
+
+
+def active_grant_keys(grants: Iterable[TrustGrant], now: datetime) -> frozenset[str]:
+    """Keys of grants active at ``now``.
+
+    Defensive against a grant whose timestamp awareness does not match ``now``
+    (naive vs. tz-aware): such a grant simply does not count as active — the
+    conservative choice, since a grant only ever *waives* an escalation.
+    """
+    keys: set[str] = set()
+    for grant in grants:
+        try:
+            if grant.is_active(now):
+                keys.add(grant.key)
+        except TypeError:
+            continue
+    return frozenset(keys)
+
+
+def waive_by_grants(
+    decision: PolicyDecision | None,
+    grant_keys: frozenset[str],
+) -> PolicyDecision | None:
+    """Waive an escalate/deny ``decision`` when an active grant matches its reason.
+
+    Trust grants only ever *reduce* severity: a matching active grant turns an
+    ``ESCALATE``/``DENY`` into "no recommendation" (``None`` → allowed). Non-severe
+    decisions (allow/warn/transform) and unmatched reasons pass through unchanged.
+    """
+    if decision is None:
+        return None
+    if (
+        decision.action in (RecommendedAction.ESCALATE, RecommendedAction.DENY)
+        and decision.reason_code in grant_keys
+    ):
+        return None
+    return decision
+
+
+def _decision_from_match(rule_match: RuleMatch | None) -> PolicyDecision | None:
+    """Project a :class:`RuleMatch` onto its (action, reason_code) decision."""
+    if rule_match is None:
+        return None
+    return PolicyDecision(
+        action=RecommendedAction(rule_match.template.recommended_action),
+        reason_code=rule_match.template.reason_code,
+    )
+
+
+def _match_from_decision(
+    decision: PolicyDecision | None,
+    original: RuleMatch | None,
+) -> RuleMatch | None:
+    """Reconstruct a :class:`RuleMatch` for ``decision``, reusing ``original`` when unchanged.
+
+    When the resolved decision equals the original rule match's action+reason, the
+    original match is returned *by identity* so its template (message, transform)
+    and matched predicates are preserved exactly — the key to zero behavior change.
+    Otherwise a synthetic match is built carrying the overlay's action and reason.
+    """
+    if decision is None:
+        return None
+    if (
+        original is not None
+        and RecommendedAction(original.template.recommended_action) == decision.action
+        and original.template.reason_code == decision.reason_code
+    ):
+        return original
+    return RuleMatch(
+        template=RecommendationTemplate(
+            recommended_action=decision.action,
+            reason_code=decision.reason_code,
+        ),
+        rule_id=f"policy:{decision.reason_code}",
+        matched_predicates=(),
+    )
+
+
+def apply_policy_overlay(
+    rule_match: RuleMatch | None,
+    ctx: EnrichmentContext,
+    now: datetime,
+    assessors: Sequence[PolicyAssessor] = (),
+    grant_keys: frozenset[str] = frozenset(),
+) -> RuleMatch | None:
+    """Fold policy-assessor decisions and trust-grant waivers over a base match.
+
+    The base rule-engine ``rule_match`` is combined (by severity) with each
+    assessor's decision, then any matching active trust grant waives an
+    escalate/deny outcome. Returns the resulting :class:`RuleMatch` (possibly the
+    original by identity, a synthetic one, or ``None``).
+
+    Fast path: with no assessors and no active grant keys the base match is
+    returned untouched, so a default (empty) policy is a guaranteed no-op.
+    """
+    if not assessors and not grant_keys:
+        return rule_match
+    base = _decision_from_match(rule_match)
+    overlay = [assessor.assess(ctx, now) for assessor in assessors]
+    combined = combine_policy_decisions(base, overlay)
+    combined = waive_by_grants(combined, grant_keys)
+    return _match_from_decision(combined, rule_match)
+
+
+@dataclass(frozen=True)
+class ProtectedPathAssessor:
+    """Escalate/deny when a tool call touches a consumer-designated path.
+
+    A general primitive: the consumer supplies the glob ``patterns`` (which paths
+    are protected) and the ``action`` to take on a match (typically ``ESCALATE``
+    or ``DENY``). This is an *explicit*, policy-driven matcher — deliberately
+    distinct from the IFC clearance heuristics, which infer sensitivity from a
+    built-in table. With no patterns configured it never fires.
+    """
+
+    patterns: tuple[str, ...] = ()
+    action: RecommendedAction = RecommendedAction.ESCALATE
+    reason_code: str = "protected_path"
+
+    def assess(self, ctx: EnrichmentContext, now: datetime) -> PolicyDecision | None:
+        from traceforge.governance.types import ToolCallEvent
+
+        if not self.patterns or not isinstance(ctx.event, ToolCallEvent):
+            return None
+        paths = extract_candidate_paths(ctx.event.tool_args_json)
+        if first_matching_glob(paths, self.patterns) is None:
+            return None
+        return PolicyDecision(action=self.action, reason_code=self.reason_code)
+
+
+class PolicyAssessorRegistry:
+    """Ordered, mutable collection of :class:`PolicyAssessor`\\ s.
+
+    The extension point consumers use to register additional deterministic checks
+    alongside the built-ins. A fresh registry is empty, so it contributes nothing
+    until something is registered.
+    """
+
+    __slots__ = ("_assessors",)
+
+    def __init__(self, assessors: Iterable[PolicyAssessor] = ()) -> None:
+        self._assessors: list[PolicyAssessor] = list(assessors)
+
+    def register(self, assessor: PolicyAssessor) -> PolicyAssessorRegistry:
+        """Register an assessor; returns self for chaining."""
+        self._assessors.append(assessor)
+        return self
+
+    @property
+    def assessors(self) -> tuple[PolicyAssessor, ...]:
+        """The registered assessors, in registration order."""
+        return tuple(self._assessors)
+
+    def __len__(self) -> int:
+        return len(self._assessors)

--- a/src/traceforge/governance/state.py
+++ b/src/traceforge/governance/state.py
@@ -6,9 +6,14 @@ import json
 import sqlite3
 import threading
 from collections import Counter, deque
+from collections.abc import Iterable
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from traceforge.governance.types import TrustGrant
 
 _BUDGET_DIMENSIONS = (
     "effect",
@@ -76,6 +81,7 @@ class SessionStateSnapshot:
     budget: BudgetSnapshot
     phase_window: tuple[str, ...] = ()
     taint_ledger: tuple[TaintEntry, ...] = ()
+    trust_grants: tuple[TrustGrant, ...] = ()
     last_assistant_event_id: str | None = None
     last_user_event_id: str | None = None
     event_count: int = 0
@@ -112,6 +118,9 @@ class SessionState:
     _denied_count: int = 0
     _prior_verdicts: deque = field(default_factory=lambda: deque(maxlen=100))
     _prior_tool_call_ids: deque = field(default_factory=lambda: deque(maxlen=100))
+    # Time-boxed trust grants for this session. Initialized in __post_init__ so
+    # the default is a fresh, independent store per instance (not a shared one).
+    _trust_grants: TrustGrantStore | None = None
 
     PHASE_WINDOW_SIZE: int = 20
     TAINT_LEDGER_MAX: int = 200
@@ -128,6 +137,14 @@ class SessionState:
                 "action": Counter(),
                 "structure": Counter(),
             }
+        if self._trust_grants is None:
+            self._trust_grants = TrustGrantStore()
+
+    @property
+    def trust_grants(self) -> TrustGrantStore:
+        """The session's trust-grant store (empty by default)."""
+        assert self._trust_grants is not None  # established in __post_init__
+        return self._trust_grants
 
     def attach_db(
         self, db: sqlite3.Connection | None, lock: "threading.Lock | None" = None
@@ -274,6 +291,7 @@ class SessionState:
             _dropped_events=self._dropped_events,
             _last_sequence=self._last_sequence,
             _gap_ordinal=self._gap_ordinal,
+            _trust_grants=TrustGrantStore(self.trust_grants.all_grants()),
             _db=None,
         )
 
@@ -297,6 +315,7 @@ class SessionState:
             budget=budget,
             phase_window=tuple(self._phase_window),
             taint_ledger=tuple(self._taint_ledger),
+            trust_grants=self.trust_grants.all_grants(),
             last_assistant_event_id=self._last_assistant_event_id,
             last_user_event_id=self._last_user_event_id,
             event_count=self._event_count,
@@ -365,6 +384,23 @@ class SessionState:
                     t.payload_pointer,
                 ),
             )
+        # Normalized trust grants: ordinal preserves insert order and permits
+        # duplicate keys. Expiry is derived at read time from granted_at + ttl,
+        # so no "active" flag is stored. Full rewrite mirrors the taint ledger.
+        self._db.execute("DELETE FROM trust_grants WHERE session_id = ?", (self.session_id,))
+        for ordinal, g in enumerate(self.trust_grants.all_grants()):
+            self._db.execute(
+                "INSERT INTO trust_grants (session_id, ordinal, key, granted_at, "
+                "ttl_seconds, reason) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    self.session_id,
+                    ordinal,
+                    g.key,
+                    g.granted_at.isoformat(),
+                    g.ttl_seconds,
+                    g.reason,
+                ),
+            )
 
     def persist(self) -> None:
         """Write-through to SQLite (self-committing, single-writer safe).
@@ -422,6 +458,31 @@ class SessionState:
             for r in rows
         ]
 
+    @staticmethod
+    def _read_trust_grants(db: sqlite3.Connection, session_id: str) -> list["TrustGrant"]:
+        """Read the persisted trust grants, ordered by insert ordinal.
+
+        ``granted_at`` round-trips through ISO-8601 (``datetime.fromisoformat``),
+        preserving whatever tz-awareness the grant was created with. Expiry is
+        recomputed from ``granted_at`` + ``ttl_seconds`` at query time.
+        """
+        from traceforge.governance.types import TrustGrant
+
+        rows = db.execute(
+            "SELECT key, granted_at, ttl_seconds, reason "
+            "FROM trust_grants WHERE session_id = ? ORDER BY ordinal",
+            (session_id,),
+        ).fetchall()
+        return [
+            TrustGrant(
+                key=r[0],
+                granted_at=datetime.fromisoformat(r[1]),
+                ttl_seconds=r[2],
+                reason=r[3] or "",
+            )
+            for r in rows
+        ]
+
     @classmethod
     def load_from_db(
         cls,
@@ -460,7 +521,65 @@ class SessionState:
             state._last_assistant_event_id = row[5]
             state._last_user_event_id = row[6]
             state._taint_ledger = cls._read_taint_entries(db, session_id)
+            state._trust_grants = TrustGrantStore(cls._read_trust_grants(db, session_id))
             state._event_count = row[7] or 0
             state._dropped_events = row[8] or 0
             state._last_sequence = row[9]
         return state
+
+
+class TrustGrantStore:
+    """In-memory collection of :class:`TrustGrant`\\ s with lazy TTL expiry.
+
+    A general governance primitive: it holds opaque-keyed grants and answers
+    "is there an active grant for key *K* at time *now*?". Grants carry no
+    consumer-specific meaning here — ``key`` is an opaque token whose vocabulary
+    the consumer owns. Expiry is by TTL only and is always evaluated against an
+    explicit ``now`` (never a wall clock), so the store is fully deterministic
+    and testable.
+
+    The store is not internally locked; callers that share it across threads
+    should serialize mutation the same way :class:`SessionState` does. Query
+    methods are pure and take a snapshot of ``now``, so a grant "auto-expires"
+    the instant ``now`` reaches its ``expires_at`` — no background sweep needed.
+    :meth:`prune` is an optional convenience to drop permanently-expired grants
+    (e.g. before persisting).
+    """
+
+    __slots__ = ("_grants",)
+
+    def __init__(self, grants: Iterable[TrustGrant] = ()) -> None:
+        self._grants: list[TrustGrant] = list(grants)
+
+    def add(self, grant: TrustGrant) -> None:
+        """Append a grant to the store."""
+        self._grants.append(grant)
+
+    def all_grants(self) -> tuple[TrustGrant, ...]:
+        """Return every stored grant (active, pending, or expired) in insert order."""
+        return tuple(self._grants)
+
+    def active(self, now: datetime) -> tuple[TrustGrant, ...]:
+        """Return the grants active at ``now`` (in insert order)."""
+        return tuple(g for g in self._grants if g.is_active(now))
+
+    def active_keys(self, now: datetime) -> frozenset[str]:
+        """Return the set of keys with at least one active grant at ``now``."""
+        return frozenset(g.key for g in self._grants if g.is_active(now))
+
+    def has_active(self, key: str, now: datetime) -> bool:
+        """Whether any grant for ``key`` is active at ``now``."""
+        return any(g.key == key and g.is_active(now) for g in self._grants)
+
+    def prune(self, now: datetime) -> int:
+        """Drop grants permanently expired at ``now``; return the number removed.
+
+        A grant is dropped only when ``now >= expires_at`` (it can never be active
+        again). Not-yet-active future grants are retained.
+        """
+        before = len(self._grants)
+        self._grants = [g for g in self._grants if now < g.expires_at]
+        return before - len(self._grants)
+
+    def __len__(self) -> int:
+        return len(self._grants)

--- a/src/traceforge/governance/types.py
+++ b/src/traceforge/governance/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Literal
 
 from traceforge.classify.core import Classification
@@ -174,3 +174,37 @@ class EnrichmentContext:
     engine: Literal["shell", "mcp", "coding"]
     drift_baseline: tuple[tuple[str, float], ...] | None
     mcp_profile_key: str | None
+
+
+@dataclass(frozen=True)
+class TrustGrant:
+    """A time-boxed trust grant — a general governance primitive.
+
+    While active (``granted_at <= now < expires_at``), a grant lets a consumer
+    waive a policy escalation it would otherwise incur. TraceForge assigns *no*
+    meaning to ``key``: it is an opaque token whose vocabulary the consumer owns
+    (e.g. a policy label it wants to waive, a tool name, a capability). The
+    governance layer only checks activeness by TTL and matches ``key`` equality —
+    the mechanism is general; the values are supplied by the consumer via config.
+
+    Time is always passed in explicitly (never read from a wall clock inside this
+    type), so grant activeness — and therefore TTL expiry — is fully deterministic
+    and testable.
+
+    A non-positive ``ttl_seconds`` yields ``expires_at == granted_at``, i.e. an
+    inert grant that is never active — a safe default for a mis-supplied value.
+    """
+
+    key: str
+    granted_at: datetime
+    ttl_seconds: float
+    reason: str = ""
+
+    @property
+    def expires_at(self) -> datetime:
+        """Instant at (and after) which the grant is no longer active."""
+        return self.granted_at + timedelta(seconds=max(self.ttl_seconds, 0.0))
+
+    def is_active(self, now: datetime) -> bool:
+        """Whether the grant is active at ``now`` (half-open ``[granted_at, expires_at)``)."""
+        return self.granted_at <= now < self.expires_at

--- a/src/traceforge/migrations/models.py
+++ b/src/traceforge/migrations/models.py
@@ -118,6 +118,21 @@ taint_entries = Table(
     PrimaryKeyConstraint("session_id", "ordinal"),
 )
 
+# One row per time-boxed trust grant. ``ordinal`` preserves insert order and
+# lets multiple grants for the same opaque ``key`` coexist. Activeness is derived
+# from granted_at + ttl_seconds at read time; there is no stored active flag.
+trust_grants = Table(
+    "trust_grants",
+    metadata,
+    Column("session_id", Text, nullable=False),
+    Column("ordinal", Integer, nullable=False),
+    Column("key", Text, nullable=False),
+    Column("granted_at", Text, nullable=False),
+    Column("ttl_seconds", Float, nullable=False),
+    Column("reason", Text, nullable=False, server_default=""),
+    PrimaryKeyConstraint("session_id", "ordinal"),
+)
+
 # Scalar MCP tool fingerprint. The many-valued role/capability/scope attributes
 # live in mcp_profile_attributes below (1NF), one row per value.
 mcp_profiles = Table(

--- a/src/traceforge/migrations/versions/0001_initial.py
+++ b/src/traceforge/migrations/versions/0001_initial.py
@@ -116,6 +116,23 @@ def upgrade() -> None:
         )
     """)
 
+    # ── Time-boxed trust grants ──
+    # One row per grant; ordinal preserves insert order and lets multiple grants
+    # for the same opaque key coexist. Activeness/expiry is computed from
+    # granted_at + ttl_seconds at read time — no stored "active" flag to keep in
+    # sync. ``key`` carries no schema-level meaning (a consumer-owned token).
+    conn.exec_driver_sql("""
+        CREATE TABLE IF NOT EXISTS trust_grants (
+            session_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            key TEXT NOT NULL,
+            granted_at TEXT NOT NULL,
+            ttl_seconds REAL NOT NULL,
+            reason TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (session_id, ordinal)
+        )
+    """)
+
     conn.exec_driver_sql("""
         CREATE TABLE IF NOT EXISTS drift_baselines (
             agent_model TEXT NOT NULL,
@@ -169,6 +186,7 @@ def downgrade() -> None:
     op.drop_table("session_summaries")
     op.drop_table("content_hashes")
     op.drop_table("drift_baselines")
+    op.drop_table("trust_grants")
     op.drop_table("taint_entries")
     op.drop_table("budget_counters")
     op.drop_table("mcp_profile_attributes")

--- a/tests/unit/test_governance_cost_ceiling.py
+++ b/tests/unit/test_governance_cost_ceiling.py
@@ -1,0 +1,140 @@
+"""Deterministic tests for the cost-ceiling action primitive (U10).
+
+Budget tracking already computes a ``pressure`` flag and counters but takes no
+action. ``CostCeiling`` + ``ceiling_action`` + ``CostCeilingAssessor`` supply the
+missing policy: mapping an already-computed budget snapshot to an escalate/deny
+action. TraceForge supplies the mechanism; the consumer supplies the action and
+the hard ceiling via config. All fields default to *off*.
+"""
+
+from datetime import datetime, timezone
+
+from traceforge.classify.core import Classification
+from traceforge.governance.budget import CostCeiling, CostCeilingAssessor, ceiling_action
+from traceforge.governance.results import RecommendedAction
+from traceforge.governance.state import BudgetSnapshot, SessionStateSnapshot
+from traceforge.governance.types import EnrichmentContext, ToolCallEvent
+
+NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def _snapshot(*, total_tool_calls: int = 0, pressure: bool = False) -> SessionStateSnapshot:
+    return SessionStateSnapshot(
+        budget=BudgetSnapshot(total_tool_calls=total_tool_calls, pressure=pressure),
+        event_count=total_tool_calls,
+    )
+
+
+def _ctx(snapshot: SessionStateSnapshot | None) -> EnrichmentContext:
+    event = ToolCallEvent(
+        event_id="e1",
+        session_id="s1",
+        timestamp=NOW,
+        source_event_key="k1",
+        span_id="sp1",
+        tool_name="bash",
+        server_namespace=None,
+        tool_args_json="{}",
+        source_event_id=None,
+    )
+    return EnrichmentContext(
+        event=event,
+        base_classification=Classification(mechanism="shell.execute"),
+        command_analysis=None,
+        session_state=snapshot,
+        mcp_profiles=None,
+        project_root=None,
+        engine="shell",
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+# ─── ceiling_action (pure mapping) ───────────────────────────────────────────
+
+
+class TestCeilingAction:
+    def test_no_ceiling_returns_none(self):
+        assert ceiling_action(BudgetSnapshot(pressure=True), None) is None
+
+    def test_default_ceiling_is_off(self):
+        # pressure_action=None, hard_max_tool_calls=None → never fires.
+        ceiling = CostCeiling()
+        assert ceiling_action(BudgetSnapshot(pressure=True, total_tool_calls=999), ceiling) is None
+
+    def test_pressure_maps_to_configured_action(self):
+        ceiling = CostCeiling(pressure_action=RecommendedAction.ESCALATE)
+        assert ceiling_action(BudgetSnapshot(pressure=True), ceiling) == RecommendedAction.ESCALATE
+
+    def test_no_pressure_no_action(self):
+        ceiling = CostCeiling(pressure_action=RecommendedAction.ESCALATE)
+        assert ceiling_action(BudgetSnapshot(pressure=False), ceiling) is None
+
+    def test_hard_ceiling_fires_at_threshold(self):
+        ceiling = CostCeiling(hard_max_tool_calls=10)
+        snap = BudgetSnapshot(total_tool_calls=10)
+        assert ceiling_action(snap, ceiling) == RecommendedAction.DENY
+
+    def test_hard_ceiling_below_threshold_no_action(self):
+        ceiling = CostCeiling(hard_max_tool_calls=10)
+        assert ceiling_action(BudgetSnapshot(total_tool_calls=9), ceiling) is None
+
+    def test_hard_ceiling_custom_action(self):
+        ceiling = CostCeiling(hard_max_tool_calls=5, hard_action=RecommendedAction.ESCALATE)
+        assert (
+            ceiling_action(BudgetSnapshot(total_tool_calls=6), ceiling)
+            == RecommendedAction.ESCALATE
+        )
+
+    def test_hard_ceiling_takes_precedence_over_pressure(self):
+        ceiling = CostCeiling(
+            pressure_action=RecommendedAction.ESCALATE,
+            hard_max_tool_calls=10,
+            hard_action=RecommendedAction.DENY,
+        )
+        snap = BudgetSnapshot(total_tool_calls=10, pressure=True)
+        # Hard ceiling (DENY) wins over soft pressure (ESCALATE).
+        assert ceiling_action(snap, ceiling) == RecommendedAction.DENY
+
+
+# ─── CostCeilingAssessor ─────────────────────────────────────────────────────
+
+
+class TestCostCeilingAssessor:
+    def test_no_ceiling_never_fires(self):
+        assessor = CostCeilingAssessor()  # ceiling defaults to None
+        assert assessor.assess(_ctx(_snapshot(pressure=True)), NOW) is None
+
+    def test_none_snapshot_returns_none(self):
+        assessor = CostCeilingAssessor(ceiling=CostCeiling(pressure_action=RecommendedAction.DENY))
+        assert assessor.assess(_ctx(None), NOW) is None
+
+    def test_fires_on_pressure(self):
+        assessor = CostCeilingAssessor(
+            ceiling=CostCeiling(pressure_action=RecommendedAction.ESCALATE)
+        )
+        decision = assessor.assess(_ctx(_snapshot(pressure=True)), NOW)
+        assert decision is not None
+        assert decision.action == RecommendedAction.ESCALATE
+        assert decision.reason_code == "cost_ceiling"
+
+    def test_no_pressure_no_fire(self):
+        assessor = CostCeilingAssessor(
+            ceiling=CostCeiling(pressure_action=RecommendedAction.ESCALATE)
+        )
+        assert assessor.assess(_ctx(_snapshot(pressure=False)), NOW) is None
+
+    def test_fires_on_hard_ceiling(self):
+        assessor = CostCeilingAssessor(ceiling=CostCeiling(hard_max_tool_calls=3))
+        decision = assessor.assess(_ctx(_snapshot(total_tool_calls=3)), NOW)
+        assert decision is not None
+        assert decision.action == RecommendedAction.DENY
+
+    def test_custom_reason_code(self):
+        assessor = CostCeilingAssessor(
+            ceiling=CostCeiling(pressure_action=RecommendedAction.DENY),
+            reason_code="over_budget",
+        )
+        decision = assessor.assess(_ctx(_snapshot(pressure=True)), NOW)
+        assert decision is not None
+        assert decision.reason_code == "over_budget"

--- a/tests/unit/test_governance_policy_config.py
+++ b/tests/unit/test_governance_policy_config.py
@@ -175,3 +175,61 @@ class TestEndToEndZeroChange:
     def test_default_pipeline_builds_no_policy_assessors(self):
         cfg = GovernanceConfig()
         assert _build_policy_assessors(cfg.policy) == ()
+
+
+# A battery of diverse tool calls that do NOT touch a protected path, spanning
+# several rule-engine outcomes (benign read, destructive shell, network egress,
+# ordinary write). Session ids are pipeline-local (each pipeline has its own
+# in-memory DB), so reuse across pipelines is isolated.
+_NONMATCHING_PAYLOADS = [
+    {"tool_name": "read_file", "tool_input": {"path": "/repo/src/main.py"}, "session_id": "z1"},
+    {"tool_name": "bash", "tool_input": {"command": "rm -rf /tmp/build"}, "session_id": "z2"},
+    {"tool_name": "bash", "tool_input": {"command": "curl http://example.com"}, "session_id": "z3"},
+    {"tool_name": "write_file", "tool_input": {"path": "/repo/src/app.py"}, "session_id": "z4"},
+    {"tool_name": "bash", "tool_input": {"command": "ls -la"}, "session_id": "z5"},
+]
+
+
+def _decision(trace):
+    """The gating-relevant decision surface of an EventTrace."""
+    return (trace.suggested_action, trace.risk_score, trace.reason)
+
+
+class TestConfiguredPolicyInertOnNonMatchingEvents:
+    """The single most important regression guard.
+
+    A pipeline with a *configured* policy must produce byte-identical decisions to
+    a default (no-policy) pipeline for every event that does not match the policy.
+    This proves the overlay is completely inert except on the events it targets —
+    the strongest form of "default-off = zero behavior change".
+    """
+
+    def _configured(self):
+        cfg = GovernanceConfig(
+            policy=PolicyConfig(
+                protected_paths=ProtectedPathsPolicyConfig(
+                    patterns=["**/secrets/**"], action="escalate"
+                ),
+                cost_ceiling=CostCeilingPolicyConfig(
+                    pressure_action="escalate", hard_max_tool_calls=10_000
+                ),
+            )
+        )
+        return GovernancePipeline.create(cfg)
+
+    def test_configured_policy_matches_default_on_nonmatching_events(self):
+        default_pipe = GovernancePipeline.create()
+        policy_pipe = self._configured()
+        for payload in _NONMATCHING_PAYLOADS:
+            base = default_pipe.score_tool_call(dict(payload))
+            with_policy = policy_pipe.score_tool_call(dict(payload))
+            assert _decision(with_policy) == _decision(base), payload["tool_name"]
+
+    def test_empty_policyconfig_matches_omitted_policy(self):
+        # Supplying an explicit empty PolicyConfig() is identical to omitting it.
+        omitted = GovernancePipeline.create(GovernanceConfig())
+        explicit = GovernancePipeline.create(GovernanceConfig(policy=PolicyConfig()))
+        for payload in _NONMATCHING_PAYLOADS + [dict(_SECRETS_PAYLOAD)]:
+            a = omitted.score_tool_call(dict(payload))
+            b = explicit.score_tool_call(dict(payload))
+            assert _decision(a) == _decision(b), payload["tool_name"]

--- a/tests/unit/test_governance_policy_config.py
+++ b/tests/unit/test_governance_policy_config.py
@@ -1,0 +1,177 @@
+"""Config-model and end-to-end tests for the U10 policy primitives.
+
+Proves the consumer-supplied config chain wires into working assessors and that
+the whole stack — config → assessor → scoring → overlay → grants — behaves, while
+a default (empty) policy leaves ``score_tool_call`` output unchanged.
+"""
+
+import pytest
+
+from traceforge.config.models import (
+    CostCeilingPolicyConfig,
+    GovernanceConfig,
+    PolicyConfig,
+    ProtectedPathsPolicyConfig,
+)
+from traceforge.governance.budget import CostCeilingAssessor
+from traceforge.governance.pipeline import GovernancePipeline, _build_policy_assessors
+from traceforge.governance.rules import ProtectedPathAssessor
+
+
+# ─── Config models: defaults off + strict validation ─────────────────────────
+
+
+class TestPolicyConfigDefaults:
+    def test_policy_config_defaults_empty(self):
+        cfg = PolicyConfig()
+        assert cfg.protected_paths.patterns == []
+        assert cfg.protected_paths.action == "escalate"
+        assert cfg.cost_ceiling.pressure_action is None
+        assert cfg.cost_ceiling.hard_max_tool_calls is None
+        assert cfg.cost_ceiling.hard_action == "deny"
+
+    def test_governance_config_has_default_policy(self):
+        gov = GovernanceConfig()
+        assert isinstance(gov.policy, PolicyConfig)
+        assert gov.policy.protected_paths.patterns == []
+
+    def test_protected_paths_rejects_unknown_field(self):
+        with pytest.raises(Exception):
+            ProtectedPathsPolicyConfig(pattern=["oops"])  # singular typo
+
+    def test_cost_ceiling_rejects_unknown_field(self):
+        with pytest.raises(Exception):
+            CostCeilingPolicyConfig(ceiling=5)
+
+    def test_policy_config_rejects_unknown_field(self):
+        with pytest.raises(Exception):
+            PolicyConfig(protected_path={})  # singular typo
+
+    def test_action_literal_validation(self):
+        with pytest.raises(Exception):
+            ProtectedPathsPolicyConfig(action="halt")  # not escalate/deny
+
+    def test_hard_max_tool_calls_must_be_positive(self):
+        with pytest.raises(Exception):
+            CostCeilingPolicyConfig(hard_max_tool_calls=0)
+
+    def test_valid_full_config(self):
+        cfg = PolicyConfig(
+            protected_paths=ProtectedPathsPolicyConfig(patterns=["**/secrets/**"], action="deny"),
+            cost_ceiling=CostCeilingPolicyConfig(
+                pressure_action="escalate", hard_max_tool_calls=100
+            ),
+        )
+        assert cfg.protected_paths.action == "deny"
+        assert cfg.cost_ceiling.hard_max_tool_calls == 100
+
+
+# ─── _build_policy_assessors: config → assessors ─────────────────────────────
+
+
+class TestBuildPolicyAssessors:
+    def test_empty_config_builds_no_assessors(self):
+        assert _build_policy_assessors(PolicyConfig()) == ()
+
+    def test_protected_paths_builds_assessor(self):
+        cfg = PolicyConfig(
+            protected_paths=ProtectedPathsPolicyConfig(patterns=["*.pem"], action="deny")
+        )
+        assessors = _build_policy_assessors(cfg)
+        assert len(assessors) == 1
+        assert isinstance(assessors[0], ProtectedPathAssessor)
+        assert assessors[0].patterns == ("*.pem",)
+
+    def test_cost_ceiling_builds_assessor_on_pressure_action(self):
+        cfg = PolicyConfig(cost_ceiling=CostCeilingPolicyConfig(pressure_action="escalate"))
+        assessors = _build_policy_assessors(cfg)
+        assert len(assessors) == 1
+        assert isinstance(assessors[0], CostCeilingAssessor)
+
+    def test_cost_ceiling_builds_assessor_on_hard_ceiling(self):
+        cfg = PolicyConfig(cost_ceiling=CostCeilingPolicyConfig(hard_max_tool_calls=50))
+        assessors = _build_policy_assessors(cfg)
+        assert len(assessors) == 1
+        assert isinstance(assessors[0], CostCeilingAssessor)
+
+    def test_both_configured_builds_two(self):
+        cfg = PolicyConfig(
+            protected_paths=ProtectedPathsPolicyConfig(patterns=["*.pem"]),
+            cost_ceiling=CostCeilingPolicyConfig(pressure_action="deny"),
+        )
+        assert len(_build_policy_assessors(cfg)) == 2
+
+
+# ─── End-to-end via GovernancePipeline.score_tool_call ───────────────────────
+
+_SECRETS_PAYLOAD = {
+    "tool_name": "read_file",
+    "tool_input": {"path": "/repo/secrets/prod.pem"},
+    "session_id": "sess-e2e",
+}
+
+
+def _action(trace):
+    return trace.suggested_action
+
+
+class TestEndToEndProtectedPath:
+    def _pipeline(self):
+        cfg = GovernanceConfig(
+            policy=PolicyConfig(
+                protected_paths=ProtectedPathsPolicyConfig(
+                    patterns=["**/secrets/**"], action="escalate"
+                )
+            )
+        )
+        return GovernancePipeline.create(cfg)
+
+    def test_protected_path_escalates(self):
+        pipe = self._pipeline()
+        trace = pipe.score_tool_call(_SECRETS_PAYLOAD)
+        assert _action(trace) == "escalate"
+
+    def test_normal_path_unaffected(self):
+        pipe = self._pipeline()
+        trace = pipe.score_tool_call(
+            {
+                "tool_name": "read_file",
+                "tool_input": {"path": "/repo/src/main.py"},
+                "session_id": "sess-normal",
+            }
+        )
+        assert _action(trace) is None
+
+    def test_active_grant_waives_escalation(self):
+        pipe = self._pipeline()
+        # Without a grant: escalates.
+        assert _action(pipe.score_tool_call(_SECRETS_PAYLOAD)) == "escalate"
+        # Grant trust keyed to the protected_path reason code for this session.
+        pipe.grant_trust("sess-e2e", "protected_path", ttl_seconds=3600)
+        # Now waived.
+        assert _action(pipe.score_tool_call(_SECRETS_PAYLOAD)) is None
+
+    def test_grant_scoped_to_session(self):
+        pipe = self._pipeline()
+        pipe.grant_trust("sess-e2e", "protected_path", ttl_seconds=3600)
+        # A DIFFERENT session touching the same protected path still escalates.
+        other = {
+            "tool_name": "read_file",
+            "tool_input": {"path": "/repo/secrets/prod.pem"},
+            "session_id": "sess-other",
+        }
+        assert _action(pipe.score_tool_call(other)) == "escalate"
+
+
+class TestEndToEndZeroChange:
+    """A default (empty) policy must not alter score_tool_call output."""
+
+    def test_default_pipeline_secrets_read_unchanged(self):
+        pipe = GovernancePipeline.create()  # no policy
+        trace = pipe.score_tool_call(_SECRETS_PAYLOAD)
+        # The benign read is not escalated by any protected-path policy.
+        assert _action(trace) is None
+
+    def test_default_pipeline_builds_no_policy_assessors(self):
+        cfg = GovernanceConfig()
+        assert _build_policy_assessors(cfg.policy) == ()

--- a/tests/unit/test_governance_policy_overlay.py
+++ b/tests/unit/test_governance_policy_overlay.py
@@ -1,0 +1,225 @@
+"""Deterministic tests for the policy-overlay extension point (U10).
+
+The overlay folds registered ``PolicyAssessor`` decisions and trust-grant waivers
+over the base rule-engine match. The single most important property proven here:
+**with no assessors and no active grants the base match is returned UNCHANGED (by
+identity)** — an empty/default policy is a guaranteed no-op, so existing gating
+cannot regress.
+"""
+
+from datetime import datetime, timezone
+
+from traceforge.classify.core import Classification
+from traceforge.governance.results import RecommendedAction
+from traceforge.governance.rules import (
+    PolicyAssessor,
+    PolicyAssessorRegistry,
+    PolicyDecision,
+    RecommendationTemplate,
+    RuleMatch,
+    apply_policy_overlay,
+    combine_policy_decisions,
+)
+from traceforge.governance.types import EnrichmentContext, ToolCallEvent
+
+NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def _match(action: RecommendedAction, reason_code: str, *, message: str | None = None) -> RuleMatch:
+    return RuleMatch(
+        template=RecommendationTemplate(
+            recommended_action=action, reason_code=reason_code, message=message
+        ),
+        rule_id=f"rule:{reason_code}",
+        matched_predicates=(),
+    )
+
+
+def _ctx() -> EnrichmentContext:
+    event = ToolCallEvent(
+        event_id="e1",
+        session_id="s1",
+        timestamp=NOW,
+        source_event_key="k1",
+        span_id="sp1",
+        tool_name="bash",
+        server_namespace=None,
+        tool_args_json="{}",
+        source_event_id=None,
+    )
+    return EnrichmentContext(
+        event=event,
+        base_classification=Classification(mechanism="shell.execute"),
+        command_analysis=None,
+        session_state=None,
+        mcp_profiles=None,
+        project_root=None,
+        engine="shell",
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+class _FixedAssessor:
+    """A minimal ``PolicyAssessor`` returning a preset decision."""
+
+    def __init__(self, decision: PolicyDecision | None) -> None:
+        self._decision = decision
+
+    def assess(self, ctx: EnrichmentContext, now: datetime) -> PolicyDecision | None:
+        return self._decision
+
+
+# ─── combine_policy_decisions ────────────────────────────────────────────────
+
+
+class TestCombinePolicyDecisions:
+    def test_none_base_takes_overlay(self):
+        overlay = PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="x")
+        assert combine_policy_decisions(None, [overlay]) == overlay
+
+    def test_higher_severity_overlay_wins(self):
+        base = PolicyDecision(action=RecommendedAction.WARN, reason_code="b")
+        overlay = PolicyDecision(action=RecommendedAction.DENY, reason_code="o")
+        assert combine_policy_decisions(base, [overlay]) == overlay
+
+    def test_base_wins_over_lower_severity_overlay(self):
+        base = PolicyDecision(action=RecommendedAction.DENY, reason_code="b")
+        overlay = PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="o")
+        assert combine_policy_decisions(base, [overlay]) == base
+
+    def test_tie_keeps_incumbent_base(self):
+        base = PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="b")
+        overlay = PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="o")
+        # Equal severity → base is kept (by identity), order-independent.
+        assert combine_policy_decisions(base, [overlay]) is base
+
+    def test_ignores_none_overlays(self):
+        base = PolicyDecision(action=RecommendedAction.WARN, reason_code="b")
+        assert combine_policy_decisions(base, [None, None]) == base
+
+    def test_all_none(self):
+        assert combine_policy_decisions(None, [None]) is None
+
+
+# ─── apply_policy_overlay: the zero-change proof ─────────────────────────────
+
+
+class TestApplyPolicyOverlayIdentity:
+    def test_no_assessors_no_grants_returns_same_object(self):
+        base = _match(RecommendedAction.ESCALATE, "rule_x", message="hi")
+        result = apply_policy_overlay(base, _ctx(), NOW)
+        # CRITICAL: identical object, not merely equal — zero behavior change.
+        assert result is base
+
+    def test_none_base_unchanged_when_empty(self):
+        assert apply_policy_overlay(None, _ctx(), NOW) is None
+
+    def test_abstaining_assessor_preserves_base_identity(self):
+        base = _match(RecommendedAction.ESCALATE, "rule_x", message="hi")
+        assessor = _FixedAssessor(None)
+        # Assessor present but abstains, no grants: the ORIGINAL match (with its
+        # message/template) is preserved by identity.
+        result = apply_policy_overlay(base, _ctx(), NOW, [assessor])
+        assert result is base
+
+    def test_lower_severity_assessor_preserves_base_identity(self):
+        base = _match(RecommendedAction.DENY, "rule_x")
+        assessor = _FixedAssessor(PolicyDecision(action=RecommendedAction.WARN, reason_code="w"))
+        result = apply_policy_overlay(base, _ctx(), NOW, [assessor])
+        assert result is base
+
+
+class TestApplyPolicyOverlayEscalation:
+    def test_assessor_raises_from_allow(self):
+        assessor = _FixedAssessor(
+            PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="protected_path")
+        )
+        result = apply_policy_overlay(None, _ctx(), NOW, [assessor])
+        assert result is not None
+        assert result.template.recommended_action == RecommendedAction.ESCALATE
+        assert result.template.reason_code == "protected_path"
+        assert result.rule_id == "policy:protected_path"
+
+    def test_assessor_escalates_over_warn_base(self):
+        base = _match(RecommendedAction.WARN, "warn_rule")
+        assessor = _FixedAssessor(
+            PolicyDecision(action=RecommendedAction.DENY, reason_code="cost_ceiling")
+        )
+        result = apply_policy_overlay(base, _ctx(), NOW, [assessor])
+        assert result is not None
+        assert result.template.recommended_action == RecommendedAction.DENY
+        assert result.template.reason_code == "cost_ceiling"
+
+
+class TestApplyPolicyOverlayGrantWaiver:
+    def test_active_grant_waives_assessor_escalation(self):
+        assessor = _FixedAssessor(
+            PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="protected_path")
+        )
+        result = apply_policy_overlay(None, _ctx(), NOW, [assessor], frozenset({"protected_path"}))
+        assert result is None
+
+    def test_grant_waives_matching_base_rule_escalation(self):
+        # A grant waives ANY escalate/deny whose reason_code it matches, including
+        # a base rule's — the general waiver mechanism.
+        base = _match(RecommendedAction.ESCALATE, "protected_path")
+        result = apply_policy_overlay(base, _ctx(), NOW, (), frozenset({"protected_path"}))
+        assert result is None
+
+    def test_grant_does_not_waive_unmatched_reason(self):
+        base = _match(RecommendedAction.ESCALATE, "some_other_rule")
+        result = apply_policy_overlay(base, _ctx(), NOW, (), frozenset({"protected_path"}))
+        # Unmatched reason → base stands, preserved by identity.
+        assert result is base
+
+    def test_grant_only_present_still_hits_slow_path_but_preserves_allow(self):
+        # grant_keys non-empty but base is None and no assessors → stays None.
+        result = apply_policy_overlay(None, _ctx(), NOW, (), frozenset({"anything"}))
+        assert result is None
+
+
+# ─── PolicyAssessorRegistry ──────────────────────────────────────────────────
+
+
+class TestPolicyAssessorRegistry:
+    def test_empty_registry(self):
+        reg = PolicyAssessorRegistry()
+        assert len(reg) == 0
+        assert reg.assessors == ()
+
+    def test_register_appends_in_order(self):
+        a = _FixedAssessor(None)
+        b = _FixedAssessor(None)
+        reg = PolicyAssessorRegistry()
+        reg.register(a).register(b)
+        assert reg.assessors == (a, b)
+        assert len(reg) == 2
+
+    def test_register_returns_self_for_chaining(self):
+        reg = PolicyAssessorRegistry()
+        assert reg.register(_FixedAssessor(None)) is reg
+
+    def test_seeded_from_iterable(self):
+        a = _FixedAssessor(None)
+        reg = PolicyAssessorRegistry([a])
+        assert reg.assessors == (a,)
+
+    def test_registry_assessors_drive_overlay(self):
+        reg = PolicyAssessorRegistry()
+        reg.register(
+            _FixedAssessor(
+                PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="pluggable")
+            )
+        )
+        result = apply_policy_overlay(None, _ctx(), NOW, reg.assessors)
+        assert result is not None
+        assert result.template.reason_code == "pluggable"
+
+
+class TestProtocolMembership:
+    def test_fixed_assessor_satisfies_protocol(self):
+        # PolicyAssessor is a runtime-checkable structural protocol only by shape;
+        # confirm the minimal implementation is accepted where one is expected.
+        assessor: PolicyAssessor = _FixedAssessor(None)
+        assert assessor.assess(_ctx(), NOW) is None

--- a/tests/unit/test_governance_protected_paths.py
+++ b/tests/unit/test_governance_protected_paths.py
@@ -1,0 +1,208 @@
+"""Deterministic tests for the protected-path glob primitive (U10).
+
+Covers the general matcher (``normalize_path``, ``path_matches_glob``,
+``first_matching_glob``, ``extract_candidate_paths``) and the built-in
+``ProtectedPathAssessor``. The consumer supplies the glob patterns and the
+action; TraceForge supplies only the mechanism. With no patterns configured the
+assessor never fires.
+"""
+
+from datetime import datetime, timezone
+
+from traceforge.classify.core import Classification
+from traceforge.governance.results import RecommendedAction
+from traceforge.governance.rules import (
+    ProtectedPathAssessor,
+    extract_candidate_paths,
+    first_matching_glob,
+    normalize_path,
+    path_matches_glob,
+)
+from traceforge.governance.types import EnrichmentContext, ToolCallEvent
+
+NOW = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def _event(tool_args_json: str) -> ToolCallEvent:
+    return ToolCallEvent(
+        event_id="e1",
+        session_id="s1",
+        timestamp=NOW,
+        source_event_key="k1",
+        span_id="sp1",
+        tool_name="write_file",
+        server_namespace=None,
+        tool_args_json=tool_args_json,
+        source_event_id=None,
+    )
+
+
+def _ctx(event: ToolCallEvent) -> EnrichmentContext:
+    return EnrichmentContext(
+        event=event,
+        base_classification=Classification(mechanism="fs.write"),
+        command_analysis=None,
+        session_state=None,
+        mcp_profiles=None,
+        project_root=None,
+        engine="mcp",
+        drift_baseline=None,
+        mcp_profile_key=None,
+    )
+
+
+# ─── normalize_path ──────────────────────────────────────────────────────────
+
+
+class TestNormalizePath:
+    def test_backslashes_become_slashes(self):
+        assert normalize_path("a\\b\\c") == "a/b/c"
+
+    def test_lowercased(self):
+        assert normalize_path("Secrets/PROD.PEM") == "secrets/prod.pem"
+
+    def test_stripped(self):
+        assert normalize_path("  /x/y  ") == "/x/y"
+
+
+# ─── path_matches_glob ───────────────────────────────────────────────────────
+
+
+class TestPathMatchesGlob:
+    def test_star_within_segment(self):
+        assert path_matches_glob("dir/file.pem", "dir/*.pem") is True
+        # * does not cross a separator
+        assert path_matches_glob("dir/sub/file.pem", "dir/*.pem") is False
+
+    def test_double_star_crosses_separators(self):
+        assert path_matches_glob("a/b/c/file.pem", "a/**/file.pem") is True
+
+    def test_leading_double_star_matches_any_depth(self):
+        assert path_matches_glob("x/y/secrets/prod.key", "**/secrets/**") is True
+        # ** as a leading directory allows zero dirs too
+        assert path_matches_glob("secrets/prod.key", "**/secrets/**") is True
+
+    def test_question_mark_single_char(self):
+        assert path_matches_glob("a/fileX.txt", "a/file?.txt") is True
+        assert path_matches_glob("a/fileXX.txt", "a/file?.txt") is False
+
+    def test_slashless_pattern_matches_basename_anywhere(self):
+        assert path_matches_glob("/repo/deep/.env", ".env") is True
+        assert path_matches_glob("/repo/a/b/secret.pem", "*.pem") is True
+
+    def test_case_insensitive(self):
+        assert path_matches_glob("/repo/Secrets/Prod.PEM", "**/secrets/*.pem") is True
+
+    def test_backslash_paths_normalized(self):
+        assert path_matches_glob("C:\\repo\\secrets\\a.key", "**/secrets/**") is True
+
+    def test_empty_inputs_return_false(self):
+        assert path_matches_glob("", "*.pem") is False
+        assert path_matches_glob("a.pem", "") is False
+
+
+# ─── first_matching_glob ─────────────────────────────────────────────────────
+
+
+class TestFirstMatchingGlob:
+    def test_returns_first_pattern_in_order(self):
+        patterns = ["*.txt", "*.pem", "*.key"]
+        assert first_matching_glob(["a/b.pem"], patterns) == "*.pem"
+
+    def test_none_when_no_match(self):
+        assert first_matching_glob(["a/b.txt"], ["*.pem"]) is None
+
+    def test_empty_paths(self):
+        assert first_matching_glob([], ["*.pem"]) is None
+
+    def test_empty_patterns(self):
+        assert first_matching_glob(["a.pem"], []) is None
+
+
+# ─── extract_candidate_paths ─────────────────────────────────────────────────
+
+
+class TestExtractCandidatePaths:
+    def test_scalar_path_keys(self):
+        assert extract_candidate_paths('{"path": "/a/b.pem"}') == ("/a/b.pem",)
+
+    def test_multiple_keys_collected_in_key_order(self):
+        # 'path' precedes 'dest' in _PATH_ARG_KEYS
+        args = '{"dest": "/d.txt", "path": "/p.txt"}'
+        assert extract_candidate_paths(args) == ("/p.txt", "/d.txt")
+
+    def test_list_valued_keys(self):
+        assert extract_candidate_paths('{"paths": ["/a", "/b"]}') == ("/a", "/b")
+
+    def test_dedupes_preserving_first_seen(self):
+        args = '{"path": "/x", "src": "/x", "dest": "/y"}'
+        assert extract_candidate_paths(args) == ("/x", "/y")
+
+    def test_ignores_non_path_keys(self):
+        assert extract_candidate_paths('{"command": "rm -rf /"}') == ()
+
+    def test_malformed_json_returns_empty(self):
+        assert extract_candidate_paths("not json") == ()
+        assert extract_candidate_paths("") == ()
+
+    def test_non_object_json_returns_empty(self):
+        assert extract_candidate_paths("[1, 2, 3]") == ()
+
+    def test_non_string_scalar_ignored(self):
+        assert extract_candidate_paths('{"path": 123}') == ()
+
+
+# ─── ProtectedPathAssessor ───────────────────────────────────────────────────
+
+
+class TestProtectedPathAssessor:
+    def test_no_patterns_never_fires(self):
+        assessor = ProtectedPathAssessor()  # default: empty patterns
+        ctx = _ctx(_event('{"path": "/repo/secrets/prod.pem"}'))
+        assert assessor.assess(ctx, NOW) is None
+
+    def test_escalates_on_match(self):
+        assessor = ProtectedPathAssessor(patterns=("**/secrets/**",))
+        ctx = _ctx(_event('{"path": "/repo/secrets/prod.pem"}'))
+        decision = assessor.assess(ctx, NOW)
+        assert decision is not None
+        assert decision.action == RecommendedAction.ESCALATE
+        assert decision.reason_code == "protected_path"
+
+    def test_denies_when_configured(self):
+        assessor = ProtectedPathAssessor(patterns=("*.pem",), action=RecommendedAction.DENY)
+        ctx = _ctx(_event('{"path": "/repo/x/prod.pem"}'))
+        decision = assessor.assess(ctx, NOW)
+        assert decision is not None
+        assert decision.action == RecommendedAction.DENY
+
+    def test_no_match_returns_none(self):
+        assessor = ProtectedPathAssessor(patterns=("**/secrets/**",))
+        ctx = _ctx(_event('{"path": "/repo/src/main.py"}'))
+        assert assessor.assess(ctx, NOW) is None
+
+    def test_custom_reason_code(self):
+        assessor = ProtectedPathAssessor(patterns=("*.key",), reason_code="sensitive_key")
+        ctx = _ctx(_event('{"path": "/a/b.key"}'))
+        decision = assessor.assess(ctx, NOW)
+        assert decision is not None
+        assert decision.reason_code == "sensitive_key"
+
+    def test_non_toolcall_event_returns_none(self):
+        # A plain SessionEvent (not a ToolCallEvent) carries no tool args.
+        from traceforge.governance.types import SessionEvent
+
+        assessor = ProtectedPathAssessor(patterns=("*.pem",))
+        ev = SessionEvent(event_id="e", session_id="s", timestamp=NOW, source_event_key="k")
+        ctx = EnrichmentContext(
+            event=ev,
+            base_classification=Classification(mechanism="fs.write"),
+            command_analysis=None,
+            session_state=None,
+            mcp_profiles=None,
+            project_root=None,
+            engine="mcp",
+            drift_baseline=None,
+            mcp_profile_key=None,
+        )
+        assert assessor.assess(ctx, NOW) is None

--- a/tests/unit/test_governance_trust_grants.py
+++ b/tests/unit/test_governance_trust_grants.py
@@ -1,0 +1,229 @@
+"""Deterministic tests for the trust-grant primitive (U10).
+
+Covers the general, consumer-agnostic mechanism:
+  * ``TrustGrant`` TTL semantics (half-open activeness, inert non-positive TTL).
+  * ``TrustGrantStore`` query/prune behaviour.
+  * ``active_grant_keys`` / ``waive_by_grants`` overlay helpers.
+  * Durable persistence round-trip through ``SessionState`` (grant honored, then
+    expires by TTL → escalation no longer waived).
+
+Time is always supplied explicitly — no wall clock is read — so TTL expiry is
+fully deterministic.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from traceforge.governance.persistence import SystemStore
+from traceforge.governance.results import RecommendedAction
+from traceforge.governance.rules import (
+    PolicyDecision,
+    active_grant_keys,
+    waive_by_grants,
+)
+from traceforge.governance.state import SessionState, TrustGrantStore
+from traceforge.governance.types import TrustGrant
+
+T0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ─── TrustGrant TTL semantics ────────────────────────────────────────────────
+
+
+class TestTrustGrantActiveness:
+    def test_active_at_grant_instant(self):
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=60)
+        assert g.is_active(T0) is True
+
+    def test_active_within_window(self):
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=60)
+        assert g.is_active(T0 + timedelta(seconds=59)) is True
+
+    def test_inactive_before_grant(self):
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=60)
+        assert g.is_active(T0 - timedelta(seconds=1)) is False
+
+    def test_expiry_is_half_open(self):
+        # Exactly at expires_at the grant is NO longer active.
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=60)
+        assert g.expires_at == T0 + timedelta(seconds=60)
+        assert g.is_active(g.expires_at) is False
+
+    def test_inactive_after_expiry(self):
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=60)
+        assert g.is_active(T0 + timedelta(seconds=61)) is False
+
+    def test_zero_ttl_is_inert(self):
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=0)
+        assert g.expires_at == T0
+        assert g.is_active(T0) is False
+
+    def test_negative_ttl_is_inert(self):
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=-5)
+        assert g.expires_at == T0
+        assert g.is_active(T0) is False
+
+    def test_reason_defaults_empty(self):
+        g = TrustGrant(key="k", granted_at=T0, ttl_seconds=1)
+        assert g.reason == ""
+
+
+# ─── TrustGrantStore ─────────────────────────────────────────────────────────
+
+
+class TestTrustGrantStore:
+    def test_empty_store(self):
+        store = TrustGrantStore()
+        assert len(store) == 0
+        assert store.active(T0) == ()
+        assert store.active_keys(T0) == frozenset()
+        assert store.has_active("k", T0) is False
+        assert store.all_grants() == ()
+
+    def test_add_and_query_active(self):
+        store = TrustGrantStore()
+        store.add(TrustGrant(key="a", granted_at=T0, ttl_seconds=60))
+        store.add(TrustGrant(key="b", granted_at=T0, ttl_seconds=10))
+        assert len(store) == 2
+        # Both active at T0
+        assert store.active_keys(T0) == frozenset({"a", "b"})
+        # Only 'a' active after b expires
+        assert store.active_keys(T0 + timedelta(seconds=30)) == frozenset({"a"})
+        # Neither active after both expire
+        assert store.active_keys(T0 + timedelta(seconds=120)) == frozenset()
+
+    def test_has_active(self):
+        store = TrustGrantStore()
+        store.add(TrustGrant(key="a", granted_at=T0, ttl_seconds=60))
+        assert store.has_active("a", T0) is True
+        assert store.has_active("a", T0 + timedelta(seconds=120)) is False
+        assert store.has_active("missing", T0) is False
+
+    def test_all_grants_preserves_insert_order(self):
+        store = TrustGrantStore()
+        g1 = TrustGrant(key="a", granted_at=T0, ttl_seconds=1)
+        g2 = TrustGrant(key="b", granted_at=T0, ttl_seconds=1)
+        store.add(g1)
+        store.add(g2)
+        assert store.all_grants() == (g1, g2)
+
+    def test_prune_drops_only_permanently_expired(self):
+        store = TrustGrantStore()
+        store.add(TrustGrant(key="expired", granted_at=T0, ttl_seconds=10))
+        future = TrustGrant(key="future", granted_at=T0 + timedelta(hours=1), ttl_seconds=10)
+        store.add(future)
+        removed = store.prune(T0 + timedelta(seconds=30))
+        assert removed == 1
+        # The not-yet-active future grant is retained.
+        assert store.all_grants() == (future,)
+
+    def test_prune_retains_active(self):
+        store = TrustGrantStore()
+        store.add(TrustGrant(key="a", granted_at=T0, ttl_seconds=600))
+        removed = store.prune(T0 + timedelta(seconds=30))
+        assert removed == 0
+        assert len(store) == 1
+
+
+# ─── active_grant_keys / waive_by_grants overlay helpers ─────────────────────
+
+
+class TestActiveGrantKeys:
+    def test_collects_active_only(self):
+        grants = [
+            TrustGrant(key="live", granted_at=T0, ttl_seconds=100),
+            TrustGrant(key="dead", granted_at=T0, ttl_seconds=1),
+        ]
+        assert active_grant_keys(grants, T0 + timedelta(seconds=50)) == frozenset({"live"})
+
+    def test_empty_iterable(self):
+        assert active_grant_keys([], T0) == frozenset()
+
+    def test_naive_vs_aware_mismatch_is_conservative(self):
+        # A naive grant timestamp compared with an aware ``now`` raises TypeError
+        # internally; the grant simply does not count as active (safe default,
+        # since grants only ever waive an escalation).
+        naive = TrustGrant(key="k", granted_at=T0.replace(tzinfo=None), ttl_seconds=100)
+        assert active_grant_keys([naive], T0 + timedelta(seconds=1)) == frozenset()
+
+
+class TestWaiveByGrants:
+    def test_waives_escalate_when_key_matches(self):
+        d = PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="protected_path")
+        assert waive_by_grants(d, frozenset({"protected_path"})) is None
+
+    def test_waives_deny_when_key_matches(self):
+        d = PolicyDecision(action=RecommendedAction.DENY, reason_code="cost_ceiling")
+        assert waive_by_grants(d, frozenset({"cost_ceiling"})) is None
+
+    def test_does_not_waive_unmatched_reason(self):
+        d = PolicyDecision(action=RecommendedAction.ESCALATE, reason_code="protected_path")
+        assert waive_by_grants(d, frozenset({"other"})) == d
+
+    def test_does_not_waive_warn(self):
+        d = PolicyDecision(action=RecommendedAction.WARN, reason_code="k")
+        assert waive_by_grants(d, frozenset({"k"})) == d
+
+    def test_does_not_waive_allow(self):
+        d = PolicyDecision(action=RecommendedAction.ALLOW, reason_code="k")
+        assert waive_by_grants(d, frozenset({"k"})) == d
+
+    def test_none_decision_passes_through(self):
+        assert waive_by_grants(None, frozenset({"k"})) is None
+
+
+# ─── Durable persistence round-trip (grant honored → expires → denied) ───────
+
+
+class TestGrantPersistence:
+    def _store(self, tmp_path):
+        return SystemStore(tmp_path / "grants.db")
+
+    def test_grant_round_trips_through_db(self, tmp_path):
+        store = self._store(tmp_path)
+        try:
+            s1 = SessionState(session_id="sess")
+            s1.attach_db(store.connection)
+            s1.trust_grants.add(TrustGrant(key="protected_path", granted_at=T0, ttl_seconds=3600))
+            s1.persist()
+
+            s2 = SessionState.load_from_db("sess", store.connection)
+            grants = s2.trust_grants.all_grants()
+            assert len(grants) == 1
+            assert grants[0].key == "protected_path"
+            assert grants[0].granted_at == T0
+            assert grants[0].ttl_seconds == 3600.0
+        finally:
+            store.close()
+
+    def test_grant_honored_then_expires_by_ttl(self, tmp_path):
+        """The same persisted grant is active early, inert after its TTL."""
+        store = self._store(tmp_path)
+        try:
+            s1 = SessionState(session_id="sess")
+            s1.attach_db(store.connection)
+            s1.trust_grants.add(TrustGrant(key="protected_path", granted_at=T0, ttl_seconds=60))
+            s1.persist()
+
+            s2 = SessionState.load_from_db("sess", store.connection)
+            snap = s2.snapshot()
+
+            # Honored: within TTL the escalation for 'protected_path' is waived.
+            keys_early = active_grant_keys(snap.trust_grants, T0 + timedelta(seconds=30))
+            decision = PolicyDecision(
+                action=RecommendedAction.ESCALATE, reason_code="protected_path"
+            )
+            assert waive_by_grants(decision, keys_early) is None
+
+            # Expired: past the TTL the same escalation stands.
+            keys_late = active_grant_keys(snap.trust_grants, T0 + timedelta(seconds=61))
+            assert waive_by_grants(decision, keys_late) == decision
+        finally:
+            store.close()
+
+    def test_snapshot_defaults_to_no_grants(self, tmp_path):
+        store = self._store(tmp_path)
+        try:
+            s = SessionState.load_from_db("never-granted", store.connection)
+            assert s.snapshot().trust_grants == ()
+        finally:
+            store.close()


### PR DESCRIPTION
## U10 — General governance policy primitives

⚠️ **HOLD — do not merge.** Opened as **draft** to enforce the hold. Coordinator verifies the diff before any merge.

Adds four **general, additive, default-off** agent-governance primitives to `GatePolicy` + the governance subsystem. Per the governing principle, this ships **mechanism + extension points only** — consumers supply the *values* (globs, TTLs, ceilings, actions) through the existing config/override chain. **An empty/default policy is a proven no-op** (the base rule match is returned *unchanged by identity*), so existing gating cannot regress.

> Branch is kept current with `main` (includes the merge of U1a #137 / U9b #138 / U1b #139); the full suite passes on the combined tree.

### The four primitives
1. **Trust grants with TTL** — `TrustGrant` (opaque `key`, `granted_at`, `ttl_seconds`, `reason`) + `TrustGrantStore`, persisted in a new `trust_grants` table. An **active** grant whose key equals a decision's `reason_code` waives that escalate/deny in the assessment overlay. Activeness is `[granted_at, expires_at)` evaluated against an **explicit `now`** (the event timestamp) → fully deterministic; auto-expires by TTL with no background sweep.
2. **Protected-path globs** — `ProtectedPathAssessor` matches consumer-supplied glob patterns against tool-call paths and escalates/denies. Explicit policy matcher, deliberately **distinct from the IFC heuristics**. Empty patterns ⇒ never fires.
3. **Cost-ceiling ACTION** — `CostCeiling` + `ceiling_action` + `CostCeilingAssessor` map the **existing** budget `pressure` flag / an optional hard tool-call ceiling to a `RecommendedAction` through the rules. Consumes existing budget tracking; adds no new tracking.
4. **`PolicyAssessor` protocol + `PolicyAssessorRegistry`** — a small pluggable extension point surfacing the deterministic (non-LLM) checks so consumers can register their own.

The overlay `apply_policy_overlay(...)` folds assessor decisions (by a severity lattice) and grant waivers over the base rule match; wired default-off through `DefaultAssessor`, `GovernancePipeline` (+ a general `grant_trust(session_id, key, ttl_seconds, *, now=None, reason="")` API), and `PolicyConfig`.

### New public types — all generic (zero consumer-named surface)
- **`governance/types.py`**: `TrustGrant`
- **`governance/state.py`**: `TrustGrantStore`; `SessionStateSnapshot.trust_grants` field
- **`governance/rules.py`**: `PolicyDecision`, `PolicyAssessor` (Protocol), `PolicyAssessorRegistry`, `ProtectedPathAssessor`, `apply_policy_overlay`, `combine_policy_decisions`, `active_grant_keys`, `waive_by_grants`, and glob helpers `normalize_path` / `path_matches_glob` / `first_matching_glob` / `extract_candidate_paths`
- **`governance/budget.py`**: `CostCeiling`, `ceiling_action`, `CostCeilingAssessor`
- **`governance/pipeline.py`**: `GovernancePipeline.grant_trust(...)`
- **`config/models.py`**: `PolicyConfig`, `ProtectedPathsPolicyConfig`, `CostCeilingPolicyConfig` (+ `GovernanceConfig.policy`)

Default reason codes are generic (`protected_path`, `cost_ceiling`); `key` is opaque — the consumer owns the vocabulary.

### ⑃ Design forks (all confirmed with coordinator)
- **F1 — migration folded into `0001_initial`, no `0002`.** Per the `[no-phantom-legacy-prealpha]` ruling (pre-alpha, no released schema; the old shape must never exist — a prior `0002` was deleted + folded, same idiom as the #135 gate-token fold). `LATEST_REVISION` stays `0001_initial`. *There is no shipped DB to migrate, so this PR makes no "existing-DB upgrade" claim.*
- **F2 — 2/3 implemented on the rules→assessor path** (`RecommendedAction`), keeping TraceForge as the *derive + stamp* intelligence layer rather than hosting enforcement on the gate/Verdict path. Additive, default-off edits to `governance/assessor.py`, `governance/pipeline.py`, `config/models.py`. No frozen file touched (enricher, sources/*, sinks/*, `sdk/pipeline.py push()`, `gate/*` IPC).
- **F3 — new `PolicyAssessor` protocol + registry**, composed into `DefaultAssessor` as the default-off overlay; the existing heavy `Assessor`/`DefaultAssessor` shape is untouched.
- **F4 — the shared assess/`_phase3` overlay *is* the grant-consulting preflight check** (Shield's `preview_state` = `clone_detached()` of durable state, which now copies grants). No grant-aware `GatePolicy` Verdict gate added.

### Acceptance
- `ruff check .` ✅ and `ruff format --check .` ✅ (pinned 0.15.20) on the merged tree.
- **Full `tests/unit`: 2271 passed, 3 skipped** (no `-k`) — includes **112 new** deterministic tests (TTL controlled via explicit `now`; no network). Proven: grant honored → TTL-expires → denied; protected-path escalate/deny; cost-ceiling fires on pressure + hard ceiling; `PolicyAssessor` pluggable via registry; grant DB round-trip.
- **Zero-behavior-change (default-off) proven two ways:** (a) `apply_policy_overlay` returns the base match *by object identity* with no assessors + no grants; (b) a pipeline with a **configured** protected-path + cost-ceiling policy yields **byte-identical decisions** (`suggested_action`, `risk_score`, `reason`) to a default no-policy pipeline across a battery of non-matching events (benign read, destructive shell, network egress, ordinary write, `ls`) — the overlay is inert except on the events it targets.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>