### PR TITLE
feat(telemetry): add opt-in cost/latency attribution framework (U11)

### DIFF
--- a/src/traceforge/__init__.py
+++ b/src/traceforge/__init__.py
@@ -22,9 +22,18 @@ from traceforge.parsers.aider import AiderPreParser
 from traceforge.pipeline import EventPipeline
 from traceforge.sinks.base import StorageSink
 from traceforge.sinks.callback import CallbackSink
+from traceforge.telemetry.attribution import (
+    DURATION_MS_ATTR,
+    Anomaly,
+    AttributionRollup,
+    Attributor,
+    build_attributor,
+)
 from traceforge.trace import EventTrace
 from traceforge.types import (
     KNOWN_KINDS,
+    TRACE_NATIVE_DIMENSIONS,
+    CostBreakdown,
     EventKind,
     EventMetadata,
     IngestionMode,
@@ -69,4 +78,12 @@ __all__ = [
     "is_known_kind",
     "load_config",
     "normalize_tool_name",
+    # Attribution (U11)
+    "Anomaly",
+    "AttributionRollup",
+    "Attributor",
+    "CostBreakdown",
+    "DURATION_MS_ATTR",
+    "TRACE_NATIVE_DIMENSIONS",
+    "build_attributor",
 ]

--- a/src/traceforge/config/models.py
+++ b/src/traceforge/config/models.py
@@ -20,6 +20,7 @@ from typing import Annotated, Literal
 from pydantic import Field, field_validator, model_validator
 
 from traceforge.models import StrictModel
+from traceforge.types import TRACE_NATIVE_DIMENSIONS
 
 
 # ─── Source Configs ──────────────────────────────────────────────────────────
@@ -568,6 +569,61 @@ class TitleConfig(StrictModel):
     activity_titling: ActivityTitlingConfig = Field(default_factory=ActivityTitlingConfig)
 
 
+# ─── Attribution Config ──────────────────────────────────────────────────────
+
+
+class ModelPricing(StrictModel):
+    """Per-model token pricing for deriving a cost breakdown.
+
+    Used when a :class:`~traceforge.types.UsageRecord` lacks ``cost_usd``, or when
+    explicit per-token rates are preferred over proportionally splitting a known
+    cost. Rates are USD per 1,000 tokens.
+    """
+
+    input_per_1k_usd: float = Field(ge=0)
+    output_per_1k_usd: float = Field(ge=0)
+
+
+class AttributionConfig(StrictModel):
+    """Opt-in cost/latency attribution (off by default).
+
+    When ``enabled`` is False (the default) nothing is attached to the pipeline and
+    the hot path pays nothing — spans and usage records flow through byte-identical.
+    When True, they are enriched and rolled up per trace-native dimension
+    (:data:`~traceforge.types.TRACE_NATIVE_DIMENSIONS`), with optional threshold /
+    z-score anomaly flags. Every rollup / attribute / anomaly key stays a
+    trace-native dimension — consumer taxonomies are rejected at validation.
+    """
+
+    enabled: bool = False
+    #: Which trace-native dimensions to attribute against. Restricted to
+    #: ``TRACE_NATIVE_DIMENSIONS`` — a consumer taxonomy name is rejected.
+    dimensions: list[str] = Field(default_factory=lambda: list(TRACE_NATIVE_DIMENSIONS))
+    #: Optional per-model token pricing, keyed by model name. Empty = derive each
+    #: breakdown by splitting the record's own ``cost_usd`` by token share.
+    pricing: dict[str, ModelPricing] = Field(default_factory=dict)
+    #: Flag a dimension bucket whose total duration exceeds this many milliseconds.
+    duration_threshold_ms: float | None = Field(default=None, ge=0)
+    #: Flag a dimension bucket whose total cost exceeds this many USD.
+    cost_threshold_usd: float | None = Field(default=None, ge=0)
+    #: Flag a bucket whose metric is at least this many standard deviations above
+    #: its dimension's mean. ``None`` disables z-score anomaly detection.
+    zscore_threshold: float | None = Field(default=None, gt=0)
+    #: Minimum number of buckets in a dimension before z-score detection runs.
+    min_samples: int = Field(default=3, ge=2)
+
+    @field_validator("dimensions")
+    @classmethod
+    def _known_dimensions(cls, v: list[str]) -> list[str]:
+        unknown = [d for d in v if d not in TRACE_NATIVE_DIMENSIONS]
+        if unknown:
+            raise ValueError(
+                f"unknown attribution dimension(s) {unknown}; "
+                f"allowed trace-native dimensions: {list(TRACE_NATIVE_DIMENSIONS)}"
+            )
+        return v
+
+
 # ─── Root Config ─────────────────────────────────────────────────────────────
 
 
@@ -609,6 +665,9 @@ class TraceforgeConfig(StrictModel):
 
     # Titling (span titles + configurable session naming)
     title: TitleConfig = Field(default_factory=TitleConfig)
+
+    # Cost/latency attribution (opt-in; off by default)
+    attribution: AttributionConfig = Field(default_factory=AttributionConfig)
 
     @field_validator("pipelines")
     @classmethod

--- a/src/traceforge/pipeline.py
+++ b/src/traceforge/pipeline.py
@@ -22,6 +22,7 @@ from traceforge.types import EventMetadata, SessionEvent, TelemetrySpan, TitleUp
 if TYPE_CHECKING:
     from traceforge.governance.results import SessionMeta
     from traceforge.telemetry import PipelineMetrics
+    from traceforge.telemetry.attribution import Attributor
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,7 @@ class EventPipeline:
         max_sessions: int | None = _DEFAULT_MAX_SESSIONS,
         governance=None,
         metrics: PipelineMetrics | None = None,
+        attribution: Attributor | None = None,
     ) -> None:
         self._sinks = list(sinks)
         self._enricher = enricher
@@ -171,6 +173,24 @@ class EventPipeline:
         self._sink_labels: list[str] | None = (
             _sink_labels_for(self._sinks) if metrics is not None else None
         )
+
+        # Opt-in cost/latency attribution (U11). ``None`` (the default) means the
+        # hot path never enriches, times, or accumulates: ``push_span`` /
+        # ``push_usage`` are guarded on ``self._attribution is not None`` and the
+        # span / usage object flows through byte-identical. Attaching an
+        # :class:`~traceforge.telemetry.attribution.Attributor` (via
+        # ``build_attributor(config.attribution)``) is the only way to turn it on.
+        self._attribution = attribution
+
+    @property
+    def attribution(self) -> Attributor | None:
+        """The attached :class:`~traceforge.telemetry.attribution.Attributor`, or ``None``.
+
+        Rollups and anomalies update live as spans / usage are pushed; read a stable
+        view after :meth:`flush` / :meth:`close` via ``pipeline.attribution.rollups()``
+        and ``pipeline.attribution.anomalies()``. ``None`` when attribution is off.
+        """
+        return self._attribution
 
     @property
     def metrics(self) -> PipelineMetrics | None:
@@ -750,11 +770,25 @@ class EventPipeline:
         )
 
     async def push_span(self, span: TelemetrySpan) -> None:
-        """Fan-out span to all registered sinks."""
+        """Fan-out span to all registered sinks.
+
+        When attribution is enabled the span is first enriched (stamped with a
+        derived ``duration_ms`` and folded into the per-dimension rollups); when it
+        is off (the default) the original span object flows through untouched.
+        """
+        if self._attribution is not None:
+            span = self._attribution.enrich_span(span)
         await self._fanout((sink.on_span(span) for sink in self._sinks), f"span {span.name}")
 
     async def push_usage(self, usage: UsageRecord) -> None:
-        """Fan-out usage record to all registered sinks."""
+        """Fan-out usage record to all registered sinks.
+
+        When attribution is enabled the record is first enriched (a derived
+        ``cost_breakdown`` and its cost folded into the per-dimension rollups); when
+        it is off (the default) the original usage object flows through untouched.
+        """
+        if self._attribution is not None:
+            usage = self._attribution.enrich_usage(usage)
         await self._fanout((sink.on_usage(usage) for sink in self._sinks), "usage record")
 
     async def flush(self) -> None:
@@ -806,6 +840,15 @@ class EventPipeline:
 
         if self._metrics is not None:
             logger.debug("EventPipeline self-metrics at flush: %s", self._metrics.snapshot())
+
+        # Attribution rollups are computed at flush from the accumulated spans /
+        # usage and read back off ``pipeline.attribution`` (no sink emission here —
+        # persisting them is the stacked follow-up's concern). Off = nothing runs.
+        if self._attribution is not None:
+            logger.debug(
+                "EventPipeline attribution at flush: %d rollup(s)",
+                len(self._attribution.rollups()),
+            )
 
     async def _push_to_sinks(self, event: SessionEvent) -> None:
         """Push event to sinks, stamping governance first if a stage is wired in.

--- a/src/traceforge/telemetry/attribution.py
+++ b/src/traceforge/telemetry/attribution.py
@@ -1,0 +1,358 @@
+"""Opt-in cost/latency attribution for :class:`~traceforge.pipeline.EventPipeline`.
+
+This is traceforge's *attribution* seam: it answers "where did the time and money
+go?" by keying every span's latency and every usage record's cost against the
+**trace-native** dimensions the run already has — phase / turn / segment / tool /
+file / retry (:data:`~traceforge.types.TRACE_NATIVE_DIMENSIONS`). It never invents
+a consumer taxonomy (team, cost-center, product, …); downstream consumers attach
+those in their own layer, keyed off the trace-native rollups produced here.
+
+Design contract (identical in spirit to the ``PipelineMetrics`` opt-in of #48):
+
+- **Opt-in.** A pipeline created without an :class:`Attributor` does no attribution
+  work and makes no allocations on the hot path — the pipeline guards every site on
+  ``attribution is not None``. Attaching an instance (via :func:`build_attributor`,
+  which returns ``None`` for a disabled config) is the *only* way to turn it on.
+- **Identity-preserving when off.** Even a directly constructed but disabled
+  attributor early-returns its input object unchanged, so enrichment is a strict
+  no-op and the delivered span / usage is the same object it was handed.
+- **Bounded & deterministic.** Accumulation is incremental into one small counter
+  bucket per observed (dimension, key) pair — nothing grows per span / per usage
+  beyond the distinct dimension values actually seen — and every rollup / anomaly
+  list is deterministically ordered.
+
+Usage::
+
+    from traceforge import EventPipeline, build_attributor
+    from traceforge.config.models import AttributionConfig
+
+    attribution = build_attributor(AttributionConfig(enabled=True))
+    pipeline = EventPipeline(sinks=[...], attribution=attribution)
+    ...
+    await pipeline.flush()
+    for rollup in pipeline.attribution.rollups():
+        print(rollup.dimension, rollup.key, rollup.total_cost_usd)
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from traceforge.models import FrozenModel
+from traceforge.types import (
+    TRACE_NATIVE_DIMENSIONS,
+    CostBreakdown,
+    TelemetrySpan,
+    UsageRecord,
+)
+
+if TYPE_CHECKING:
+    from traceforge.config.models import AttributionConfig
+
+__all__ = [
+    "DURATION_MS_ATTR",
+    "Anomaly",
+    "AttributionRollup",
+    "Attributor",
+    "build_attributor",
+]
+
+#: Derived span attribute holding the span's wall-clock duration in milliseconds.
+#: Stamped onto ``TelemetrySpan.attributes`` by :meth:`Attributor.enrich_span` when
+#: attribution is enabled. This is a derived *metric*, never a grouping dimension.
+DURATION_MS_ATTR = "duration_ms"
+
+#: Derived metric name for accumulated cost, used to label cost anomalies.
+COST_USD_METRIC = "cost_usd"
+
+
+class AttributionRollup(FrozenModel):
+    """Aggregated cost + latency for one ``(dimension, key)`` bucket.
+
+    ``dimension`` is always one of :data:`~traceforge.types.TRACE_NATIVE_DIMENSIONS`
+    and ``key`` is the (stringified) value that dimension took for the attributed
+    units — e.g. ``dimension="tool"``, ``key="read_file"``. Span-derived latency and
+    usage-derived cost coexist in a single bucket, so a rollup reports both how long
+    that slice of the trace took and what it cost.
+    """
+
+    dimension: str
+    key: str
+    span_count: int
+    total_duration_ms: float
+    usage_count: int
+    total_cost_usd: float
+    input_tokens: int
+    output_tokens: int
+
+
+class Anomaly(FrozenModel):
+    """A flagged ``(dimension, key)`` bucket whose metric stands out.
+
+    ``kind`` is ``"threshold"`` (``value`` exceeded a configured absolute limit) or
+    ``"zscore"`` (``value`` sat ``score`` population standard deviations above its
+    dimension's mean). ``metric`` names what was measured: :data:`DURATION_MS_ATTR`
+    or :data:`COST_USD_METRIC`. ``threshold`` is the limit that fired (the absolute
+    limit for threshold anomalies, or the configured z-score cutoff for z-score
+    anomalies); ``score`` is the computed z-score, or ``None`` for threshold flags.
+    """
+
+    dimension: str
+    key: str
+    metric: str
+    kind: str
+    value: float
+    threshold: float
+    score: float | None = None
+
+
+@dataclass
+class _Bucket:
+    """Mutable per-``(dimension, key)`` accumulator; internal to the attributor."""
+
+    span_count: int = 0
+    total_duration_ms: float = 0.0
+    usage_count: int = 0
+    total_cost_usd: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+class Attributor:
+    """Engine that enriches spans / usage and rolls up cost + latency per dimension.
+
+    Normally constructed only when attribution is enabled (see
+    :func:`build_attributor`), so a pipeline with no attributor pays nothing. Even
+    so, every mutating method early-returns its input unchanged when :attr:`enabled`
+    is False, so an explicitly disabled instance is *also* a strict no-op that
+    preserves object identity.
+    """
+
+    def __init__(self, config: AttributionConfig) -> None:
+        self._config = config
+        # Only the configured dimensions are ever stamped or rolled up. Config
+        # validation already restricts these to the trace-native vocabulary; the
+        # intersection here is a defensive second guard (guardrail #2) so no
+        # consumer taxonomy key can ever become a bucket.
+        self._dimensions: tuple[str, ...] = tuple(
+            d for d in config.dimensions if d in TRACE_NATIVE_DIMENSIONS
+        )
+        self._buckets: dict[tuple[str, str], _Bucket] = {}
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this attributor mutates and accumulates (mirrors config)."""
+        return self._config.enabled
+
+    @property
+    def config(self) -> AttributionConfig:
+        """The :class:`~traceforge.config.models.AttributionConfig` in effect."""
+        return self._config
+
+    def enrich_span(self, span: TelemetrySpan) -> TelemetrySpan:
+        """Return ``span`` stamped with ``duration_ms`` and accumulate its latency.
+
+        When disabled, returns the exact input object (identity preserved). When
+        enabled, returns a copy whose ``attributes`` additionally carries
+        :data:`DURATION_MS_ATTR`; the original span is never mutated.
+        """
+        if not self.enabled:
+            return span
+        duration_ms = (span.end_time - span.start_time).total_seconds() * 1000.0
+        for dimension in self._dimensions:
+            value = span.attributes.get(dimension)
+            if value is None:
+                continue
+            bucket = self._bucket(dimension, value)
+            bucket.span_count += 1
+            bucket.total_duration_ms += duration_ms
+        enriched = {**span.attributes, DURATION_MS_ATTR: duration_ms}
+        return span.model_copy(update={"attributes": enriched})
+
+    def enrich_usage(self, usage: UsageRecord) -> UsageRecord:
+        """Return ``usage`` with a derived ``cost_breakdown`` and accumulate cost.
+
+        When disabled, returns the exact input object (identity preserved). When
+        enabled, computes a :class:`~traceforge.types.CostBreakdown` (when a cost can
+        be derived) and returns a copy carrying it; the original is never mutated. If
+        no cost can be derived the input object is returned unchanged, but its
+        dimensional cost of ``0`` still counts toward the rollups.
+        """
+        if not self.enabled:
+            return usage
+        breakdown = self._breakdown(usage)
+        total_cost = breakdown.total_cost_usd if breakdown is not None else (usage.cost_usd or 0.0)
+        for dimension in self._dimensions:
+            value = usage.attributes.get(dimension)
+            if value is None:
+                continue
+            bucket = self._bucket(dimension, value)
+            bucket.usage_count += 1
+            bucket.total_cost_usd += total_cost
+            bucket.input_tokens += usage.input_tokens
+            bucket.output_tokens += usage.output_tokens
+        if breakdown is None:
+            return usage
+        return usage.model_copy(update={"cost_breakdown": breakdown})
+
+    def rollups(self) -> list[AttributionRollup]:
+        """Return the per-``(dimension, key)`` rollups accumulated so far.
+
+        Deterministically ordered by dimension (in trace-native order) then key.
+        Idempotent: reading does not reset accumulation, so it is safe to call at
+        each flush and again afterwards.
+        """
+        return [
+            AttributionRollup(
+                dimension=dimension,
+                key=key,
+                span_count=bucket.span_count,
+                total_duration_ms=bucket.total_duration_ms,
+                usage_count=bucket.usage_count,
+                total_cost_usd=bucket.total_cost_usd,
+                input_tokens=bucket.input_tokens,
+                output_tokens=bucket.output_tokens,
+            )
+            for (dimension, key), bucket in self._sorted_buckets()
+        ]
+
+    def anomalies(self) -> list[Anomaly]:
+        """Return anomaly flags over the current rollups.
+
+        Threshold flags fire when a bucket's total duration or cost exceeds the
+        configured absolute limit. Z-score flags fire when a bucket's metric sits at
+        least ``zscore_threshold`` population standard deviations above the mean of
+        its dimension, once that dimension has at least ``min_samples`` buckets. Any
+        family is disabled by leaving its threshold ``None`` (all default off).
+        """
+        rollups = self.rollups()
+        anomalies: list[Anomaly] = []
+        anomalies.extend(self._threshold_anomalies(rollups))
+        anomalies.extend(self._zscore_anomalies(rollups))
+        anomalies.sort(key=lambda a: (_dimension_rank(a.dimension), a.key, a.metric, a.kind))
+        return anomalies
+
+    def _threshold_anomalies(self, rollups: list[AttributionRollup]) -> list[Anomaly]:
+        out: list[Anomaly] = []
+        duration_limit = self._config.duration_threshold_ms
+        cost_limit = self._config.cost_threshold_usd
+        for r in rollups:
+            if duration_limit is not None and r.total_duration_ms > duration_limit:
+                out.append(
+                    Anomaly(
+                        dimension=r.dimension,
+                        key=r.key,
+                        metric=DURATION_MS_ATTR,
+                        kind="threshold",
+                        value=r.total_duration_ms,
+                        threshold=duration_limit,
+                    )
+                )
+            if cost_limit is not None and r.total_cost_usd > cost_limit:
+                out.append(
+                    Anomaly(
+                        dimension=r.dimension,
+                        key=r.key,
+                        metric=COST_USD_METRIC,
+                        kind="threshold",
+                        value=r.total_cost_usd,
+                        threshold=cost_limit,
+                    )
+                )
+        return out
+
+    def _zscore_anomalies(self, rollups: list[AttributionRollup]) -> list[Anomaly]:
+        z_limit = self._config.zscore_threshold
+        if z_limit is None:
+            return []
+        by_dimension: dict[str, list[AttributionRollup]] = {}
+        for r in rollups:
+            by_dimension.setdefault(r.dimension, []).append(r)
+        out: list[Anomaly] = []
+        for group in by_dimension.values():
+            if len(group) < self._config.min_samples:
+                continue
+            for metric, values in (
+                (DURATION_MS_ATTR, [r.total_duration_ms for r in group]),
+                (COST_USD_METRIC, [r.total_cost_usd for r in group]),
+            ):
+                mean = statistics.fmean(values)
+                std = statistics.pstdev(values)
+                if std == 0.0:
+                    continue
+                for r, value in zip(group, values):
+                    score = (value - mean) / std
+                    if score >= z_limit:
+                        out.append(
+                            Anomaly(
+                                dimension=r.dimension,
+                                key=r.key,
+                                metric=metric,
+                                kind="zscore",
+                                value=value,
+                                threshold=z_limit,
+                                score=score,
+                            )
+                        )
+        return out
+
+    def _bucket(self, dimension: str, value: object) -> _Bucket:
+        bucket_key = (dimension, str(value))
+        bucket = self._buckets.get(bucket_key)
+        if bucket is None:
+            bucket = _Bucket()
+            self._buckets[bucket_key] = bucket
+        return bucket
+
+    def _sorted_buckets(self) -> list[tuple[tuple[str, str], _Bucket]]:
+        return sorted(
+            self._buckets.items(),
+            key=lambda item: (_dimension_rank(item[0][0]), item[0][1]),
+        )
+
+    def _breakdown(self, usage: UsageRecord) -> CostBreakdown | None:
+        pricing = self._config.pricing.get(usage.model)
+        if pricing is not None:
+            input_cost = usage.input_tokens / 1000.0 * pricing.input_per_1k_usd
+            output_cost = usage.output_tokens / 1000.0 * pricing.output_per_1k_usd
+            return CostBreakdown(
+                input_cost_usd=input_cost,
+                output_cost_usd=output_cost,
+                total_cost_usd=input_cost + output_cost,
+            )
+        if usage.cost_usd is not None:
+            total = usage.cost_usd
+            total_tokens = usage.input_tokens + usage.output_tokens
+            input_cost = total * (usage.input_tokens / total_tokens) if total_tokens else 0.0
+            # Derive output as the remainder so the two parts always re-sum to the
+            # known total exactly, with no floating-point drift.
+            output_cost = total - input_cost
+            return CostBreakdown(
+                input_cost_usd=input_cost,
+                output_cost_usd=output_cost,
+                total_cost_usd=total,
+            )
+        return None
+
+
+def _dimension_rank(dimension: str) -> int:
+    """Sort index of a dimension in canonical trace-native order (unknown last)."""
+    try:
+        return TRACE_NATIVE_DIMENSIONS.index(dimension)
+    except ValueError:
+        return len(TRACE_NATIVE_DIMENSIONS)
+
+
+def build_attributor(config: AttributionConfig) -> Attributor | None:
+    """Construct an :class:`Attributor` from config, or ``None`` when disabled.
+
+    Returning ``None`` for a disabled config is deliberate: attaching an attributor
+    is the *only* way to turn attribution on, so a pipeline built with
+    ``EventPipeline(..., attribution=build_attributor(config.attribution))`` stays a
+    strict hot-path no-op unless the config explicitly enables it.
+    """
+    if not config.enabled:
+        return None
+    return Attributor(config)

--- a/src/traceforge/types.py
+++ b/src/traceforge/types.py
@@ -265,15 +265,61 @@ class SessionEvent(FrozenModel):
     metadata: EventMetadata = Field(default_factory=EventMetadata)
 
 
+# ─── Trace-native attribution dimensions ────────────────────────────────────
+#
+# The closed vocabulary of dimensions cost/latency can be attributed against.
+# Every one is intrinsic to the *trace itself* — the shape a coding-agent run
+# already has — never a consumer taxonomy (team, cost-center, product, …). These
+# are the only keys the attribution framework (``telemetry/attribution.py``) rolls
+# up, stamps, or flags by, and the only values accepted in an
+# ``AttributionConfig.dimensions`` list. Attributed units carry their dimension
+# values in ``TelemetrySpan.attributes`` / ``UsageRecord.attributes`` under these
+# exact keys.
+
+PHASE: Final = "phase"  # workflow phase (e.g. explore / implement / verify)
+TURN: Final = "turn"  # conversational turn id/index
+SEGMENT: Final = "segment"  # activity/step segment id
+TOOL: Final = "tool"  # normalized tool name
+FILE: Final = "file"  # file path touched
+RETRY: Final = "retry"  # retry marker/count for the attempted unit
+
+#: The complete, ordered set of trace-native attribution dimensions.
+TRACE_NATIVE_DIMENSIONS: Final[tuple[str, ...]] = (PHASE, TURN, SEGMENT, TOOL, FILE, RETRY)
+
+
 # ─── Telemetry Span ──────────────────────────────────────────────────────────
 
 
 class TelemetrySpan(FrozenModel):
+    """A timed unit of work.
+
+    ``attributes`` is an open bag. When attribution is enabled it is enriched with
+    a derived ``duration_ms`` and read for any trace-native dimension keys present
+    (see :data:`TRACE_NATIVE_DIMENSIONS`); when attribution is off the span flows
+    through untouched.
+    """
+
     name: str
     session_id: str
     start_time: datetime
     end_time: datetime
     attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+# ─── Cost Breakdown ──────────────────────────────────────────────────────────
+
+
+class CostBreakdown(FrozenModel):
+    """Decomposition of a :class:`UsageRecord`'s cost into input vs. output.
+
+    Produced by the attribution framework (never on the hot path unless enabled)
+    and attached to :attr:`UsageRecord.cost_breakdown`. ``total_cost_usd`` always
+    equals ``input_cost_usd + output_cost_usd`` (subject to float rounding).
+    """
+
+    input_cost_usd: float = Field(ge=0)
+    output_cost_usd: float = Field(ge=0)
+    total_cost_usd: float = Field(ge=0)
 
 
 # ─── Usage Record ────────────────────────────────────────────────────────────
@@ -286,6 +332,15 @@ class UsageRecord(FrozenModel):
     input_tokens: int = Field(ge=0)
     output_tokens: int = Field(ge=0)
     cost_usd: float | None = Field(default=None, ge=0)
+    # Trace-native dimension context for cost attribution (symmetric with
+    # ``TelemetrySpan.attributes``). Empty by default; populated by the producer
+    # with keys from ``TRACE_NATIVE_DIMENSIONS`` so cost/tokens can roll up per
+    # tool / phase / turn / segment / file / retry.
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    # Input/output cost decomposition, filled in by the attribution framework when
+    # enabled; ``None`` (the default) otherwise — a usage record is unchanged when
+    # attribution is off.
+    cost_breakdown: CostBreakdown | None = None
 
 
 # ─── Title Update ────────────────────────────────────────────────────────────

--- a/tests/unit/test_telemetry_attribution.py
+++ b/tests/unit/test_telemetry_attribution.py
@@ -1,0 +1,381 @@
+"""Tests for opt-in cost/latency attribution (upstream item U11).
+
+Three things matter here and are asserted directly:
+
+1. **When disabled (the default)**, attribution is a *genuine* no-op: the pipeline
+   attaches no attributor, ``push_span`` / ``push_usage`` deliver the exact same
+   object they were handed (identity preserved), and the delivered span / usage
+   serializes byte-identically to the input — the hard bar PR-9 also had to meet.
+2. **When enabled**, spans are stamped with a derived ``duration_ms``, usage records
+   gain a ``cost_breakdown``, and both roll up per trace-native dimension with
+   optional threshold / z-score anomaly flags.
+3. **Guardrail #2**: every rollup / attribute / anomaly key is a trace-native
+   dimension (phase / turn / segment / tool / file / retry). A consumer-taxonomy
+   dimension name is rejected at config validation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from traceforge import (
+    TRACE_NATIVE_DIMENSIONS,
+    Anomaly,
+    AttributionRollup,
+    Attributor,
+    CostBreakdown,
+    DURATION_MS_ATTR,
+    EventPipeline,
+    build_attributor,
+)
+from traceforge.config.models import AttributionConfig, ModelPricing, TraceforgeConfig
+from tests.conftest import RecordingSink, make_span, make_usage
+
+_EPOCH = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+def _plain_pipeline(**kwargs) -> EventPipeline:
+    """An EventPipeline with the model-loading inferencers off (span/usage only)."""
+    kwargs.setdefault("enable_phase", False)
+    kwargs.setdefault("enable_boundary", False)
+    return EventPipeline(**kwargs)
+
+
+def _span_ms(duration_ms: float, **attributes):
+    """A span whose wall-clock duration is exactly ``duration_ms``."""
+    return make_span(
+        start_time=_EPOCH,
+        end_time=_EPOCH + timedelta(milliseconds=duration_ms),
+        attributes=attributes,
+    )
+
+
+def _enabled(**kwargs) -> Attributor:
+    return Attributor(AttributionConfig(enabled=True, **kwargs))
+
+
+# ─── Config / guardrail #2 ───────────────────────────────────────────────────
+
+
+class TestAttributionConfig:
+    def test_disabled_by_default(self) -> None:
+        assert AttributionConfig().enabled is False
+        assert TraceforgeConfig().attribution.enabled is False
+
+    def test_default_dimensions_are_the_full_trace_native_set(self) -> None:
+        assert AttributionConfig().dimensions == list(TRACE_NATIVE_DIMENSIONS)
+
+    def test_accepts_a_trace_native_subset(self) -> None:
+        cfg = AttributionConfig(dimensions=["tool", "phase"])
+        assert cfg.dimensions == ["tool", "phase"]
+
+    @pytest.mark.parametrize("bad", ["team", "cost_center", "product", "customer", "org"])
+    def test_rejects_consumer_taxonomy_dimension(self, bad: str) -> None:
+        # Guardrail #2: a consumer-named key is not a trace-native dimension.
+        with pytest.raises(ValidationError):
+            AttributionConfig(dimensions=[bad])
+
+    def test_rejects_consumer_key_mixed_with_valid_ones(self) -> None:
+        with pytest.raises(ValidationError):
+            AttributionConfig(dimensions=["tool", "team"])
+
+    def test_parent_config_appends_attribution_field(self) -> None:
+        cfg = TraceforgeConfig()
+        assert isinstance(cfg.attribution, AttributionConfig)
+
+
+class TestBuildAttributor:
+    def test_returns_none_when_disabled(self) -> None:
+        assert build_attributor(AttributionConfig()) is None
+
+    def test_returns_instance_when_enabled(self) -> None:
+        att = build_attributor(AttributionConfig(enabled=True))
+        assert isinstance(att, Attributor)
+        assert att.enabled is True
+
+
+# ─── Hard bar: disabled == byte-identical no-op ──────────────────────────────
+
+
+class TestDisabledIsNoOp:
+    """The default (no attributor) path must not alter or replace any object."""
+
+    def test_attribution_is_none_by_default(self) -> None:
+        assert _plain_pipeline(sinks=[]).attribution is None
+
+    async def test_push_span_preserves_object_identity_when_off(self) -> None:
+        recording = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[recording.sink])
+        span = _span_ms(1000, tool="read")
+
+        await pipeline.push_span(span)
+        await pipeline.flush()
+
+        assert recording.spans[0] is span
+        assert DURATION_MS_ATTR not in recording.spans[0].attributes
+
+    async def test_push_usage_preserves_object_identity_when_off(self) -> None:
+        recording = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[recording.sink])
+        usage = make_usage(cost_usd=0.5, attributes={"tool": "read"})
+
+        await pipeline.push_usage(usage)
+        await pipeline.flush()
+
+        assert recording.usages[0] is usage
+        assert recording.usages[0].cost_breakdown is None
+
+    async def test_delivered_span_and_usage_are_byte_identical_when_off(self) -> None:
+        # The regression proof: with attribution off, the existing pipeline path
+        # returns the same values it always did — identical serialization.
+        recording = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[recording.sink])
+        span = _span_ms(1234, tool="read", phase="implement")
+        usage = make_usage(cost_usd=0.25, attributes={"tool": "read"})
+        span_json_before = span.model_dump_json()
+        usage_json_before = usage.model_dump_json()
+
+        await pipeline.push_span(span)
+        await pipeline.push_usage(usage)
+        await pipeline.flush()
+
+        assert recording.spans[0].model_dump_json() == span_json_before
+        assert recording.usages[0].model_dump_json() == usage_json_before
+
+    def test_directly_constructed_disabled_attributor_is_identity(self) -> None:
+        # Even an explicitly-built disabled instance is a strict no-op — non-vacuous
+        # complement to the enabled tests below.
+        att = Attributor(AttributionConfig(enabled=False))
+        span = _span_ms(500, tool="read")
+        usage = make_usage(cost_usd=0.5, attributes={"tool": "read"})
+
+        assert att.enrich_span(span) is span
+        assert att.enrich_usage(usage) is usage
+        assert att.rollups() == []
+
+
+# ─── Enabled: span enrichment ────────────────────────────────────────────────
+
+
+class TestEnabledSpanEnrichment:
+    def test_span_stamped_with_duration_ms(self) -> None:
+        att = _enabled()
+        enriched = att.enrich_span(_span_ms(1500, tool="read"))
+        assert enriched.attributes[DURATION_MS_ATTR] == 1500.0
+        assert enriched.attributes["tool"] == "read"
+
+    def test_enriched_span_is_a_new_object_original_unmutated(self) -> None:
+        att = _enabled()
+        span = _span_ms(750, tool="read")
+        enriched = att.enrich_span(span)
+        assert enriched is not span
+        assert DURATION_MS_ATTR not in span.attributes
+
+    async def test_pipeline_enriches_delivered_span(self) -> None:
+        recording = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[recording.sink], attribution=_enabled())
+        await pipeline.push_span(_span_ms(2000, tool="read"))
+        await pipeline.flush()
+        assert recording.spans[0].attributes[DURATION_MS_ATTR] == 2000.0
+
+
+# ─── Enabled: usage cost breakdown ───────────────────────────────────────────
+
+
+class TestEnabledCostBreakdown:
+    def test_breakdown_from_pricing(self) -> None:
+        att = _enabled(pricing={"gpt": ModelPricing(input_per_1k_usd=0.01, output_per_1k_usd=0.03)})
+        usage = make_usage(
+            model="gpt", input_tokens=1000, output_tokens=500, attributes={"tool": "x"}
+        )
+        breakdown = att.enrich_usage(usage).cost_breakdown
+        assert breakdown == CostBreakdown(
+            input_cost_usd=0.01, output_cost_usd=0.015, total_cost_usd=0.025
+        )
+
+    def test_breakdown_splits_known_cost_by_token_share(self) -> None:
+        att = _enabled()
+        usage = make_usage(
+            input_tokens=1000, output_tokens=1000, cost_usd=0.30, attributes={"tool": "x"}
+        )
+        breakdown = att.enrich_usage(usage).cost_breakdown
+        assert breakdown.input_cost_usd == pytest.approx(0.15)
+        assert breakdown.output_cost_usd == pytest.approx(0.15)
+        assert breakdown.total_cost_usd == 0.30
+
+    def test_breakdown_parts_always_resum_to_total(self) -> None:
+        att = _enabled()
+        usage = make_usage(input_tokens=3, output_tokens=7, cost_usd=0.1, attributes={"tool": "x"})
+        b = att.enrich_usage(usage).cost_breakdown
+        assert b.input_cost_usd + b.output_cost_usd == b.total_cost_usd
+
+    def test_no_breakdown_when_no_price_and_no_cost(self) -> None:
+        att = _enabled()
+        usage = make_usage(model="unknown", cost_usd=None, attributes={"tool": "x"})
+        result = att.enrich_usage(usage)
+        # Nothing to derive: the object is returned unchanged (identity), yet it
+        # still counts toward the rollups at zero cost.
+        assert result is usage
+        assert result.cost_breakdown is None
+        assert att.rollups()[0].usage_count == 1
+
+    def test_zero_token_known_cost_puts_all_in_output(self) -> None:
+        att = _enabled()
+        usage = make_usage(input_tokens=0, output_tokens=0, cost_usd=0.4, attributes={"tool": "x"})
+        b = att.enrich_usage(usage).cost_breakdown
+        assert b.input_cost_usd == 0.0
+        assert b.output_cost_usd == 0.4
+        assert b.total_cost_usd == 0.4
+
+
+# ─── Rollups ─────────────────────────────────────────────────────────────────
+
+
+class TestRollups:
+    def test_span_and_usage_coexist_in_one_bucket(self) -> None:
+        att = _enabled()
+        att.enrich_span(_span_ms(100, tool="read"))
+        att.enrich_usage(make_usage(cost_usd=0.5, attributes={"tool": "read"}))
+        (rollup,) = att.rollups()
+        assert rollup == AttributionRollup(
+            dimension="tool",
+            key="read",
+            span_count=1,
+            total_duration_ms=100.0,
+            usage_count=1,
+            total_cost_usd=0.5,
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+    def test_one_unit_fans_into_every_present_dimension(self) -> None:
+        att = _enabled()
+        att.enrich_span(_span_ms(300, tool="read", phase="implement"))
+        keys = {(r.dimension, r.key) for r in att.rollups()}
+        assert keys == {("tool", "read"), ("phase", "implement")}
+
+    def test_only_configured_dimensions_are_rolled_up(self) -> None:
+        att = _enabled(dimensions=["tool"])
+        att.enrich_span(_span_ms(300, tool="read", phase="implement"))
+        dims = {r.dimension for r in att.rollups()}
+        assert dims == {"tool"}
+
+    def test_rollups_deterministically_ordered(self) -> None:
+        att = _enabled()
+        att.enrich_span(_span_ms(1, tool="write"))
+        att.enrich_span(_span_ms(1, tool="read"))
+        att.enrich_span(_span_ms(1, phase="verify"))
+        att.enrich_span(_span_ms(1, turn="2"))
+        ordered = [(r.dimension, r.key) for r in att.rollups()]
+        # phase < turn < tool by trace-native rank; keys sorted within a dimension.
+        assert ordered == [("phase", "verify"), ("turn", "2"), ("tool", "read"), ("tool", "write")]
+
+    def test_rollups_are_idempotent(self) -> None:
+        att = _enabled()
+        att.enrich_span(_span_ms(100, tool="read"))
+        first = att.rollups()
+        second = att.rollups()
+        assert first == second
+        assert first[0].span_count == 1
+
+
+# ─── Anomalies ───────────────────────────────────────────────────────────────
+
+
+class TestAnomalies:
+    def test_none_by_default(self) -> None:
+        att = _enabled()
+        att.enrich_span(_span_ms(9999, tool="read"))
+        assert att.anomalies() == []
+
+    def test_duration_threshold(self) -> None:
+        att = _enabled(duration_threshold_ms=100)
+        att.enrich_span(_span_ms(60, tool="read"))
+        att.enrich_span(_span_ms(200, tool="write"))
+        flagged = att.anomalies()
+        assert flagged == [
+            Anomaly(
+                dimension="tool",
+                key="write",
+                metric=DURATION_MS_ATTR,
+                kind="threshold",
+                value=200.0,
+                threshold=100.0,
+            )
+        ]
+
+    def test_cost_threshold(self) -> None:
+        att = _enabled(cost_threshold_usd=0.10)
+        att.enrich_usage(make_usage(cost_usd=0.50, attributes={"tool": "read"}))
+        att.enrich_usage(make_usage(cost_usd=0.05, attributes={"tool": "write"}))
+        flagged = att.anomalies()
+        assert [(a.key, a.metric, a.kind) for a in flagged] == [("read", "cost_usd", "threshold")]
+
+    def test_zscore_flags_only_the_outlier(self) -> None:
+        att = _enabled(zscore_threshold=1.5, min_samples=3)
+        for tool in ("a", "b", "c", "d"):
+            att.enrich_span(_span_ms(10, tool=tool))
+        att.enrich_span(_span_ms(1000, tool="e"))
+        flagged = att.anomalies()
+        assert len(flagged) == 1
+        assert flagged[0].key == "e"
+        assert flagged[0].kind == "zscore"
+        assert flagged[0].metric == DURATION_MS_ATTR
+        assert flagged[0].score == pytest.approx(2.0)
+
+    def test_zscore_requires_min_samples(self) -> None:
+        att = _enabled(zscore_threshold=1.0, min_samples=3)
+        att.enrich_span(_span_ms(10, tool="a"))
+        att.enrich_span(_span_ms(1000, tool="b"))
+        assert att.anomalies() == []
+
+    def test_zscore_skips_zero_variance(self) -> None:
+        att = _enabled(zscore_threshold=1.0, min_samples=3)
+        for tool in ("a", "b", "c"):
+            att.enrich_span(_span_ms(50, tool=tool))
+        assert att.anomalies() == []
+
+
+# ─── Pipeline integration ────────────────────────────────────────────────────
+
+
+class TestPipelineIntegration:
+    def test_attribution_property_returns_attached_instance(self) -> None:
+        att = _enabled()
+        pipeline = _plain_pipeline(sinks=[], attribution=att)
+        assert pipeline.attribution is att
+
+    async def test_rollups_available_after_flush(self) -> None:
+        recording = RecordingSink()
+        att = _enabled(pricing={"gpt": ModelPricing(input_per_1k_usd=0.01, output_per_1k_usd=0.02)})
+        pipeline = _plain_pipeline(sinks=[recording.sink], attribution=att)
+
+        await pipeline.push_span(_span_ms(500, tool="read"))
+        await pipeline.push_usage(
+            make_usage(
+                model="gpt", input_tokens=1000, output_tokens=1000, attributes={"tool": "read"}
+            )
+        )
+        await pipeline.flush()
+
+        (rollup,) = pipeline.attribution.rollups()
+        assert rollup.dimension == "tool"
+        assert rollup.key == "read"
+        assert rollup.total_duration_ms == 500.0
+        assert rollup.total_cost_usd == pytest.approx(0.03)
+
+    async def test_flush_does_not_emit_rollups_as_sink_writes(self) -> None:
+        # Rollups are read off ``pipeline.attribution`` — persisting them is the
+        # stacked follow-up's job, so flush must add no extra span / usage writes.
+        recording = RecordingSink()
+        pipeline = _plain_pipeline(sinks=[recording.sink], attribution=_enabled())
+
+        await pipeline.push_span(_span_ms(100, tool="read"))
+        await pipeline.push_usage(make_usage(cost_usd=0.1, attributes={"tool": "read"}))
+        await pipeline.flush()
+
+        assert len(recording.spans) == 1
+        assert len(recording.usages) == 1


### PR DESCRIPTION
## What & why (upstream item U11)

TraceForge had `on_span` / `on_usage` sink hooks but **no attribution framework**. This adds one: it keys cost and latency against the **trace-native** dimensions a run already has — `phase` / `turn` / `segment` / `tool` / `file` / `retry` — and never a consumer taxonomy. Downstream consumers attach their own taxonomies in their own layer, keyed off these trace-native rollups.

It mirrors the existing `PipelineMetrics` opt-in precedent: **attaching an `Attributor` is the only way to turn it on**, so when disabled (the default) the hot path pays nothing.

## Hard bar — disabled == byte-identical (proven)

With attribution off (`pipeline.attribution is None`, the default):
- `push_span` / `push_usage` deliver the **exact same object** they were handed (identity preserved).
- The delivered span/usage **serializes byte-identically** to the input.

Both are asserted in `TestDisabledIsNoOp` (incl. a `model_dump_json()` regression + a non-vacuous directly-constructed-disabled-instance complement).

## Guardrail #2 — trace-native only

Every rollup / attribute / anomaly key is a trace-native dimension. `AttributionConfig.dimensions` is constrained to `TRACE_NATIVE_DIMENSIONS` by a validator; a consumer-named key (`team`, `cost_center`, `product`, …) is **rejected at validation** (parametrized test). The attributor re-filters defensively as a second guard.

## What's included

- **`telemetry/attribution.py`** (new): `Attributor` engine + `build_attributor()` factory (returns `None` when disabled), `AttributionRollup`, `Anomaly`.
- **`types.py`**: `TRACE_NATIVE_DIMENSIONS` vocabulary, `CostBreakdown`, and symmetric `UsageRecord.attributes` + `UsageRecord.cost_breakdown` enrichment fields.
- **`config/models.py`**: `AttributionConfig` (opt-in) + `ModelPricing`, validator for guardrail #2, plus one field appended to `TraceforgeConfig`.
- **`pipeline.py`**: opt-in `attribution` param/property + guarded enrichment in `push_span`/`push_usage`; rollups computed at flush (read back off `pipeline.attribution`, **no sink emission**).

Rollups aggregate span duration/count + usage cost/tokens per `(dimension, key)`; anomalies via absolute **threshold** and/or per-dimension **z-score**. Cost breakdown is deterministic: per-model pricing when configured, else proportional split of a known `cost_usd` (output derived as the remainder so parts re-sum exactly).

## Stack contract

The public shapes (`TelemetrySpan.attributes`, `UsageRecord.attributes`/`cost_breakdown`, `AttributionRollup`, `Anomaly`, `CostBreakdown`) are **final**. **No sink tables or migrations here** — a stacked follow-up branches off this and persists these shapes.

## Verification

- `ruff check .` clean; `ruff format --check .` clean (ruff 0.15.20).
- Full `tests/unit`: **2310 passed, 3 skipped** (2271 baseline + 39 new).

## Design fork (flagged)

Added `UsageRecord.attributes` (symmetric with `TelemetrySpan.attributes`) so cost carries trace-native dimensional context — without it, cost could only roll up globally. Conservative/clean default; delivers real per-dimension cost attribution.

**HELD — do not merge.** Held for the coordinator to verify and stack the follow-up.