### PR TITLE
feat(classify): resolve and populate tool_display at enrichment (U2)

### DIFF
--- a/src/traceforge/classify/__init__.py
+++ b/src/traceforge/classify/__init__.py
@@ -43,6 +43,7 @@ from traceforge.classify.shell import (
     classify_shell,
 )
 from traceforge.classify.tools import classify_tool, normalize_tool_name
+from traceforge.classify.tool_display import ToolDisplayProvider, ToolDisplayResolver
 from traceforge.classify.workflow import Phase, Visibility
 
 __all__ = [
@@ -87,6 +88,9 @@ __all__ = [
     "McpServerProfile",
     "McpToolOverride",
     "normalize_tool_name",
+    # Tool display
+    "ToolDisplayProvider",
+    "ToolDisplayResolver",
     # Risk scoring
     "Confidence",
     "RiskAssessment",

--- a/src/traceforge/classify/config.py
+++ b/src/traceforge/classify/config.py
@@ -142,6 +142,11 @@ class ClassifyConfig(StrictModel):
     verification_role_actions: dict[str, str] = Field(default_factory=dict)
     transparent_wrappers: list[str] = Field(default_factory=list)
     activity_defaults: dict[str, dict[str, str]] = Field(default_factory=dict)
+    # Canonical tool identity -> human-facing display label. Populates
+    # EventMetadata.tool_display at enrichment. Small generic default set; a
+    # consumer supplies its own vocabulary as an overlay via the config-override /
+    # traceforge.profiles entry-point chain (per-key override wins).
+    tool_display: dict[str, str] = Field(default_factory=dict)
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> ClassifyConfig:
@@ -226,6 +231,7 @@ def _load_builtin_defaults() -> dict[str, Any]:
         "mcp_profiles.yaml",
         "shell_rules.yaml",
         "tool_classifications.yaml",
+        "tool_display.yaml",
     ):
         resource = data_dir / filename
         try:
@@ -387,6 +393,7 @@ class ClassificationEngine:
     __slots__ = (
         "canonical_tools",
         "tool_classifications",
+        "tool_display",
         "verb_inference",
         "effect_overrides",
         "shell_rules",
@@ -412,6 +419,12 @@ class ClassificationEngine:
         # Canonical tool aliases — normalize all keys to lowercase for lookup
         self.canonical_tools: dict[str, str] = {
             k.lower().replace("-", "_"): v for k, v in config.canonical_tools.items()
+        }
+
+        # Tool display labels — canonical tool identity -> human-facing label.
+        # Keys normalized like canonical_tools so lookup matches normalize_tool_name.
+        self.tool_display: dict[str, str] = {
+            k.lower().replace("-", "_"): v for k, v in config.tool_display.items()
         }
 
         # Tool classifications (with phase_map derived)

--- a/src/traceforge/classify/data/tool_display.yaml
+++ b/src/traceforge/classify/data/tool_display.yaml
@@ -1,0 +1,30 @@
+# Tool display names — maps a canonical tool identity to a human-facing label.
+#
+# This populates ``EventMetadata.tool_display`` at enrichment time. Keys are the
+# CANONICAL tool identity (the normalized form produced by ``normalize_tool_name``,
+# e.g. every shell-family alias collapses to ``shell``, every read alias to
+# ``view``), NOT the raw per-harness tool name.
+#
+# This is a SMALL, GENERAL default set covering the universal coding-agent tool
+# taxonomy. It is an extension point: supply your own ``tool_display:`` section via
+# the standard config-override chain (``.traceforge/config.yaml``, a
+# ``TRACEFORGE_CONFIG`` file, or a ``traceforge.profiles`` entry point) to add or
+# override labels with your own vocabulary. Per-key overrides win over these
+# defaults; unknown tools resolve to None (the stub stays empty, unchanged).
+
+tool_display:
+  shell: shell
+  view: read file
+  edit: edit file
+  create: create file
+  delete_file: delete file
+  grep: search
+  glob: find files
+  codebase_search: search codebase
+  web_fetch: fetch url
+  web_search: web search
+  web_browse: browse web
+  task: delegate task
+  ask_user: ask user
+  report_intent: report intent
+  think: think

--- a/src/traceforge/classify/tool_display.py
+++ b/src/traceforge/classify/tool_display.py
@@ -1,0 +1,113 @@
+"""Tool display resolution — populate ``EventMetadata.tool_display``.
+
+The display string is the human-facing label for a tool call (e.g. ``"read file"``
+for a ``view``-family tool). It is resolved at enrichment time from the canonical
+tool identity via a layered chain:
+
+1. Programmatic :class:`ToolDisplayProvider` objects (consumer-supplied extension
+   point) — first non-empty result wins. Lets a consumer compute a label
+   dynamically (e.g. per MCP server) beyond what a static map can express.
+2. A static display map (canonical tool identity -> label). This is the
+   ``tool_display`` section of :class:`~traceforge.classify.config.ClassifyConfig`:
+   the built-in generic defaults merged under consumer overrides through the same
+   config-override / ``traceforge.profiles`` entry-point chain used for
+   ``tool_classifications`` / ``mcp_profiles`` / ``tool_overrides``. Per-key
+   overrides win over the defaults.
+3. ``None`` — unknown tools degrade gracefully (the stub stays empty, as before).
+
+Ship only GENERAL defaults here; a consumer supplies its own vocabulary as an
+overlay. Nothing consumer-specific belongs in this module or the default data.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_key(name: str) -> str:
+    """Normalize a tool key to the canonical lookup form (lower, dashes -> underscores).
+
+    Mirrors the normalization applied to canonical tool names so map keys and the
+    resolved ``canonical`` argument compare equal regardless of casing/dashes.
+    """
+    return name.lower().replace("-", "_")
+
+
+@runtime_checkable
+class ToolDisplayProvider(Protocol):
+    """Extension point: resolve a display label for a tool call.
+
+    Consumers implement this to supply dynamic or domain-specific display logic
+    that a static map cannot express. It is consulted before the static display
+    map, so a provider can override the shipped defaults.
+
+    Return a non-empty label to claim the tool call, or ``None`` (or an empty
+    string) to defer to the next resolver in the chain (static map, then ``None``).
+    """
+
+    def display_for(self, canonical: str, raw: str) -> str | None:
+        """Return a display label for the tool call, or ``None`` to defer.
+
+        Args:
+            canonical: The normalized/canonical tool identity (e.g. ``"view"``).
+            raw: The original tool name as it appeared on the event (e.g.
+                ``"read_file"`` or ``"mcp__server__search"``).
+        """
+        ...
+
+
+class ToolDisplayResolver:
+    """Resolve a tool call to its display label from providers + a static map.
+
+    Immutable after construction. One resolver serves every tool call an
+    :class:`~traceforge.enricher.Enricher` observes.
+    """
+
+    __slots__ = ("_display_map", "_providers")
+
+    def __init__(
+        self,
+        display_map: Mapping[str, str] | None = None,
+        providers: Sequence[ToolDisplayProvider] | None = None,
+    ) -> None:
+        """
+        Args:
+            display_map: Canonical tool identity -> display label. Keys are
+                normalized on ingest, so callers may pass raw-cased keys.
+            providers: Optional programmatic providers, consulted in order before
+                the static map. The first non-empty result wins.
+        """
+        self._display_map: dict[str, str] = {
+            _normalize_key(k): v for k, v in (display_map or {}).items()
+        }
+        self._providers: tuple[ToolDisplayProvider, ...] = tuple(providers or ())
+
+    def resolve(self, *, canonical: str, raw: str) -> str | None:
+        """Resolve the display label for a tool call.
+
+        Args:
+            canonical: The normalized/canonical tool identity.
+            raw: The original tool name as it appeared on the event.
+
+        Returns:
+            The display label, or ``None`` when nothing matches (unknown tools
+            degrade gracefully — the stub stays empty).
+        """
+        for provider in self._providers:
+            try:
+                result = provider.display_for(canonical, raw)
+            except Exception:
+                # A misbehaving consumer provider must never break enrichment;
+                # log and fall through to the next resolver.
+                logger.warning("ToolDisplayProvider %r raised; ignoring", provider, exc_info=True)
+                continue
+            if result:
+                return result
+
+        # Empty label is treated as "no display" so a map entry cannot force an
+        # empty string onto the stub.
+        return self._display_map.get(_normalize_key(canonical)) or None

--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 
@@ -13,6 +14,7 @@ from traceforge.classify.core import Classification, PhaseSegment
 from traceforge.classify.coding import CodingMechanism, CodingScope
 from traceforge.classify.powershell import classify_powershell_command
 from traceforge.classify.risk import assess_risk, assess_tool_risk
+from traceforge.classify.tool_display import ToolDisplayProvider, ToolDisplayResolver
 from traceforge.classify.tools import normalize_tool_name
 from traceforge.classify.workflow import Phase, Visibility
 from traceforge.types import EventKind, EventMetadata, SessionEvent
@@ -39,6 +41,7 @@ class Enricher:
         pairing_ttl_s: float | None = None,
         max_pending: int | None = _DEFAULT_MAX_PENDING,
         flush_on_session_end: bool = True,
+        tool_display_providers: Sequence[ToolDisplayProvider] | None = None,
     ) -> None:
         """
         Args:
@@ -63,6 +66,12 @@ class Enricher:
                 orphans before the session-ended event is emitted. When False the
                 starts stay buffered (still subject to the bounds above and the final
                 :meth:`flush`) and are never dropped.
+            tool_display_providers: Optional programmatic
+                :class:`~traceforge.classify.tool_display.ToolDisplayProvider` objects
+                consulted before the config-driven display map when populating
+                ``metadata.tool_display``. The first non-empty result wins; when all
+                defer, the static map (built-in defaults + config overrides) is used,
+                then ``None``.
 
         Raises:
             ValueError: if ``pairing_ttl_s`` is set and not > 0, or if
@@ -86,6 +95,11 @@ class Enricher:
             self._engine = ClassificationEngine(load_config(Path(config_path)))
         else:
             self._engine = get_default_engine()
+
+        # Resolver for metadata.tool_display: config-driven display map (built-in
+        # generic defaults + consumer overrides via the entry-point chain) plus any
+        # programmatic providers passed in (consulted first).
+        self._tool_display = ToolDisplayResolver(self._engine.tool_display, tool_display_providers)
 
     def process(self, event: SessionEvent) -> SessionEvent | list[SessionEvent] | None:
         """Enrich a single event. Returns None if event is buffered (tool_start waiting
@@ -298,7 +312,15 @@ class Enricher:
         # Refine scope from file paths in payload
         cls = _refine_scope_from_payload(cls, event.payload)
 
-        new_metadata = event.metadata.model_copy(update={"classification": cls})
+        metadata_update: dict[str, object] = {"classification": cls}
+        # Populate the tool_display stub from the resolver. Only set it when the
+        # resolver has an answer, so unknown tools degrade gracefully (stub stays
+        # as-is — None by default) rather than clobbering any pre-set value.
+        display = self._tool_display.resolve(canonical=canonical, raw=tool_name)
+        if display is not None:
+            metadata_update["tool_display"] = display
+
+        new_metadata = event.metadata.model_copy(update=metadata_update)
         event = event.model_copy(update={"metadata": new_metadata})
 
         # Risk scoring

--- a/tests/unit/test_tool_display.py
+++ b/tests/unit/test_tool_display.py
@@ -1,0 +1,277 @@
+"""Tests for the tool-display resolver, registry, and enrichment population.
+
+Covers the general mechanism that fills the ``EventMetadata.tool_display`` stub:
+the :class:`ToolDisplayResolver` precedence chain (providers -> static map ->
+None), the ``ClassifyConfig.tool_display`` config section + engine
+materialization, the config-override chain (consumer overrides win over the
+shipped generic defaults), and the Enricher wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from traceforge import Enricher, EventKind, SessionEvent
+from traceforge.classify import ToolDisplayProvider, ToolDisplayResolver
+from traceforge.classify.config import (
+    ClassificationEngine,
+    ClassifyConfig,
+    _load_builtin_defaults,
+    _merge_raw,
+    load_config,
+)
+
+TS = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ── Fixtures / helpers ──
+
+
+def _start(tool_name: str, tool_call_id: str = "tc-1", session_id: str = "s1") -> SessionEvent:
+    return SessionEvent(
+        kind=EventKind.TOOL_CALL_STARTED,
+        session_id=session_id,
+        timestamp=TS,
+        payload={"tool_call_id": tool_call_id, "tool_name": tool_name},
+    )
+
+
+def _complete(tool_name: str, tool_call_id: str = "tc-1", session_id: str = "s1") -> SessionEvent:
+    return SessionEvent(
+        kind=EventKind.TOOL_CALL_COMPLETED,
+        session_id=session_id,
+        timestamp=TS,
+        payload={"tool_call_id": tool_call_id, "tool_name": tool_name},
+    )
+
+
+def _enrich_pair(enricher: Enricher, tool_name: str) -> SessionEvent:
+    """Push a start+complete pair and return the emitted (completed) event."""
+    assert enricher.process(_start(tool_name)) is None  # start is buffered
+    out = enricher.process(_complete(tool_name))
+    assert isinstance(out, SessionEvent)
+    return out
+
+
+class _StaticProvider:
+    """Test provider that returns a fixed label for one canonical identity."""
+
+    def __init__(self, canonical: str, label: str | None) -> None:
+        self._canonical = canonical
+        self._label = label
+
+    def display_for(self, canonical: str, raw: str) -> str | None:
+        return self._label if canonical == self._canonical else None
+
+
+# ── ToolDisplayResolver: static map ──
+
+
+def test_resolver_returns_mapped_label():
+    r = ToolDisplayResolver({"view": "read file"})
+    assert r.resolve(canonical="view", raw="read_file") == "read file"
+
+
+def test_resolver_unknown_returns_none():
+    r = ToolDisplayResolver({"view": "read file"})
+    assert r.resolve(canonical="totally_unknown", raw="totally_unknown") is None
+
+
+def test_resolver_empty_map_returns_none():
+    assert ToolDisplayResolver().resolve(canonical="view", raw="view") is None
+
+
+def test_resolver_normalizes_keys_case_and_dashes():
+    r = ToolDisplayResolver({"Web-Fetch": "fetch url"})
+    assert r.resolve(canonical="web_fetch", raw="WebFetch") == "fetch url"
+
+
+def test_resolver_empty_string_value_is_treated_as_none():
+    # A map entry cannot force an empty label onto the stub.
+    r = ToolDisplayResolver({"view": ""})
+    assert r.resolve(canonical="view", raw="view") is None
+
+
+# ── ToolDisplayResolver: providers (extension point) ──
+
+
+def test_provider_wins_over_static_map():
+    r = ToolDisplayResolver({"view": "read file"}, [_StaticProvider("view", "CUSTOM")])
+    assert r.resolve(canonical="view", raw="read_file") == "CUSTOM"
+
+
+def test_provider_returning_none_defers_to_map():
+    r = ToolDisplayResolver({"view": "read file"}, [_StaticProvider("edit", "X")])
+    assert r.resolve(canonical="view", raw="read_file") == "read file"
+
+
+def test_provider_returning_empty_string_defers():
+    r = ToolDisplayResolver({"view": "read file"}, [_StaticProvider("view", "")])
+    assert r.resolve(canonical="view", raw="read_file") == "read file"
+
+
+def test_first_nonempty_provider_wins_in_order():
+    providers = [
+        _StaticProvider("view", None),
+        _StaticProvider("view", "SECOND"),
+        _StaticProvider("view", "THIRD"),
+    ]
+    r = ToolDisplayResolver({"view": "read file"}, providers)
+    assert r.resolve(canonical="view", raw="read_file") == "SECOND"
+
+
+def test_provider_exception_is_swallowed_and_falls_through():
+    class _Boom:
+        def display_for(self, canonical: str, raw: str) -> str | None:
+            raise RuntimeError("boom")
+
+    r = ToolDisplayResolver({"view": "read file"}, [_Boom()])
+    assert r.resolve(canonical="view", raw="read_file") == "read file"
+
+
+def test_provider_protocol_is_runtime_checkable():
+    assert isinstance(_StaticProvider("view", "x"), ToolDisplayProvider)
+
+
+# ── ClassifyConfig + engine materialization ──
+
+
+def test_default_engine_has_generic_display_map():
+    shipped = _load_builtin_defaults()["tool_display"]
+    assert shipped, "built-in tool_display defaults must be present"
+    # A handful of universal, generic identities are covered.
+    for key in ("view", "edit", "create", "shell", "grep"):
+        assert key in shipped
+
+
+def test_engine_normalizes_config_display_keys():
+    engine = ClassificationEngine(
+        ClassifyConfig(tool_display={"Web-Fetch": "fetch url", "VIEW": "read"})
+    )
+    assert engine.tool_display["web_fetch"] == "fetch url"
+    assert engine.tool_display["view"] == "read"
+
+
+def test_default_display_map_has_zero_consumer_named_values():
+    # Acceptance: the shipped default set is GENERAL — no consumer vocabulary.
+    shipped = _load_builtin_defaults()["tool_display"]
+    for key, value in shipped.items():
+        assert "codeplane" not in key.lower()
+        assert "codeplane" not in value.lower()
+
+
+# ── Config-override chain: consumer overrides win over defaults ──
+
+
+def test_merge_raw_override_wins_per_key():
+    base = {"tool_display": {"view": "read file", "shell": "shell"}}
+    override = {"tool_display": {"view": "CUSTOM VIEW"}}
+    merged = _merge_raw(base, override)
+    # Per-key override wins; non-overridden default is preserved.
+    assert merged["tool_display"]["view"] == "CUSTOM VIEW"
+    assert merged["tool_display"]["shell"] == "shell"
+
+
+def test_config_file_override_wins_over_builtin_defaults(tmp_path, monkeypatch):
+    # Isolate the discovery chain so only built-in defaults + the explicit file apply.
+    monkeypatch.setattr("traceforge.classify.config._find_project_config", lambda: None)
+    monkeypatch.setattr("traceforge.classify.config._find_user_config", lambda: None)
+    monkeypatch.setattr("traceforge.classify.config._load_entry_point_configs", lambda: [])
+    monkeypatch.delenv("TRACEFORGE_CONFIG", raising=False)
+
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("tool_display:\n  view: CONSUMER READ\n", encoding="utf-8")
+
+    cfg = load_config(config_path=cfg_file)
+    # Consumer override wins for its key...
+    assert cfg.tool_display["view"] == "CONSUMER READ"
+    # ...while untouched built-in generic defaults survive the merge.
+    assert cfg.tool_display["shell"] == "shell"
+
+
+# ── Enricher integration: the stub gets populated ──
+
+
+def test_enricher_populates_display_for_known_tool():
+    enricher = Enricher()
+    out = _enrich_pair(enricher, "read_file")  # alias -> canonical "view"
+    assert out.metadata.tool_display == "read file"
+
+
+def test_enricher_shell_alias_maps_to_shell_display():
+    enricher = Enricher()
+    out = _enrich_pair(enricher, "Bash")  # alias -> canonical "shell"
+    assert out.metadata.tool_display == "shell"
+
+
+def test_enricher_unknown_tool_leaves_display_none():
+    enricher = Enricher()
+    out = _enrich_pair(enricher, "some_bespoke_unmapped_tool")
+    assert out.metadata.tool_display is None
+
+
+def test_enricher_no_tool_name_leaves_display_none():
+    enricher = Enricher()
+    # No tool_call_id -> the start is emitted immediately (not buffered).
+    ev = SessionEvent(
+        kind=EventKind.TOOL_CALL_STARTED,
+        session_id="s1",
+        timestamp=TS,
+        payload={},  # no tool_name, no tool_call_id
+    )
+    out = enricher.process(ev)
+    assert isinstance(out, SessionEvent)
+    assert out.metadata.tool_display is None
+
+
+def test_enricher_display_survives_start_complete_merge():
+    # tool_display is set on the START and must be carried onto the merged COMPLETE.
+    enricher = Enricher()
+    out = _enrich_pair(enricher, "write_file")  # alias -> canonical "create"
+    assert out.metadata.tool_display == "create file"
+
+
+def test_enricher_provider_overrides_config_map():
+    enricher = Enricher(tool_display_providers=[_StaticProvider("view", "PROVIDER LABEL")])
+    out = _enrich_pair(enricher, "read_file")
+    assert out.metadata.tool_display == "PROVIDER LABEL"
+
+
+def test_enricher_config_override_reflected_in_enrichment(tmp_path, monkeypatch):
+    # A merged config (built-in canonical_tools + a tool_display override) drives
+    # enrichment: "read_file" normalizes to canonical "view", which the override
+    # relabels. Isolate the discovery chain for determinism.
+    monkeypatch.setattr("traceforge.classify.config._find_project_config", lambda: None)
+    monkeypatch.setattr("traceforge.classify.config._find_user_config", lambda: None)
+    monkeypatch.setattr("traceforge.classify.config._load_entry_point_configs", lambda: [])
+    monkeypatch.delenv("TRACEFORGE_CONFIG", raising=False)
+
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("tool_display:\n  view: OVERRIDDEN\n", encoding="utf-8")
+
+    enricher = Enricher(config=load_config(config_path=cfg_file))
+    out = _enrich_pair(enricher, "read_file")  # alias -> canonical "view"
+    assert out.metadata.tool_display == "OVERRIDDEN"
+
+
+def test_enricher_display_is_deterministic():
+    labels = {_enrich_pair(Enricher(), "grep").metadata.tool_display for _ in range(5)}
+    assert labels == {"search"}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("read_file", "read file"),
+        ("Read", "read file"),
+        ("edit_file", "edit file"),
+        ("create_file", "create file"),
+        ("Bash", "shell"),
+        ("powershell", "shell"),
+        ("Grep", "search"),
+    ],
+)
+def test_enricher_alias_display_matrix(raw, expected):
+    assert _enrich_pair(Enricher(), raw).metadata.tool_display == expected


### PR DESCRIPTION
## PR-5 / upstream item U2 — GENERALIZE

`EventMetadata.tool_display` (`types.py`) has been a **stub that was never populated**. This PR builds the general mechanism that fills it at enrichment time, resolvable through the **existing** `traceforge.profiles` entry-point / config-override chain (the same chain already used for `tool_overrides` / `mcp_profiles` / `tool_classifications`).

### What it does
- **`classify/tool_display.py` (new):** `ToolDisplayProvider` (runtime-checkable Protocol — the extension point) + `ToolDisplayResolver`. Precedence: programmatic providers (first non-empty) → static display map (built-in defaults + config overrides) → `None`. Empty strings coerce to `None`; provider exceptions are swallowed + logged; keys normalized like `canonical_tools`.
- **`classify/config.py`:** one `tool_display: dict[str, str]` field appended to `ClassifyConfig`, its yaml added to the built-in defaults, and materialization on `ClassificationEngine` (normalized keys) — resolved via the full config-override / entry-point chain, so **per-key consumer overrides win** over defaults.
- **`classify/data/tool_display.yaml` (new):** a **small, generic** default set (15 entries) keyed by canonical tool identity (e.g. `view → "read file"`, `edit → "edit file"`, `grep → "search"`). **Zero consumer-named keys/types/values.**
- **`enricher.py`:** populates the stub in `_classify`, only when the resolver returns a value — **unknown tools degrade gracefully** (stay `None`, as today). Optional `tool_display_providers` constructor arg (safe default `None`, no caller changes required).
- **`classify/__init__.py`:** exports the two new public symbols.

### Acceptance
- ✅ `tool_display` populated for known tools; unknown tools stay empty/`None` as today.
- ✅ Consumer overrides win over defaults (per-key merge via the existing chain).
- ✅ Default set is generic — **no consumer-specific names**. CodePlane's domain specs remain an overlay the consumer supplies via config / entry point.
- ✅ **Non-breaking:** with no config the only change is the stub gets filled from the generic default set. Full `tests/unit`: **2271 → 2302** (2271 baseline + 31 new), 3 skipped.

### Verification
- `ruff check .` — clean; `ruff format --check .` — clean (ruff 0.15.20).
- Full `tests/unit`: **2302 passed, 3 skipped**.
- e2e: the enrichment-exercising suites pass; the only failures are pre-existing `ModuleNotFoundError` for optional agent-framework packages (`crewai`, `langchain_core`, `semantic_kernel`, `smolagents`, `agents`) not installed in this environment — unrelated to this change.

### Design fork (flagged to coordinator)
The brief's scope fence named `config/models.py`, but the `traceforge.profiles` entry-point chain and the sibling `tool_*` config sections actually live in **`classify/config.py`** (`ClassifyConfig` → `ClassificationEngine`), which the `Enricher` already owns. `config/models.py` (`TraceforgeConfig`) has **no** entry-point chain and is **not** wired into enrichment. Implementing in `classify/*` is the only way to satisfy *"resolvable via the existing `traceforge.profiles` chain"* and populate at enrichment non-invasively — and it avoids touching the sibling-owned `config/models.py`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>