### PR TITLE
feat(sinks): persist spans, usage, and attribution rollups in SQLite sink (U13)

### DIFF
--- a/src/traceforge/pipeline.py
+++ b/src/traceforge/pipeline.py
@@ -920,13 +920,24 @@ class EventPipeline:
             logger.debug("EventPipeline self-metrics at flush: %s", self._metrics.snapshot())
 
         # Attribution rollups are computed at flush from the accumulated spans /
-        # usage and read back off ``pipeline.attribution`` (no sink emission here —
-        # persisting them is the stacked follow-up's concern). Off = nothing runs.
+        # usage and read back off ``pipeline.attribution``. When attribution is off
+        # (``self._attribution is None``) nothing here runs — a no-attribution run
+        # is byte-identical. When on, the terminal roll-up + anomaly flags fan out
+        # once to every sink via ``on_attribution`` (opt-in; the base hook is a
+        # no-op, so only sinks that persist them — e.g. ``SqliteOutputSink`` — act).
         if self._attribution is not None:
+            rollups = self._attribution.rollups()
+            anomalies = self._attribution.anomalies()
             logger.debug(
-                "EventPipeline attribution at flush: %d rollup(s)",
-                len(self._attribution.rollups()),
+                "EventPipeline attribution at flush: %d rollup(s), %d anomaly(ies)",
+                len(rollups),
+                len(anomalies),
             )
+            if rollups or anomalies:
+                await self._fanout(
+                    (sink.on_attribution(rollups, anomalies) for sink in self._sinks),
+                    "attribution rollups",
+                )
 
     async def _push_to_sinks(self, event: SessionEvent) -> None:
         """Push event to sinks, stamping governance first if a stage is wired in.

--- a/src/traceforge/sinks/base.py
+++ b/src/traceforge/sinks/base.py
@@ -10,6 +10,7 @@ from traceforge.types import ProgressUpdate, SessionEvent, TelemetrySpan, TitleU
 
 if TYPE_CHECKING:
     from traceforge.governance.envelope import EnrichedEvent
+    from traceforge.telemetry.attribution import Anomaly, AttributionRollup
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,23 @@ class StorageSink(ABC):
 
     async def on_usage(self, usage: UsageRecord) -> None:
         """Handle a usage record. Default no-op."""
+
+    async def on_attribution(
+        self,
+        rollups: "list[AttributionRollup]",
+        anomalies: "list[Anomaly]",
+    ) -> None:
+        """Handle the terminal cost/latency attribution roll-up. Default no-op.
+
+        Emitted once at :meth:`traceforge.pipeline.EventPipeline.flush` when — and
+        only when — attribution is enabled, carrying the per-``(dimension, key)``
+        :class:`~traceforge.telemetry.attribution.AttributionRollup` list and the
+        :class:`~traceforge.telemetry.attribution.Anomaly` flags accumulated from
+        the run's spans / usage. Like ``on_span``/``on_usage`` this is an optional
+        signal, so the base default silently drops it — a sink opts in by
+        overriding (``SqliteOutputSink`` does). When attribution is off the pipeline
+        never calls this, so a no-attribution run is unaffected.
+        """
 
     async def on_progress(self, update: ProgressUpdate) -> None:
         """Handle a live incremental progress headline. Default no-op.

--- a/src/traceforge/sinks/sqlite_output.py
+++ b/src/traceforge/sinks/sqlite_output.py
@@ -1,4 +1,12 @@
-"""SQLite output sink — stores enriched events in a queryable database."""
+"""SQLite output sink — stores enriched events, spans, usage, and attribution.
+
+The sink owns its own on-disk schema (:data:`_CREATE_TABLE`), created idempotently
+with ``CREATE TABLE IF NOT EXISTS`` the first time a connection opens. This is a
+standalone output database, distinct from the Alembic-managed governance
+``system.db``; there is no versioned migration here — the schema is defined once,
+in full, and rewritten in place when it grows (traceforge has never shipped a DB,
+so no upgrade/back-compat path exists).
+"""
 
 from __future__ import annotations
 
@@ -7,11 +15,28 @@ import json
 import logging
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from traceforge.sinks.base import StorageSink
 from traceforge.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
 
+if TYPE_CHECKING:
+    from traceforge.telemetry.attribution import Anomaly, AttributionRollup
+
 logger = logging.getLogger(__name__)
+
+
+def _coerce_float(value: object) -> float | None:
+    """Return ``value`` as a float when it is a real number, else ``None``.
+
+    Event payloads are open dicts, so a producer-supplied ``cost_usd`` may be
+    missing or non-numeric. Booleans are rejected (``bool`` is an ``int`` subclass
+    but never a cost).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
 
 _CREATE_TABLE = """\
 CREATE TABLE IF NOT EXISTS enriched_events (
@@ -23,6 +48,10 @@ CREATE TABLE IF NOT EXISTS enriched_events (
     risk_level TEXT,
     risk_score INTEGER,
     action TEXT,
+    tool_display TEXT,
+    verdict TEXT,
+    cost REAL,
+    duration_ms REAL,
     payload_json TEXT,
     metadata_json TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -60,14 +89,74 @@ CREATE TABLE IF NOT EXISTS context_gaps (
 );
 
 CREATE INDEX IF NOT EXISTS idx_context_gaps_session ON context_gaps(session_id);
+
+CREATE TABLE IF NOT EXISTS spans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    start_time TEXT NOT NULL,
+    end_time TEXT NOT NULL,
+    duration_ms REAL,
+    attributes_json TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_spans_session ON spans(session_id);
+CREATE INDEX IF NOT EXISTS idx_spans_name ON spans(name);
+
+CREATE TABLE IF NOT EXISTS usage_records (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    model TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    cost_usd REAL,
+    input_cost_usd REAL,
+    output_cost_usd REAL,
+    total_cost_usd REAL,
+    attributes_json TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_records(session_id);
+CREATE INDEX IF NOT EXISTS idx_usage_model ON usage_records(model);
+
+CREATE TABLE IF NOT EXISTS attribution_rollups (
+    dimension TEXT NOT NULL,
+    key TEXT NOT NULL,
+    span_count INTEGER NOT NULL,
+    total_duration_ms REAL NOT NULL,
+    usage_count INTEGER NOT NULL,
+    total_cost_usd REAL NOT NULL,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (dimension, key)
+);
+
+CREATE TABLE IF NOT EXISTS attribution_anomalies (
+    dimension TEXT NOT NULL,
+    key TEXT NOT NULL,
+    metric TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    value REAL NOT NULL,
+    threshold REAL NOT NULL,
+    score REAL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (dimension, key, metric, kind)
+);
 """
 
 
 class SqliteOutputSink(StorageSink):
-    """Persists enriched events to a SQLite database.
+    """Persists enriched events, telemetry spans, usage records, and attribution
+    roll-ups to a SQLite database.
 
-    Provides a queryable local audit trail with indexed columns for
-    session_id, timestamp, risk_level, and action.
+    Provides a queryable local audit trail: ``enriched_events`` (indexed by
+    session_id, timestamp, risk_level, action, and carrying trace-native
+    tool_display / verdict / cost / duration_ms), ``spans``, ``usage_records``,
+    and the terminal ``attribution_rollups`` / ``attribution_anomalies`` tables.
     """
 
     _VALID_JOURNAL_MODES = frozenset({"wal", "delete", "truncate", "persist", "memory", "off"})
@@ -87,11 +176,21 @@ class SqliteOutputSink(StorageSink):
         risk_level = None
         risk_score = None
         action = None
+        tool_display = None
+        verdict = None
+        cost = None
+        duration_ms = None
 
         if event.payload:
             tool_name = event.payload.get("tool_name")
+            # Per-event cost is best-effort: SessionEvent has no dedicated cost
+            # field, so a producer stamps it in the payload (e.g. on an
+            # ``llm.call.completed``). Authoritative cost lives in ``usage_records``.
+            cost = _coerce_float(event.payload.get("cost_usd"))
 
         if event.metadata:
+            tool_display = event.metadata.tool_display
+            duration_ms = event.metadata.duration_ms
             gov = event.metadata.governance
             if gov is not None:
                 if gov.risk_assessment is not None:
@@ -99,6 +198,9 @@ class SqliteOutputSink(StorageSink):
                     risk_score = gov.risk_assessment.score
                 if gov.recommendation is not None:
                     action = gov.recommendation.recommended_action.value
+                    # The recommended action is already stored in ``action``;
+                    # ``verdict`` carries the previously-unpersisted reason for it.
+                    verdict = gov.recommendation.reason_code
 
         payload_json = json.dumps(event.payload, default=str) if event.payload else None
         metadata_json = (
@@ -116,6 +218,10 @@ class SqliteOutputSink(StorageSink):
             risk_level,
             risk_score,
             action,
+            tool_display,
+            verdict,
+            cost,
+            duration_ms,
             payload_json,
             metadata_json,
         )
@@ -128,8 +234,9 @@ class SqliteOutputSink(StorageSink):
         try:
             conn.execute(
                 """INSERT OR IGNORE INTO enriched_events
-                   (id, session_id, kind, timestamp, tool_name, risk_level, risk_score, action, payload_json, metadata_json)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   (id, session_id, kind, timestamp, tool_name, risk_level, risk_score, action,
+                    tool_display, verdict, cost, duration_ms, payload_json, metadata_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 params,
             )
             conn.commit()
@@ -137,10 +244,148 @@ class SqliteOutputSink(StorageSink):
             logger.error("SqliteOutputSink: write failed: %s", exc)
 
     async def on_span(self, span: TelemetrySpan) -> None:
-        pass
+        """Persist a telemetry span to the ``spans`` table.
+
+        ``duration_ms`` is derived from the span's own start/end (always available,
+        identical to the value the attributor stamps when enabled); the full
+        ``attributes`` bag — which additionally carries that stamp and any
+        trace-native dimension keys when attribution is on — is stored verbatim as
+        JSON. Works whether or not attribution is enabled.
+        """
+        duration_ms = (span.end_time - span.start_time).total_seconds() * 1000.0
+        params = (
+            span.session_id,
+            span.name,
+            span.start_time.isoformat() if span.start_time else None,
+            span.end_time.isoformat() if span.end_time else None,
+            duration_ms,
+            json.dumps(span.attributes, default=str) if span.attributes else None,
+        )
+        await asyncio.to_thread(self._write_span, params)
+
+    def _write_span(self, params: tuple) -> None:
+        """Synchronous span write — called via asyncio.to_thread."""
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO spans
+                   (session_id, name, start_time, end_time, duration_ms, attributes_json)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                params,
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.error("SqliteOutputSink: span write failed: %s", exc)
 
     async def on_usage(self, usage: UsageRecord) -> None:
-        pass
+        """Persist a usage record to the ``usage_records`` table.
+
+        Token counts and ``cost_usd`` are always stored; the input/output/total
+        :class:`~traceforge.types.CostBreakdown` columns are filled only when the
+        attributor has attached one (``None`` otherwise). The ``attributes`` bag
+        (trace-native dimension context) is stored verbatim as JSON.
+        """
+        breakdown = usage.cost_breakdown
+        params = (
+            usage.session_id,
+            usage.timestamp.isoformat() if usage.timestamp else None,
+            usage.model,
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cost_usd,
+            breakdown.input_cost_usd if breakdown is not None else None,
+            breakdown.output_cost_usd if breakdown is not None else None,
+            breakdown.total_cost_usd if breakdown is not None else None,
+            json.dumps(usage.attributes, default=str) if usage.attributes else None,
+        )
+        await asyncio.to_thread(self._write_usage, params)
+
+    def _write_usage(self, params: tuple) -> None:
+        """Synchronous usage write — called via asyncio.to_thread."""
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO usage_records
+                   (session_id, timestamp, model, input_tokens, output_tokens, cost_usd,
+                    input_cost_usd, output_cost_usd, total_cost_usd, attributes_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                params,
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.error("SqliteOutputSink: usage write failed: %s", exc)
+
+    async def on_attribution(
+        self,
+        rollups: "list[AttributionRollup]",
+        anomalies: "list[Anomaly]",
+    ) -> None:
+        """Persist the terminal attribution roll-up + anomaly flags.
+
+        Called once at pipeline flush when attribution is enabled. Rollups upsert
+        by ``(dimension, key)`` and anomalies by ``(dimension, key, metric, kind)``
+        so re-flushing overwrites the latest cumulative values in place — no stale
+        rows accumulate and there is no dual-write. Every ``dimension`` is a
+        trace-native key by construction (the attributor rejects anything else).
+        """
+        rollup_params = [
+            (
+                r.dimension,
+                r.key,
+                r.span_count,
+                r.total_duration_ms,
+                r.usage_count,
+                r.total_cost_usd,
+                r.input_tokens,
+                r.output_tokens,
+            )
+            for r in rollups
+        ]
+        anomaly_params = [
+            (a.dimension, a.key, a.metric, a.kind, a.value, a.threshold, a.score) for a in anomalies
+        ]
+        if rollup_params or anomaly_params:
+            await asyncio.to_thread(self._write_attribution, rollup_params, anomaly_params)
+
+    def _write_attribution(
+        self,
+        rollup_params: list[tuple],
+        anomaly_params: list[tuple],
+    ) -> None:
+        """Synchronous attribution write — called via asyncio.to_thread."""
+        conn = self._get_conn()
+        try:
+            if rollup_params:
+                conn.executemany(
+                    """INSERT INTO attribution_rollups
+                       (dimension, key, span_count, total_duration_ms, usage_count,
+                        total_cost_usd, input_tokens, output_tokens)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(dimension, key) DO UPDATE SET
+                           span_count=excluded.span_count,
+                           total_duration_ms=excluded.total_duration_ms,
+                           usage_count=excluded.usage_count,
+                           total_cost_usd=excluded.total_cost_usd,
+                           input_tokens=excluded.input_tokens,
+                           output_tokens=excluded.output_tokens,
+                           updated_at=datetime('now')""",
+                    rollup_params,
+                )
+            if anomaly_params:
+                conn.executemany(
+                    """INSERT INTO attribution_anomalies
+                       (dimension, key, metric, kind, value, threshold, score)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(dimension, key, metric, kind) DO UPDATE SET
+                           value=excluded.value,
+                           threshold=excluded.threshold,
+                           score=excluded.score,
+                           updated_at=datetime('now')""",
+                    anomaly_params,
+                )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.error("SqliteOutputSink: attribution write failed: %s", exc)
 
     async def on_enriched_event(self, enriched) -> None:
         """Persist a governance envelope. Live events keep byte-identical output

--- a/tests/e2e/test_sink_sqlite_e2e.py
+++ b/tests/e2e/test_sink_sqlite_e2e.py
@@ -6,23 +6,42 @@ columns, and values persisted. Covers the queryable governance columns, the
 title upsert (keep-highest-version), the context-gaps table, id de-duplication,
 and the two *defined* failure behaviors observed in this sink — a write error is
 swallowed and logged (prior rows survive), while a connection error propagates.
+
+The U13 section additionally proves span / usage / attribution persistence: the
+new ``spans``, ``usage_records``, ``attribution_rollups`` and
+``attribution_anomalies`` tables round-trip (including the ``cost_breakdown``
+columns and idempotent rollup upserts), the trace-native ``enriched_events``
+columns (tool_display / verdict / cost / duration_ms) populate for an enriched
+event and stay NULL for a bare one, and an end-to-end pipeline with attribution
+*off* still persists arriving spans/usage while producing zero rollups.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
-from tests.conftest import make_event
+from tests.conftest import make_event, make_span, make_usage
 from tests.e2e._sink_governance import governed_event
+from traceforge import Attributor, EventPipeline
+from traceforge.config.models import AttributionConfig, ModelPricing
 from traceforge.governance.envelope import ContextGapEvent, EnrichedEvent
 from traceforge.governance.results import SessionMeta
 from traceforge.sinks.sqlite_output import SqliteOutputSink
-from traceforge.types import EventKind, TitleUpdate
+from traceforge.telemetry.attribution import Anomaly, AttributionRollup
+from traceforge.types import (
+    CostBreakdown,
+    EventKind,
+    EventMetadata,
+    TelemetrySpan,
+    TitleUpdate,
+    UsageRecord,
+)
 
 
 def _query(db: Path, sql: str, params: tuple = ()) -> list[tuple]:
@@ -195,3 +214,324 @@ async def test_sqlite_connection_error_propagates(tmp_path: Path) -> None:
     sink = SqliteOutputSink(path=str(tmp_path))  # a directory, not a file
     with pytest.raises(sqlite3.OperationalError):
         await sink.on_event(make_event(session_id="x"))
+
+
+# ─── U13: spans / usage / attribution persistence ───────────────────────────
+
+
+@pytest.mark.e2e
+async def test_sqlite_new_tables_and_enriched_columns_exist(tmp_path: Path) -> None:
+    """The new tables and the trace-native ``enriched_events`` columns are all
+    created by the sink's single ``CREATE TABLE IF NOT EXISTS`` schema."""
+    db = tmp_path / "schema2.db"
+    sink = SqliteOutputSink(path=str(db))
+    await sink.on_event(make_event(session_id="s"))
+    await sink.close()
+
+    tables = {row[0] for row in _query(db, "SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"spans", "usage_records", "attribution_rollups", "attribution_anomalies"} <= tables
+
+    cols = {row[1] for row in _query(db, "PRAGMA table_info(enriched_events)")}
+    assert {"tool_display", "verdict", "cost", "duration_ms"} <= cols
+
+
+@pytest.mark.e2e
+async def test_sqlite_span_round_trips(tmp_path: Path) -> None:
+    db = tmp_path / "spans.db"
+    sink = SqliteOutputSink(path=str(db))
+    start = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 1, 0, 0, 2, tzinfo=timezone.utc)  # 2000 ms
+    await sink.on_span(
+        TelemetrySpan(
+            name="tool.execute",
+            session_id="sp",
+            start_time=start,
+            end_time=end,
+            attributes={"tool": "bash", "phase": "implement"},
+        )
+    )
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT session_id, name, start_time, end_time, duration_ms, attributes_json FROM spans",
+    )
+    assert len(rows) == 1
+    session_id, name, s, e, duration_ms, attrs = rows[0]
+    assert (session_id, name, duration_ms) == ("sp", "tool.execute", 2000.0)
+    assert s == start.isoformat()
+    assert e == end.isoformat()
+    assert json.loads(attrs) == {"tool": "bash", "phase": "implement"}
+
+
+@pytest.mark.e2e
+async def test_sqlite_usage_round_trips_with_cost_breakdown(tmp_path: Path) -> None:
+    db = tmp_path / "usage.db"
+    sink = SqliteOutputSink(path=str(db))
+    ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    await sink.on_usage(
+        UsageRecord(
+            session_id="u1",
+            timestamp=ts,
+            model="gpt-4o",
+            input_tokens=1000,
+            output_tokens=500,
+            cost_usd=0.9,
+            attributes={"tool": "bash", "turn": "3"},
+            cost_breakdown=CostBreakdown(
+                input_cost_usd=0.6, output_cost_usd=0.3, total_cost_usd=0.9
+            ),
+        )
+    )
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT session_id, model, input_tokens, output_tokens, cost_usd, "
+        "input_cost_usd, output_cost_usd, total_cost_usd, attributes_json FROM usage_records",
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row[:8] == ("u1", "gpt-4o", 1000, 500, 0.9, 0.6, 0.3, 0.9)
+    assert json.loads(row[8]) == {"tool": "bash", "turn": "3"}
+
+
+@pytest.mark.e2e
+async def test_sqlite_usage_without_breakdown_leaves_breakdown_columns_null(tmp_path: Path) -> None:
+    """A usage record from an attribution-off run has no ``cost_breakdown``; the
+    breakdown columns (and empty attributes) persist as NULL — non-breaking."""
+    db = tmp_path / "usage_nb.db"
+    sink = SqliteOutputSink(path=str(db))
+    ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    await sink.on_usage(
+        UsageRecord(session_id="u2", timestamp=ts, model="gpt-4o", input_tokens=10, output_tokens=5)
+    )
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT input_tokens, output_tokens, cost_usd, input_cost_usd, output_cost_usd, "
+        "total_cost_usd, attributes_json FROM usage_records WHERE session_id = 'u2'",
+    )
+    assert rows == [(10, 5, None, None, None, None, None)]
+
+
+@pytest.mark.e2e
+async def test_sqlite_attribution_rollups_and_anomalies_persist(tmp_path: Path) -> None:
+    db = tmp_path / "attr.db"
+    sink = SqliteOutputSink(path=str(db))
+    rollups = [
+        AttributionRollup(
+            dimension="tool",
+            key="bash",
+            span_count=2,
+            total_duration_ms=3000.0,
+            usage_count=1,
+            total_cost_usd=0.5,
+            input_tokens=100,
+            output_tokens=50,
+        ),
+        AttributionRollup(
+            dimension="phase",
+            key="implement",
+            span_count=1,
+            total_duration_ms=1000.0,
+            usage_count=0,
+            total_cost_usd=0.0,
+            input_tokens=0,
+            output_tokens=0,
+        ),
+    ]
+    anomalies = [
+        Anomaly(
+            dimension="tool",
+            key="bash",
+            metric="cost_usd",
+            kind="threshold",
+            value=0.5,
+            threshold=0.1,
+        )
+    ]
+    await sink.on_attribution(rollups, anomalies)
+    await sink.close()
+
+    got = _query(
+        db,
+        "SELECT dimension, key, span_count, total_duration_ms, usage_count, total_cost_usd, "
+        "input_tokens, output_tokens FROM attribution_rollups ORDER BY dimension, key",
+    )
+    assert got == [
+        ("phase", "implement", 1, 1000.0, 0, 0.0, 0, 0),
+        ("tool", "bash", 2, 3000.0, 1, 0.5, 100, 50),
+    ]
+
+    anom = _query(
+        db,
+        "SELECT dimension, key, metric, kind, value, threshold, score FROM attribution_anomalies",
+    )
+    assert anom == [("tool", "bash", "cost_usd", "threshold", 0.5, 0.1, None)]
+
+
+@pytest.mark.e2e
+async def test_sqlite_attribution_upsert_is_idempotent(tmp_path: Path) -> None:
+    """Rollups/anomalies are cumulative and idempotent: re-flushing the same
+    ``(dimension, key)`` overwrites in place — one row, latest values."""
+    db = tmp_path / "attr_idem.db"
+    sink = SqliteOutputSink(path=str(db))
+
+    def rollup(span_count: int, cost: float) -> AttributionRollup:
+        return AttributionRollup(
+            dimension="tool",
+            key="bash",
+            span_count=span_count,
+            total_duration_ms=span_count * 1000.0,
+            usage_count=span_count,
+            total_cost_usd=cost,
+            input_tokens=span_count * 10,
+            output_tokens=span_count * 5,
+        )
+
+    await sink.on_attribution([rollup(1, 0.2)], [])
+    await sink.on_attribution([rollup(3, 0.6)], [])  # later cumulative snapshot
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT span_count, total_cost_usd FROM attribution_rollups WHERE dimension='tool' AND key='bash'",
+    )
+    assert rows == [(3, 0.6)]
+    (count,) = _query(db, "SELECT COUNT(*) FROM attribution_rollups")[0]
+    assert count == 1
+
+
+@pytest.mark.e2e
+async def test_sqlite_enriched_trace_native_columns_populate(tmp_path: Path) -> None:
+    """An enriched event carries tool_display + duration_ms + a governance verdict,
+    and a payload cost; all four trace-native columns persist."""
+    db = tmp_path / "enr.db"
+    sink = SqliteOutputSink(path=str(db))
+    governance = governed_event("deny", reason_code="rule.block").metadata.governance
+    metadata = EventMetadata(tool_display="Delete file", duration_ms=1500.0, governance=governance)
+    event = make_event(
+        kind=EventKind.TOOL_CALL_STARTED,
+        session_id="e1",
+        payload={"tool_name": "rm", "cost_usd": 0.04},
+        metadata=metadata,
+    )
+    await sink.on_event(event)
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT tool_display, verdict, cost, duration_ms, action FROM enriched_events WHERE session_id = 'e1'",
+    )
+    assert rows == [("Delete file", "rule.block", 0.04, 1500.0, "deny")]
+
+
+@pytest.mark.e2e
+async def test_sqlite_enriched_trace_native_columns_null_when_absent(tmp_path: Path) -> None:
+    """A bare event (attribution/enrichment off) leaves every new trace-native
+    column NULL — the event path is unchanged."""
+    db = tmp_path / "enr_null.db"
+    sink = SqliteOutputSink(path=str(db))
+    await sink.on_event(make_event(session_id="e2", payload={"content": "hi"}))
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT tool_display, verdict, cost, duration_ms FROM enriched_events WHERE session_id = 'e2'",
+    )
+    assert rows == [(None, None, None, None)]
+
+
+# ─── U13: end-to-end pipeline → sqlite (attribution off is non-breaking) ──────
+
+
+def _pipeline(sink: SqliteOutputSink, attribution: Attributor | None) -> EventPipeline:
+    # Inferencers off: drive the span/usage/attribution path straight to the sink.
+    return EventPipeline(
+        sinks=[sink], attribution=attribution, enable_phase=False, enable_boundary=False
+    )
+
+
+@pytest.mark.e2e
+async def test_pipeline_attribution_off_persists_span_usage_without_rollups(
+    tmp_path: Path,
+) -> None:
+    """Attribution off (the default): spans and usage still arrive at the sink and
+    persist (cost_breakdown columns NULL), and NO attribution rollups are produced
+    — the event/span/usage path is unaffected."""
+    db = tmp_path / "pipe_off.db"
+    sink = SqliteOutputSink(path=str(db))
+    pipeline = _pipeline(sink, None)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    await pipeline.push_span(
+        make_span(name="s", session_id="p", start_time=start, end_time=start + timedelta(seconds=1))
+    )
+    await pipeline.push_usage(
+        make_usage(
+            session_id="p",
+            model="gpt",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=0.2,
+            attributes={"tool": "read"},
+        )
+    )
+    await pipeline.flush()
+    await sink.close()
+
+    counts = (
+        _query(db, "SELECT COUNT(*) FROM spans")[0][0],
+        _query(db, "SELECT COUNT(*) FROM usage_records")[0][0],
+        _query(db, "SELECT COUNT(*) FROM attribution_rollups")[0][0],
+    )
+    assert counts == (1, 1, 0)  # span + usage persisted; zero rollups when off
+    breakdown = _query(
+        db,
+        "SELECT input_cost_usd, output_cost_usd, total_cost_usd FROM usage_records WHERE session_id='p'",
+    )
+    assert breakdown == [(None, None, None)]
+
+
+@pytest.mark.e2e
+async def test_pipeline_attribution_on_persists_rollups_and_breakdown(tmp_path: Path) -> None:
+    """Attribution on: the flush hand-off lands a rollup row, and the usage record
+    carries the attributor-derived cost_breakdown."""
+    db = tmp_path / "pipe_on.db"
+    sink = SqliteOutputSink(path=str(db))
+    att = Attributor(
+        AttributionConfig(
+            enabled=True,
+            pricing={"gpt": ModelPricing(input_per_1k_usd=0.01, output_per_1k_usd=0.02)},
+        )
+    )
+    pipeline = _pipeline(sink, att)
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    await pipeline.push_span(
+        make_span(
+            name="s",
+            session_id="p",
+            start_time=start,
+            end_time=start + timedelta(milliseconds=500),
+            attributes={"tool": "read"},
+        )
+    )
+    await pipeline.push_usage(
+        make_usage(
+            session_id="p",
+            model="gpt",
+            input_tokens=1000,
+            output_tokens=1000,
+            attributes={"tool": "read"},
+        )
+    )
+    await pipeline.flush()
+    await sink.close()
+
+    rollups = _query(db, "SELECT dimension, key, span_count, usage_count FROM attribution_rollups")
+    assert rollups == [("tool", "read", 1, 1)]
+    (total,) = _query(db, "SELECT total_cost_usd FROM usage_records WHERE session_id='p'")[0]
+    assert total is not None

--- a/tests/unit/test_pipeline_attribution_handoff.py
+++ b/tests/unit/test_pipeline_attribution_handoff.py
@@ -1,0 +1,114 @@
+"""The flush-time attribution hand-off that U13 wires from the pipeline to sinks.
+
+PR-10 (#143) computes cost/latency rollups but left *persisting* them to this
+slice. The pipeline now surfaces the terminal rollup + anomaly set to every sink
+through a dedicated :meth:`StorageSink.on_attribution` hook, called once at
+``flush`` — and only when attribution is enabled. These tests pin that contract:
+
+1. **On** — after spans/usage are pushed, ``flush`` calls ``on_attribution`` once
+   with the same rollups read off ``pipeline.attribution.rollups()``.
+2. **Off (the default)** — ``on_attribution`` is never called, so a
+   no-attribution run is unaffected (the non-breaking bar).
+3. **On but empty** — with nothing accumulated, the hand-off is skipped (no empty
+   call), mirroring the ``on_span``/``on_usage`` opt-in style.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from traceforge import (
+    Anomaly,
+    AttributionRollup,
+    Attributor,
+    EventPipeline,
+    SessionEvent,
+    StorageSink,
+)
+from traceforge.config.models import AttributionConfig, ModelPricing
+from tests.conftest import make_span, make_usage
+
+_EPOCH = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+class _AttributionRecordingSink(StorageSink):
+    """Records every ``on_attribution`` hand-off (and swallows events)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[AttributionRollup], list[Anomaly]]] = []
+
+    async def on_event(self, event: SessionEvent) -> None:  # abstract; unused here
+        return None
+
+    async def on_attribution(
+        self,
+        rollups: list[AttributionRollup],
+        anomalies: list[Anomaly],
+    ) -> None:
+        self.calls.append((list(rollups), list(anomalies)))
+
+
+def _pipeline(sink: StorageSink, attribution: Attributor | None) -> EventPipeline:
+    # Inferencers off: this exercises the span/usage/attribution path only.
+    return EventPipeline(
+        sinks=[sink], attribution=attribution, enable_phase=False, enable_boundary=False
+    )
+
+
+def _enabled() -> Attributor:
+    return Attributor(
+        AttributionConfig(
+            enabled=True,
+            pricing={"gpt": ModelPricing(input_per_1k_usd=0.01, output_per_1k_usd=0.02)},
+        )
+    )
+
+
+def _span_ms(duration_ms: float, **attributes) -> object:
+    return make_span(
+        start_time=_EPOCH,
+        end_time=_EPOCH + timedelta(milliseconds=duration_ms),
+        attributes=attributes,
+    )
+
+
+class TestAttributionHandoff:
+    async def test_enabled_flush_hands_rollups_to_sink(self) -> None:
+        sink = _AttributionRecordingSink()
+        pipeline = _pipeline(sink, _enabled())
+
+        await pipeline.push_span(_span_ms(500, tool="read"))
+        await pipeline.push_usage(
+            make_usage(
+                model="gpt", input_tokens=1000, output_tokens=1000, attributes={"tool": "read"}
+            )
+        )
+        await pipeline.flush()
+
+        assert len(sink.calls) == 1
+        rollups, _anomalies = sink.calls[0]
+        # The hand-off carries exactly what the attributor accumulated.
+        assert rollups == pipeline.attribution.rollups()
+        (rollup,) = rollups
+        assert (rollup.dimension, rollup.key) == ("tool", "read")
+        assert rollup.total_duration_ms == 500.0
+
+    async def test_disabled_flush_never_calls_on_attribution(self) -> None:
+        # The non-breaking bar: attribution off (the default) => no hand-off at all.
+        sink = _AttributionRecordingSink()
+        pipeline = _pipeline(sink, None)
+
+        await pipeline.push_span(_span_ms(500, tool="read"))
+        await pipeline.push_usage(make_usage(cost_usd=0.1, attributes={"tool": "read"}))
+        await pipeline.flush()
+
+        assert sink.calls == []
+
+    async def test_enabled_but_empty_skips_the_handoff(self) -> None:
+        # Nothing accumulated => no empty on_attribution call (opt-in semantics).
+        sink = _AttributionRecordingSink()
+        pipeline = _pipeline(sink, _enabled())
+
+        await pipeline.flush()
+
+        assert sink.calls == []

--- a/tests/unit/test_telemetry_attribution.py
+++ b/tests/unit/test_telemetry_attribution.py
@@ -368,8 +368,9 @@ class TestPipelineIntegration:
         assert rollup.total_cost_usd == pytest.approx(0.03)
 
     async def test_flush_does_not_emit_rollups_as_sink_writes(self) -> None:
-        # Rollups are read off ``pipeline.attribution`` — persisting them is the
-        # stacked follow-up's job, so flush must add no extra span / usage writes.
+        # Rollups persist through the dedicated ``on_attribution`` channel (U13), so
+        # flush must add no extra span / usage writes — the rollup hand-off must not
+        # double-count as span / usage rows.
         recording = RecordingSink()
         pipeline = _plain_pipeline(sinks=[recording.sink], attribution=_enabled())
 


### PR DESCRIPTION
## CP-PR11 / U13 — richer sink schema

Makes `SqliteOutputSink` durably persist the telemetry the pipeline already produces — telemetry **spans**, **usage/cost** records with input/output/total breakdowns, **attribution rollups/anomalies** — and adds **trace-native columns** to `enriched_events`. Last slice of CodePlane-upstream Wave B; branches off fresh `main` (#141 tool-display, #142 ProgressUpdate, #143 attribution all merged). PR-10 (#143) computes these shapes but nothing durably stored them — this closes that gap.

> ⚠️ **HELD — do not merge.** Opened for coordinator review. Merge lifecycle is the coordinator's.

### Files changed
| File | Change |
|---|---|
| `src/traceforge/sinks/sqlite_output.py` | New `spans`, `usage_records`, `attribution_rollups`, `attribution_anomalies` tables + 4 new `enriched_events` columns, all in the sink's own `_CREATE_TABLE`; real `on_span` / `on_usage` / `on_attribution` writers; `on_event` now populates the new columns. |
| `src/traceforge/sinks/base.py` | New no-op `on_attribution(rollups, anomalies)` hook (mirrors the `on_span` / `on_usage` opt-in pattern). |
| `src/traceforge/pipeline.py` | `flush()` hands the terminal rollup + anomaly set to sinks via `on_attribution`, opt-in and attribution-gated. |
| `tests/e2e/test_sink_sqlite_e2e.py` | span/usage/attribution round-trip, cost_breakdown, upsert idempotency, enriched-column populate/NULL, schema-exists, and end-to-end pipeline→sqlite (attribution-off non-breaking). |
| `tests/unit/test_pipeline_attribution_handoff.py` *(new)* | flush hand-off: on → called with rollups; off → never called; on-but-empty → skipped. |
| `tests/unit/test_telemetry_attribution.py` | Updated one now-stale comment (the "persisting is the follow-up's job" test documents the new `on_attribution` channel); **assertions unchanged**. |

### 🔱 Design fork for coordinator judgment — MIGRATION RULING
The ruling said fold new tables + `enriched_events` columns into `migrations/versions/0001_initial.py` + `migrations/models.py`. **Those define a *different* database.** `0001_initial` + `models.py` + `LATEST_REVISION` are the Alembic-managed **governance `system.db`** (`session_state`, `budget_counters`, …), consumed only by `governance/persistence.py`. `enriched_events` has never lived there. `SqliteOutputSink` writes a **separate, standalone output DB** via its own inline `_CREATE_TABLE` at an arbitrary caller-supplied path.

Adding spans/usage/rollups to `system.db`'s `0001_initial` would create schema **nothing ever writes** — dead phantom schema, exactly what the `[no-phantom-legacy]` ruling forbids.

**Decision:** apply the ruling's *intent* to the sink's own schema — fold all new tables + new `enriched_events` columns directly into the sink's `_CREATE_TABLE` (`CREATE TABLE IF NOT EXISTS`, columns inline in the CREATE, **no ALTER, no second schema version, no dual-write, no back-compat path**). `migrations/versions/0001_initial.py` and `migrations/models.py` are **untouched**; `LATEST_REVISION` stays `"0001_initial"` and `versions/` still contains only `0001_initial.py` (no 0002/0003). If you'd rather these tables also be mirrored into `system.db`, say the word — but that DB is never opened by this sink, so it would be write-only dead schema.

### Guardrail #2 — trace-native only (grep evidence)
Every new column is a trace-native dimension or metric: `session_id, name, start_time, end_time, duration_ms, attributes_json, model, input_tokens, output_tokens, cost_usd, input_cost_usd, output_cost_usd, total_cost_usd, dimension, key, span_count, usage_count, total_duration_ms, metric, kind, value, threshold, score, tool_display, verdict, cost`. Dimensional/consumer context stays inside the JSON `attributes` bag (already trace-native-keyed) — never hoisted into columns. `model` is an intrinsic trace fact (like `tool`), not a consumer taxonomy.

```
$ rg -i -w 'team|cost_center|customer|product|org|organization|plan_item|codeplane|department|tenant|account|user_id|owner|project|billing|plan' src/traceforge/sinks/sqlite_output.py
(no matches)
```

### Attribution-OFF is non-breaking (proof)
- **Hand-off gated** `if self._attribution is not None` in `pipeline.flush()` → off = the block never runs. Unit test `test_disabled_flush_never_calls_on_attribution` asserts `on_attribution` is never called; `test_flush_does_not_emit_rollups_as_sink_writes` still asserts no extra span/usage writes.
- **New `enriched_events` columns nullable/defaulted** → `test_sqlite_enriched_trace_native_columns_null_when_absent` asserts a bare event writes `(NULL, NULL, NULL, NULL)`; the existing byte-identical governed-event tests still pass unchanged.
- **End-to-end** `test_pipeline_attribution_off_persists_span_usage_without_rollups`: an attribution-off pipeline still persists arriving spans/usage (spans=1, usage=1, breakdown columns NULL) and produces **zero** `attribution_rollups` rows.
- `usage.cost_breakdown is None` when off → breakdown columns persist NULL (`test_sqlite_usage_without_breakdown_leaves_breakdown_columns_null`).

**Design note (honesty):** the `enriched_events` trace-native columns are sourced from enrichment/governance — `tool_display` (metadata), `duration_ms` (metadata), `verdict` (`recommendation.reason_code`), `cost` (best-effort `payload["cost_usd"]`) — **not** from the Attributor directly. So "populate when on / NULL when off" reads more precisely as *populate for an enriched/governed event, NULL for a bare event*. `SessionEvent` has no dedicated cost field; authoritative cost lives in `usage_records`, and per-event `cost` is a nullable convenience.

### Frozen files — none touched
`enricher.py`, `sources/*`, `sdk/pipeline.py push()`, `gate/*` IPC, and the #143 `telemetry/attribution.py` + `types.py` shapes are all unmodified (verified). The edited `pipeline.py` is the pipeline module, distinct from the frozen `sdk/pipeline.py`. PR-10's exact shapes are persisted as-is (`TelemetrySpan.attributes` +derived `duration_ms`, `UsageRecord.attributes` + `cost_breakdown`, `AttributionRollup`, `Anomaly`, `CostBreakdown`).

### `on_progress`
Left as the inherited no-op — `ProgressUpdate` is a live/streaming signal; persisting it is out of core U13 scope and would add risk to the event path for no durable benefit.

### Verification
- `uv run --no-progress python -m pytest -q -p no:cacheprovider` → **3428 passed, 8 skipped**.
- `uv run --no-progress --with "ruff==0.15.20" ruff check` → **All checks passed!**
- `uv run --no-progress --with "ruff==0.15.20" ruff format --check` → **439 files already formatted**.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>