### PR TITLE
feat(progress): live ProgressUpdate emitter reusing heuristic naming (U7)

### DIFF
--- a/src/traceforge/__init__.py
+++ b/src/traceforge/__init__.py
@@ -20,6 +20,7 @@ from traceforge.classify import (
 from traceforge.enricher import Enricher
 from traceforge.parsers.aider import AiderPreParser
 from traceforge.pipeline import EventPipeline
+from traceforge.progress import ProgressEmitter
 from traceforge.sinks.base import StorageSink
 from traceforge.sinks.callback import CallbackSink
 from traceforge.trace import EventTrace
@@ -28,6 +29,7 @@ from traceforge.types import (
     EventKind,
     EventMetadata,
     IngestionMode,
+    ProgressUpdate,
     SessionEvent,
     TelemetrySpan,
     TitleUpdate,
@@ -54,6 +56,8 @@ __all__ = [
     "IngestionMode",
     "KNOWN_KINDS",
     "Phase",
+    "ProgressEmitter",
+    "ProgressUpdate",
     "SessionEvent",
     "StorageSink",
     "TelemetrySpan",

--- a/src/traceforge/pipeline.py
+++ b/src/traceforge/pipeline.py
@@ -10,14 +10,24 @@ from collections.abc import Awaitable, Iterable
 from typing import TYPE_CHECKING
 
 from traceforge.enricher import Enricher
+from traceforge.progress import ProgressEmitter
 from traceforge.sinks.base import StorageSink
 from traceforge.sinks.callback import (
     CallbackSink,
     EventCallback,
     KindFilter,
+    ProgressCallback,
     as_async_event_callback,
+    as_async_progress_callback,
 )
-from traceforge.types import EventMetadata, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from traceforge.types import (
+    EventMetadata,
+    ProgressUpdate,
+    SessionEvent,
+    TelemetrySpan,
+    TitleUpdate,
+    UsageRecord,
+)
 
 if TYPE_CHECKING:
     from traceforge.governance.results import SessionMeta
@@ -135,6 +145,12 @@ class EventPipeline:
         self._boundary_streams: dict[str, object] = {}
         self._title_inferencer = title_inferencer
         self._title_streams: dict[str, object] = {}
+        # Live progress-headline emitter (SPEC U7). Created lazily the first time
+        # a caller subscribes with ``on_progress`` (see :meth:`subscribe`); stays
+        # ``None`` otherwise, so every progress site on the hot path is a single
+        # ``is not None`` check that is False on the default path — no emitter, no
+        # per-session state, byte-identical emission when unused.
+        self._progress: ProgressEmitter | None = None
         # In-flight off-hot-path session-title API refinements, keyed by session
         # so eviction can cancel a session's pending refinement (a stale refine
         # must never emit after the session was evicted and its title stream
@@ -183,33 +199,55 @@ class EventPipeline:
 
     def subscribe(
         self,
-        on_event: EventCallback,
+        on_event: EventCallback | None = None,
         *,
+        on_progress: ProgressCallback | None = None,
         kind: KindFilter = None,
         to_thread: bool = False,
     ) -> CallbackSink:
-        """Register a lightweight event subscriber (SPEC §15 / #47).
+        """Register a lightweight event and/or progress subscriber (SPEC §15 / #47, U7).
 
-        One-line sugar over the sink model: wraps ``on_event`` in a
+        One-line sugar over the sink model: wraps the given callback(s) in a
         :class:`~traceforge.sinks.callback.CallbackSink` and appends it, so the
         subscriber joins the pipeline's existing error-isolated fan-out — a
         failing subscriber never blocks other sinks or the pipeline. This *is* the
         publish/subscribe story: no sink subclassing, no flush/close lifecycle, no
         persistence contract.
 
-        ``on_event`` may be async *or* a plain sync callable (adapted via
-        :func:`~traceforge.sinks.callback.as_async_event_callback`); pass
+        ``on_event`` receives every (post-structuring) :class:`SessionEvent`;
+        ``on_progress`` receives a live :class:`~traceforge.types.ProgressUpdate`
+        — a deterministic heuristic headline emitted the instant an activity/step
+        opens (U7). Pass either or both; at least one is required. Subscribing to
+        ``on_progress`` lazily arms the progress emitter; not subscribing to it
+        leaves the pipeline byte-identical to before (the emitter stays ``None``).
+
+        Each callback may be async *or* a plain sync callable (adapted via
+        :func:`~traceforge.sinks.callback.as_async_event_callback` /
+        :func:`~traceforge.sinks.callback.as_async_progress_callback`); pass
         ``to_thread=True`` to run a blocking sync callback off the event loop.
-        ``kind`` optionally filters which events reach this subscriber — an exact
+        ``kind`` optionally filters which *events* reach ``on_event`` — an exact
         kind, a ``"prefix.*"`` wildcard (e.g. ``"tool.*"``), an iterable of those,
-        or a predicate over the event — checked before dispatch.
+        or a predicate — checked before dispatch. It does not apply to progress
+        updates, which describe segment openings rather than events.
 
         Returns the created :class:`CallbackSink`, which doubles as the handle for
         :meth:`unsubscribe`.
         """
-        sink = CallbackSink(
-            on_event=as_async_event_callback(on_event, kind=kind, to_thread=to_thread)
+        if on_event is None and on_progress is None:
+            raise ValueError("subscribe requires at least one of on_event or on_progress")
+        event_cb = (
+            as_async_event_callback(on_event, kind=kind, to_thread=to_thread)
+            if on_event is not None
+            else None
         )
+        progress_cb = (
+            as_async_progress_callback(on_progress, to_thread=to_thread)
+            if on_progress is not None
+            else None
+        )
+        sink = CallbackSink(on_event=event_cb, on_progress=progress_cb)
+        if on_progress is not None and self._progress is None:
+            self._progress = ProgressEmitter()
         self._sinks.append(sink)
         if self._sink_labels is not None:
             self._sink_labels.append(_sink_label(len(self._sinks) - 1, sink))
@@ -368,6 +406,8 @@ class EventPipeline:
                 # no API task running after the stream is gone. Normally-completing
                 # sessions refine their trailing activity in _flush_title_streams.
         self._boundary_streams.pop(session_id, None)
+        if self._progress is not None:
+            self._progress.forget(session_id)
 
     async def _push_locked(self, event: SessionEvent) -> None:
         if self._enricher is not None:
@@ -452,6 +492,11 @@ class EventPipeline:
             if self._boundary_inferencer is not None:
                 event = self._boundary_stamp(event)
             await self._title_emit(event)
+            # Progress rides the same boundary-stamped event straight after it
+            # reaches the sinks. Gated: on the default path ``_progress`` is None,
+            # so this is a single bool check and nothing else runs (U7).
+            if self._progress is not None:
+                await self._emit_progress(event)
 
     async def _title_emit(self, event: SessionEvent) -> None:
         """Stamp the event's live segment ids, emit it immediately, then emit
@@ -749,6 +794,37 @@ class EventPipeline:
             f"title update for segment {update.segment_id}",
         )
 
+    async def _emit_progress(self, event: SessionEvent) -> None:
+        """Derive and fan-out a live progress headline for a just-emitted event.
+
+        Only reached when a progress subscriber is armed (the caller guards on
+        ``self._progress is not None``), so the default path never runs this. The
+        emitter is synchronous and error-isolated here: a failure naming one event
+        must never break live emission — it is logged and the event stands.
+        """
+        progress = self._progress
+        if progress is None:
+            return
+        try:
+            update = progress.observe(event)
+        except Exception as exc:
+            logger.error(
+                "Live progress inference failed for event %s: %s — skipping",
+                event.id,
+                exc,
+                exc_info=True,
+            )
+            return
+        if update is not None:
+            await self._push_progress_update(update)
+
+    async def _push_progress_update(self, update: ProgressUpdate) -> None:
+        """Fan-out a live incremental progress headline to all sinks. Error-isolated."""
+        await self._fanout(
+            (sink.on_progress(update) for sink in self._sinks),
+            f"progress update for segment {update.segment_id}",
+        )
+
     async def push_span(self, span: TelemetrySpan) -> None:
         """Fan-out span to all registered sinks."""
         await self._fanout((sink.on_span(span) for sink in self._sinks), f"span {span.name}")
@@ -801,6 +877,8 @@ class EventPipeline:
         self._boundary_streams.clear()
         self._session_locks.clear()
         self._session_order.clear()
+        if self._progress is not None:
+            self._progress.clear()
 
         await self._fanout((sink.flush() for sink in self._sinks), "flush")
 

--- a/src/traceforge/progress.py
+++ b/src/traceforge/progress.py
@@ -1,0 +1,128 @@
+"""Live, deterministic progress-headline emitter.
+
+Announces an incremental :class:`~traceforge.types.ProgressUpdate` the instant an
+activity/step *opens*, reusing the shipped deterministic namer
+(:func:`traceforge.title.heuristics.heuristic_title`) — no model, no network. It
+is the live counterpart of the faithful on-close title: where the titler waits
+for a segment to close, this names the opener immediately so a consumer can show
+"what the agent is doing right now".
+"""
+
+from __future__ import annotations
+
+import json
+
+from traceforge.title.context import payload_text
+from traceforge.title.heuristics import heuristic_title
+from traceforge.types import ProgressUpdate, SessionEvent
+
+# Opener labels, mirrored from the title layer (``title/inferencer.py``) rather
+# than imported, so this module stays decoupled from the boundary package. The
+# string values are the agreed boundary vocabulary — see
+# ``traceforge.boundary.inference.BOUNDARY_CLASSES``.
+_ACTIVITY = "activity-boundary"
+_STEP = "step-boundary"
+
+
+class ProgressEmitter:
+    """Turns a live event stream into incremental :class:`ProgressUpdate`s.
+
+    Purely deterministic and CPU-only. It mirrors the segment-open logic of the
+    session titler (:class:`traceforge.title.inferencer.SessionTitleStream`):
+
+    - the **first** event of a session opens an activity even with no boundary
+      label,
+    - an ``"activity-boundary"`` opens a new activity,
+    - a ``"step-boundary"`` opens a step under the current activity,
+    - any other event (``None`` / ``"noise"``) continues the current segment.
+
+    Each opener is named with the shipped
+    :func:`traceforge.title.heuristics.heuristic_title` over its payload text.
+    The emitter holds only O(1) causal state per session — the current activity's
+    segment id and a monotonic sequence counter — reclaimed by :meth:`forget`
+    (one session, on eviction) and :meth:`clear` (all, at flush).
+    """
+
+    def __init__(
+        self,
+        *,
+        method: str = "hybrid",
+        max_words: int = 8,
+        max_chars: int = 60,
+    ) -> None:
+        self._method = method
+        self._max_words = max_words
+        self._max_chars = max_chars
+        # session_id -> the current open activity's segment id (its opening event id).
+        self._activity: dict[str, str] = {}
+        # session_id -> next 0-based progress sequence number for that session.
+        self._seq: dict[str, int] = {}
+
+    def observe(self, event: SessionEvent) -> ProgressUpdate | None:
+        """Return a :class:`ProgressUpdate` if ``event`` opens an activity/step, else ``None``.
+
+        Fully synchronous (no ``await``), so it is atomic with respect to the
+        event loop and safe under the pipeline's per-session lock. It never
+        mutates the event. The activity-open is recorded *before* the headline is
+        computed — exactly as the titler sets ``activity_id`` unconditionally on
+        open — so an opener with empty payload text still parents a later step
+        correctly even though it yields no update (returns ``None``). The
+        ``sequence`` counter advances only when an update is actually emitted, so
+        a consumer sees a gapless 0-based order.
+        """
+        session_id = event.session_id
+        boundary = event.metadata.boundary if event.metadata is not None else None
+
+        has_activity = session_id in self._activity
+        opens_activity = not has_activity or boundary == _ACTIVITY
+
+        if opens_activity:
+            self._activity[session_id] = event.id
+            kind = "activity"
+            parent_id: str | None = None
+        elif boundary == _STEP:
+            kind = "step"
+            parent_id = self._activity.get(session_id)
+        else:
+            return None
+
+        headline = self._headline(event)
+        if not headline:
+            return None
+
+        sequence = self._seq.get(session_id, 0)
+        self._seq[session_id] = sequence + 1
+        return ProgressUpdate(
+            session_id=session_id,
+            segment_id=event.id,
+            kind=kind,
+            headline=headline,
+            sequence=sequence,
+            parent_id=parent_id,
+        )
+
+    def _headline(self, event: SessionEvent) -> str:
+        """Deterministic heuristic headline for ``event`` (empty if no usable text).
+
+        Reuses the title layer's own text extraction and namer so a headline is
+        byte-identical to the heuristic the titler would derive from the same
+        payload: ``payload_text`` flattens the payload's string leaves, then
+        ``heuristic_title`` names them.
+        """
+        text = payload_text({"payload_json": json.dumps(event.payload, default=str)})
+        return heuristic_title(
+            text,
+            method=self._method,
+            max_words=self._max_words,
+            max_chars=self._max_chars,
+        )
+
+    def forget(self, session_id: str) -> None:
+        """Drop one session's progress state (called on eviction)."""
+        self._activity.pop(session_id, None)
+        self._seq.pop(session_id, None)
+
+    def clear(self) -> None:
+        """Drop every session's progress state (called at flush; terminal)."""
+        self._activity.clear()
+        self._seq.clear()

--- a/src/traceforge/sinks/base.py
+++ b/src/traceforge/sinks/base.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
-from traceforge.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from traceforge.types import ProgressUpdate, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
 
 if TYPE_CHECKING:
     from traceforge.governance.envelope import EnrichedEvent
@@ -64,6 +64,16 @@ class StorageSink(ABC):
 
     async def on_usage(self, usage: UsageRecord) -> None:
         """Handle a usage record. Default no-op."""
+
+    async def on_progress(self, update: ProgressUpdate) -> None:
+        """Handle a live incremental progress headline. Default no-op.
+
+        Emitted the instant an activity/step *opens*, carrying the deterministic
+        heuristic ``headline`` for that just-opened segment (keyed to the event
+        log by ``segment_id``). Like ``on_span``/``on_usage`` this is an optional
+        live signal, so the base default silently drops it — a sink opts in by
+        overriding. See :class:`traceforge.types.ProgressUpdate`.
+        """
 
     async def on_title_update(self, update: TitleUpdate) -> None:
         """Handle an out-of-band title for a closed activity/step segment.

--- a/src/traceforge/sinks/callback.py
+++ b/src/traceforge/sinks/callback.py
@@ -7,11 +7,15 @@ import inspect
 from collections.abc import Awaitable, Callable, Iterable
 
 from traceforge.sinks.base import StorageSink
-from traceforge.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from traceforge.types import ProgressUpdate, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
 
 #: Accepted shapes for a lightweight event subscriber: a coroutine function or a
 #: plain sync callable (both taking a single :class:`SessionEvent`).
 EventCallback = Callable[[SessionEvent], Awaitable[None] | None]
+
+#: Accepted shapes for a lightweight progress subscriber: a coroutine function or
+#: a plain sync callable (both taking a single :class:`ProgressUpdate`).
+ProgressCallback = Callable[[ProgressUpdate], Awaitable[None] | None]
 
 #: Accepted shapes for a per-subscriber kind filter. ``None`` means "all events".
 #: A string is an exact kind, or a ``"prefix.*"`` wildcard matching that dotted
@@ -30,11 +34,13 @@ class CallbackSink(StorageSink):
         on_span: Callable[[TelemetrySpan], Awaitable[None]] | None = None,
         on_usage: Callable[[UsageRecord], Awaitable[None]] | None = None,
         on_title_update: Callable[[TitleUpdate], Awaitable[None]] | None = None,
+        on_progress: Callable[[ProgressUpdate], Awaitable[None]] | None = None,
     ) -> None:
         self._on_event = on_event
         self._on_span = on_span
         self._on_usage = on_usage
         self._on_title_update = on_title_update
+        self._on_progress = on_progress
 
     async def on_event(self, event: SessionEvent) -> None:
         if self._on_event is not None:
@@ -51,6 +57,10 @@ class CallbackSink(StorageSink):
     async def on_title_update(self, update: TitleUpdate) -> None:
         if self._on_title_update is not None:
             await self._on_title_update(update)
+
+    async def on_progress(self, update: ProgressUpdate) -> None:
+        if self._on_progress is not None:
+            await self._on_progress(update)
 
 
 def _kind_predicate(kind: KindFilter) -> Callable[[SessionEvent], bool] | None:
@@ -130,3 +140,43 @@ def as_async_event_callback(
             await result
 
     return on_event
+
+
+def as_async_progress_callback(
+    callback: ProgressCallback,
+    *,
+    to_thread: bool = False,
+) -> Callable[[ProgressUpdate], Awaitable[None]]:
+    """Adapt a sync-or-async progress callback into the ``async on_progress`` shape.
+
+    The progress counterpart of :func:`as_async_event_callback`, behind
+    :meth:`~traceforge.pipeline.EventPipeline.subscribe`'s ``on_progress``: it
+    lets a plain ``Callable[[ProgressUpdate], None]`` receive live headlines
+    without writing ``async def`` or a sink. There is no ``kind`` filter — kinds
+    describe events, and a :class:`ProgressUpdate` is a segment-open signal, not
+    an event.
+
+    - **async callables** (coroutine functions) are awaited directly.
+    - **sync callables** run inline on the event loop by default; pass
+      ``to_thread=True`` to offload a blocking one via :func:`asyncio.to_thread`.
+    - A sync callable that unexpectedly returns an awaitable is awaited defensively.
+
+    Raises ``TypeError`` if ``callback`` is not callable.
+    """
+    if not callable(callback):
+        raise TypeError(f"progress callback must be callable, got {type(callback).__name__}")
+
+    is_async = asyncio.iscoroutinefunction(callback)
+
+    async def on_progress(update: ProgressUpdate) -> None:
+        if is_async:
+            await callback(update)
+            return
+        if to_thread:
+            await asyncio.to_thread(callback, update)
+            return
+        result = callback(update)
+        if inspect.isawaitable(result):
+            await result
+
+    return on_progress

--- a/src/traceforge/types.py
+++ b/src/traceforge/types.py
@@ -313,3 +313,35 @@ class TitleUpdate(FrozenModel):
     title: str
     version: int = Field(default=1, ge=1)
     parent_id: str | None = None  # a step's activity_id, so a flat stream can rebuild the tree
+
+
+# ─── Progress Update ─────────────────────────────────────────────────────────
+
+
+class ProgressUpdate(FrozenModel):
+    """A live, incremental headline announced the instant a segment *opens*.
+
+    Where :class:`TitleUpdate` is the faithful title computed when a segment
+    *closes* (it needs the whole segment), a ``ProgressUpdate`` is the cheap,
+    deterministic headline emitted the moment an activity or step *opens* — so a
+    consumer can show "what the agent is doing right now" without waiting for the
+    segment to finish. It is derived by the existing heuristic namer
+    (:func:`traceforge.title.heuristics.heuristic_title`) over the opening
+    event's payload text: no model, no network, fully deterministic.
+
+    It is keyed to the event log exactly like a title: ``segment_id`` is the
+    opening event's id (the same id the titler stamps as ``activity_id`` /
+    ``step_id``), and a step carries its parent activity's segment id in
+    ``parent_id`` so a flat stream can rebuild the tree. Because ``headline`` is
+    a distinct field from :attr:`TitleUpdate.title`, a consumer can show the live
+    headline immediately and swap in the faithful title once the segment closes.
+    ``sequence`` is a 0-based per-session monotonic counter over the updates
+    emitted for that session, giving a total order without timestamps.
+    """
+
+    session_id: str
+    segment_id: str
+    kind: Literal["activity", "step"]
+    headline: str
+    sequence: int = Field(default=0, ge=0)
+    parent_id: str | None = None  # a step's activity segment id, for tree rebuild

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -1,0 +1,440 @@
+"""Tests for the live ``ProgressUpdate`` emitter (upstream item U7).
+
+Covers the deterministic emitter in isolation, its wiring through
+``EventPipeline.subscribe(on_progress=...)``, and — critically — the regression
+identity that a pipeline with *no* progress subscriber behaves exactly as before
+(the emitter is never armed and no ``on_progress`` ever fires).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from traceforge import (
+    CallbackSink,
+    EventKind,
+    EventMetadata,
+    EventPipeline,
+    ProgressEmitter,
+    ProgressUpdate,
+    SessionEvent,
+    StorageSink,
+)
+from traceforge.sinks.callback import as_async_progress_callback
+from traceforge.title.context import payload_text
+from traceforge.title.heuristics import heuristic_title
+from tests.conftest import make_event
+
+_ACTIVITY = "activity-boundary"
+_STEP = "step-boundary"
+
+
+def bev(
+    boundary: str | None = None,
+    content: str = "hello world",
+    session_id: str = "sess",
+    kind: str = EventKind.MESSAGE_USER,
+) -> SessionEvent:
+    """A boundary-stamped event: ``metadata.boundary`` set as the opener label."""
+    return make_event(
+        kind=kind,
+        session_id=session_id,
+        payload={"content": content},
+        metadata=EventMetadata(boundary=boundary),
+    )
+
+
+def _expected_headline(content: str, *, method: str = "hybrid") -> str:
+    """The deterministic headline the emitter must produce for ``content``."""
+    text = payload_text({"payload_json": json.dumps({"content": content}, default=str)})
+    return heuristic_title(text, method=method)
+
+
+def _plain_pipeline(sinks: list[StorageSink] | None = None) -> EventPipeline:
+    """A pipeline with live inference off, so pre-stamped boundaries survive
+    untouched and no ML model is needed."""
+    return EventPipeline(
+        sinks=sinks or [],
+        enable_phase=False,
+        enable_boundary=False,
+        enable_title=False,
+    )
+
+
+class _ProgressRecordingSink:
+    """A CallbackSink recording events and progress updates in arrival order."""
+
+    def __init__(self) -> None:
+        self.events: list[SessionEvent] = []
+        self.progress: list[ProgressUpdate] = []
+        self.log: list[tuple[str, str]] = []
+        self._sink = CallbackSink(on_event=self._on_event, on_progress=self._on_progress)
+
+    @property
+    def sink(self) -> CallbackSink:
+        return self._sink
+
+    async def _on_event(self, event: SessionEvent) -> None:
+        self.events.append(event)
+        self.log.append(("event", event.id))
+
+    async def _on_progress(self, update: ProgressUpdate) -> None:
+        self.progress.append(update)
+        self.log.append(("progress", update.segment_id))
+
+
+def _scripted(session_id: str = "sess") -> list[SessionEvent]:
+    """activity(first) -> continue -> step -> new activity."""
+    return [
+        bev(content="add retry logic to the client", session_id=session_id),
+        bev(boundary=None, content="thinking about it", session_id=session_id),
+        bev(boundary=_STEP, content="write a test for the parser", session_id=session_id),
+        bev(boundary=_ACTIVITY, content="refactor the database layer", session_id=session_id),
+    ]
+
+
+# ─────────────────────────── emitter unit tests ──────────────────────────────
+
+
+class TestProgressEmitterOpenDetection:
+    """``observe`` mirrors the titler's activity/step open semantics."""
+
+    def test_first_event_opens_activity(self) -> None:
+        e = bev(content="add retry logic to the client")
+        update = ProgressEmitter().observe(e)
+
+        assert update is not None
+        assert update.kind == "activity"
+        assert update.segment_id == e.id
+        assert update.parent_id is None
+        assert update.sequence == 0
+        assert update.session_id == e.session_id
+
+    def test_activity_boundary_opens_new_activity(self) -> None:
+        em = ProgressEmitter()
+        em.observe(bev(content="first activity"))
+        update = em.observe(bev(boundary=_ACTIVITY, content="second activity"))
+
+        assert update is not None
+        assert update.kind == "activity"
+        assert update.parent_id is None
+
+    def test_step_boundary_opens_step_under_current_activity(self) -> None:
+        em = ProgressEmitter()
+        opener = bev(content="open the activity")
+        em.observe(opener)
+        step = em.observe(bev(boundary=_STEP, content="run the tests now"))
+
+        assert step is not None
+        assert step.kind == "step"
+        assert step.parent_id == opener.id
+
+    def test_none_boundary_continues_without_update(self) -> None:
+        em = ProgressEmitter()
+        em.observe(bev(content="open the activity"))
+        assert em.observe(bev(boundary=None, content="more chatter")) is None
+
+    def test_noise_boundary_continues_without_update(self) -> None:
+        em = ProgressEmitter()
+        em.observe(bev(content="open the activity"))
+        # "noise" is neither opener label -> continues the current segment.
+        assert em.observe(bev(boundary="noise", content="more chatter")) is None
+
+    def test_empty_text_opener_records_activity_but_emits_nothing(self) -> None:
+        em = ProgressEmitter()
+        opener = bev(content="", session_id="s2")
+        step = bev(boundary=_STEP, content="do the real work", session_id="s2")
+
+        assert em.observe(opener) is None  # opened, but empty headline -> no update
+        linked = em.observe(step)
+        assert linked is not None
+        assert linked.parent_id == opener.id  # the empty opener still parents the step
+
+    def test_sequence_advances_only_on_emitted_updates(self) -> None:
+        em = ProgressEmitter()
+        em.observe(bev(content="", session_id="s3"))  # opens, empty -> None, no seq bump
+        first = em.observe(bev(boundary=_STEP, content="write the parser", session_id="s3"))
+        second = em.observe(bev(boundary=_STEP, content="add the cli flag", session_id="s3"))
+
+        assert first.sequence == 0
+        assert second.sequence == 1
+
+    def test_per_session_state_is_isolated(self) -> None:
+        em = ProgressEmitter()
+        a = em.observe(bev(content="alpha work", session_id="A"))
+        b = em.observe(bev(content="beta work", session_id="B"))
+
+        assert a.sequence == 0 and b.sequence == 0
+        assert a.parent_id is None and b.parent_id is None
+        assert a.session_id == "A" and b.session_id == "B"
+
+    def test_observe_does_not_mutate_event(self) -> None:
+        e = bev(content="add retry logic")
+        ProgressEmitter().observe(e)
+        # Progress never stamps the titler's segment ids onto the event.
+        assert e.metadata.activity_id is None
+        assert e.metadata.step_id is None
+
+
+class TestProgressEmitterDeterminism:
+    """Headlines come from the shipped heuristic namer — nothing new."""
+
+    def test_headline_matches_direct_heuristic_call(self) -> None:
+        content = "add retry logic to the http client"
+        update = ProgressEmitter().observe(bev(content=content))
+
+        assert update.headline == _expected_headline(content)
+        assert update.headline  # non-empty
+
+    def test_all_four_methods_are_reused_verbatim(self) -> None:
+        content = "Refactor the database connection pooling logic entirely"
+        for method in ("clip", "imperative", "keyphrase", "hybrid"):
+            update = ProgressEmitter(method=method).observe(bev(content=content))
+            assert update.headline == _expected_headline(content, method=method)
+
+    def test_same_input_is_stable_across_instances(self) -> None:
+        content = "wire up the new event bus"
+        a = ProgressEmitter().observe(bev(content=content))
+        b = ProgressEmitter().observe(bev(content=content))
+        assert a.headline == b.headline
+
+
+class TestProgressEmitterStateReclaim:
+    """``forget`` / ``clear`` bound the emitter's per-session state."""
+
+    def test_forget_resets_a_single_session(self) -> None:
+        em = ProgressEmitter()
+        first = em.observe(bev(content="first activity", session_id="s"))
+        em.observe(bev(boundary=_STEP, content="a step here", session_id="s"))
+        em.forget("s")
+
+        # After forget the next event is treated as the session's first again.
+        reopened = em.observe(bev(content="fresh activity", session_id="s"))
+        assert first.sequence == 0
+        assert reopened.kind == "activity"
+        assert reopened.parent_id is None
+        assert reopened.sequence == 0
+
+    def test_clear_resets_all_sessions(self) -> None:
+        em = ProgressEmitter()
+        em.observe(bev(content="a work", session_id="A"))
+        em.observe(bev(content="b work", session_id="B"))
+        em.clear()
+
+        again = em.observe(bev(boundary=None, content="a more", session_id="A"))
+        # Session A is forgotten, so this event opens a fresh activity.
+        assert again is not None
+        assert again.kind == "activity"
+        assert again.sequence == 0
+
+
+# ─────────────────────────── pipeline integration ────────────────────────────
+
+
+class TestSubscribeOnProgress:
+    """``subscribe(on_progress=...)`` delivers deterministic live updates."""
+
+    async def test_yields_updates_on_activity_and_step_boundaries(self) -> None:
+        got: list[ProgressUpdate] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(on_progress=got.append)
+        script = _scripted()
+        for event in script:
+            await pipeline.push(event)
+        await pipeline.close()
+
+        assert [u.kind for u in got] == ["activity", "step", "activity"]
+        assert [u.sequence for u in got] == [0, 1, 2]
+        # The step parents to the first activity's opening event.
+        assert got[1].parent_id == script[0].id
+        assert got[0].headline == _expected_headline("add retry logic to the client")
+        assert got[1].headline == _expected_headline("write a test for the parser")
+        assert got[2].headline == _expected_headline("refactor the database layer")
+
+    async def test_arms_emitter_only_when_progress_requested(self) -> None:
+        pipeline = _plain_pipeline()
+        assert pipeline._progress is None
+        pipeline.subscribe(on_event=lambda e: None)
+        assert pipeline._progress is None
+        pipeline.subscribe(on_progress=lambda u: None)
+        assert pipeline._progress is not None
+
+    async def test_both_event_and_progress_in_one_subscribe(self) -> None:
+        rec = _ProgressRecordingSink()
+
+        pipeline = _plain_pipeline([rec.sink])
+        events: list[SessionEvent] = []
+        progress: list[ProgressUpdate] = []
+        pipeline.subscribe(on_event=events.append, on_progress=progress.append)
+        for event in _scripted():
+            await pipeline.push(event)
+        await pipeline.close()
+
+        assert len(events) == 4
+        assert len(progress) == 3
+
+    async def test_progress_fires_immediately_after_its_event(self) -> None:
+        rec = _ProgressRecordingSink()
+
+        pipeline = _plain_pipeline([rec.sink])
+        pipeline.subscribe(on_progress=lambda u: None)
+        for event in _scripted():
+            await pipeline.push(event)
+        await pipeline.close()
+
+        # Every progress entry is immediately preceded by its own event entry:
+        # the opener reaches the sinks, then its headline fans out right after.
+        assert any(channel == "progress" for channel, _ in rec.log)
+        for i, entry in enumerate(rec.log):
+            if entry[0] == "progress":
+                assert rec.log[i - 1] == ("event", entry[1])
+
+    async def test_sync_progress_callback_is_adapted(self) -> None:
+        got: list[ProgressUpdate] = []
+
+        pipeline = _plain_pipeline()
+        pipeline.subscribe(on_progress=got.append)  # plain sync callable
+        await pipeline.push(bev(content="add a feature flag"))
+        await pipeline.close()
+
+        assert len(got) == 1
+        assert got[0].kind == "activity"
+
+    async def test_failing_progress_subscriber_is_isolated(self) -> None:
+        rec = _ProgressRecordingSink()
+
+        def boom(update: ProgressUpdate) -> None:
+            raise RuntimeError("progress subscriber boom")
+
+        pipeline = _plain_pipeline([rec.sink])
+        pipeline.subscribe(on_progress=boom)
+        for event in _scripted():
+            await pipeline.push(event)
+        await pipeline.close()
+
+        # The raising subscriber must not stop the recording sink's events.
+        assert len(rec.events) == 4
+
+
+class TestSubscribeErrors:
+    """Bad ``subscribe`` inputs are rejected."""
+
+    async def test_requires_at_least_one_callback(self) -> None:
+        pipeline = _plain_pipeline()
+        with pytest.raises(ValueError):
+            pipeline.subscribe()
+
+    async def test_non_callable_progress_raises_type_error(self) -> None:
+        pipeline = _plain_pipeline()
+        with pytest.raises(TypeError):
+            pipeline.subscribe(on_progress=42)  # type: ignore[arg-type]
+
+
+# ───────────────────── regression: zero behavior change ──────────────────────
+
+
+class TestNoProgressSubscriberIdentity:
+    """Not subscribing to progress = byte-identical to before U7."""
+
+    async def test_event_only_subscriber_never_arms_or_emits_progress(self) -> None:
+        rec = _ProgressRecordingSink()
+        seen: list[SessionEvent] = []
+
+        pipeline = _plain_pipeline([rec.sink])
+        pipeline.subscribe(seen.append)  # event-only, positional (legacy shape)
+        script = _scripted()
+        for event in script:
+            await pipeline.push(event)
+        await pipeline.close()
+
+        assert pipeline._progress is None
+        assert rec.progress == []
+        assert [e.id for e in rec.events] == [e.id for e in script]
+        assert [e.id for e in seen] == [e.id for e in script]
+
+    async def test_pipeline_with_no_subscriber_emits_no_progress(self) -> None:
+        rec = _ProgressRecordingSink()
+
+        pipeline = _plain_pipeline([rec.sink])
+        script = _scripted()
+        for event in script:
+            await pipeline.push(event)
+        await pipeline.close()
+
+        assert pipeline._progress is None
+        assert rec.progress == []
+        assert [e.id for e in rec.events] == [e.id for e in script]
+
+    async def test_legacy_subscribe_signature_still_works(self) -> None:
+        # Every shape the pre-U7 subscribe accepted must be unchanged.
+        got: list[str] = []
+        pipeline = _plain_pipeline()
+        handle = pipeline.subscribe(lambda e: got.append(e.kind), kind=EventKind.MESSAGE_USER)
+        await pipeline.push(bev(kind=EventKind.MESSAGE_USER))
+        await pipeline.push(bev(kind=EventKind.TOOL_CALL_STARTED))
+        await pipeline.close()
+
+        assert got == [EventKind.MESSAGE_USER]
+        assert pipeline.unsubscribe(handle) is True
+
+
+# ───────────────────────── sink base + adapter units ─────────────────────────
+
+
+class _EventOnlySink(StorageSink):
+    """A minimal sink implementing only the required ``on_event``."""
+
+    def __init__(self) -> None:
+        self.events: list[SessionEvent] = []
+
+    async def on_event(self, event: SessionEvent) -> None:
+        self.events.append(event)
+
+
+class TestSinkBaseProgressNoop:
+    """The base ``on_progress`` is a silent no-op (like on_span/on_usage)."""
+
+    async def test_default_on_progress_is_silent_noop(self, caplog) -> None:
+        sink = _EventOnlySink()
+        update = ProgressUpdate(
+            session_id="s", segment_id="e", kind="activity", headline="do work", sequence=0
+        )
+        with caplog.at_level(logging.WARNING, logger="traceforge.sinks.base"):
+            result = await sink.on_progress(update)
+
+        assert result is None
+        # Unlike on_title_update, dropping progress must NOT warn.
+        assert caplog.records == []
+
+
+class TestProgressCallbackAdapter:
+    """Direct unit tests of ``as_async_progress_callback``."""
+
+    def _update(self) -> ProgressUpdate:
+        return ProgressUpdate(
+            session_id="s", segment_id="e", kind="activity", headline="h", sequence=0
+        )
+
+    async def test_sync_callback_is_awaited(self) -> None:
+        got: list[ProgressUpdate] = []
+        adapted = as_async_progress_callback(got.append)
+        await adapted(self._update())
+        assert len(got) == 1
+
+    async def test_async_callback_is_awaited(self) -> None:
+        got: list[ProgressUpdate] = []
+
+        async def cb(update: ProgressUpdate) -> None:
+            got.append(update)
+
+        adapted = as_async_progress_callback(cb)
+        await adapted(self._update())
+        assert len(got) == 1
+
+    def test_non_callable_raises_type_error(self) -> None:
+        with pytest.raises(TypeError):
+            as_async_progress_callback(object())  # type: ignore[arg-type]


### PR DESCRIPTION
## What & why (upstream item U7, verdict ADHERE)

Adds a **live progress channel**: a deterministic, incremental *headline* announced the instant an activity/step **opens**, so a consumer can show "what the agent is doing right now" without waiting for the segment to close. It reuses the **existing** deterministic heuristic namer (`title.heuristics.heuristic_title` over `title.context.payload_text`) and the default-on boundary segmentation (`metadata.boundary`). **No LLM, no new naming scheme.**

This is the live counterpart of the faithful on-close `TitleUpdate`: where the titler waits for a segment to close, this names the opener immediately.

## Changes
- **`types.ProgressUpdate`** — trace-native incremental headline keyed to the event log by `segment_id` (the opening event's id), with `kind` (`activity`/`step`), `sequence` (0-based per-session), and `parent_id` (a step's activity segment id). Deliberately a distinct field (`headline`) from `TitleUpdate.title` so a consumer can show the live headline and swap in the faithful title on close.
- **`sinks/base.on_progress`** — pure **no-op** hook, mirroring `on_span`/`on_usage` (silent default, *not* the warn-once of `on_title_update`).
- **`sinks/callback`** — `CallbackSink` gains an `on_progress` param + method; new `as_async_progress_callback` sync-or-async adapter (no `kind` filter — kinds describe events, not segment openings).
- **`progress.ProgressEmitter`** *(new module)* — mirrors the titler's open-detection exactly (first event opens an activity even unlabeled; `activity-boundary` opens an activity; `step-boundary` opens a step under the current activity; anything else continues). O(1) per-session state with `forget`/`clear`.
- **`pipeline.EventPipeline`** — `subscribe()` now also accepts `on_progress=...` (backward compatible; `ValueError` if neither callback is given). Emission is gated after the event reaches the sinks. Lazy emitter + gated cleanup in `flush`/`_finalize_session`.
- Exports `ProgressUpdate` + `ProgressEmitter`.

## Acceptance criteria
- ✅ Subscribing to `on_progress` yields **deterministic incremental** updates on live activity/step boundaries.
- ✅ **Not** subscribing = **zero behavior change** — the emitter stays `None`, every hot-path site is a single `is not None` check, and this is **regression-tested** (`_progress is None`, zero `on_progress` calls, event stream identical).
- ✅ Sink `on_progress` defaults to **no-op**.
- ✅ Reuses the existing naming functions (clip/imperative/keyphrase/hybrid via `heuristic_title`) — a test asserts headlines are byte-identical to a direct `heuristic_title` call for all four methods.

## Scope adherence
`push()` is **untouched** (frozen). No forbidden files touched — `enricher.py`, `sources/*`, `governance/*`, `sinks/sqlite_output.py`, `telemetry/*`, `migrations/*`, `config/models.py`, `classify/*`, `boundary/*`, `phase/*` are all left alone (`boundary`'s opener labels are mirrored locally, exactly as `title/inferencer.py` already does, to avoid coupling to that package).

## Testing
- New `tests/unit/test_progress.py` — **29 tests**: emitter open-detection & parent linkage, determinism (incl. all four heuristics), state reclaim, pipeline integration, error isolation, base no-op, adapter units, and the **zero-behavior-change regression identity**.
- Full `tests/unit` suite: **2331 passed, 3 skipped** (pre-existing platform gates).
- `ruff check .` clean; `ruff format --check .` clean (pinned 0.15.20).

## Design forks flagged to coordinator
1. The task named `sdk/pipeline.py` for `subscribe`/`push()`, but the event-only `subscribe` and frozen `push()` actually live in **`EventPipeline` (`src/traceforge/pipeline.py`)** — `sdk/pipeline.py`'s facade has no `subscribe`. I extended `pipeline.py` (only `push()` was frozen, and it is untouched).
2. Progress keys off `metadata.boundary` + the opening event's id, **not** the titler's `activity_id`/`step_id` — those come only from the opt-in titler, so keying off boundary makes progress work on the default path without the ONNX titler.
3. Conservative default: a custom constructor-sink that overrides `on_progress` alone does **not** auto-arm emission — emission is armed only via `subscribe(on_progress=...)`, keeping the "unused = byte-identical" guarantee crisp.

**HELD — do not merge.** Left for the coordinator to verify and merge.