### PR TITLE
docs: consumer-supplied tool & MCP classifications (U4)

### DIFF
--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -2,7 +2,7 @@
 id: configuration
 title: Configuration
 sidebar_label: Configuration
-description: traceforge.yaml, ~/.traceforge/config.yaml, TRACEFORGE_* environment variables, and loading precedence.
+description: traceforge.yaml, ~/.traceforge/config.yaml, TRACEFORGE_* environment variables, loading precedence, and custom tool & MCP classification overlays.
 ---
 
 # Configuration
@@ -146,3 +146,154 @@ title:
 
 When `strategy: api` but no key is present (or a call fails/times out), naming silently falls
 back to the heuristic, a missing key never errors or blocks.
+
+## Custom tool & MCP classifications
+
+TraceForge classifies by **trace-native structure** — the shape of each tool call and, for
+shell, its parsed AST — and ships only a small, *general* set of tool and MCP-server
+classifications as built-in defaults. It deliberately does **not** hard-code any one consumer's
+tool catalog. If you run bespoke native tools or private MCP servers, you attach your own
+taxonomy as an **overlay**: TraceForge merges your entries on top of its generic defaults,
+per key, so you own your vocabulary with no change to — and no fork of — TraceForge itself.
+
+:::note Separate discovery chain from the root config
+The classification overlay is loaded by `traceforge.classify.config.load_config()`, a
+**different** discovery chain from the [root config precedence](#loading-precedence) above. It
+shares the `TRACEFORGE_CONFIG` environment variable (each subsystem reads only the keys it
+owns from a shared file), but its project- and user-level files live at their own paths (listed
+below). Put classification sections in one of those files — not in `./traceforge.yaml`.
+:::
+
+### The override surfaces
+
+These are top-level keys in a classification config (a `ClassifyConfig`). Supply only the
+sections you want to overlay; everything else falls through to the defaults. Dimension values
+are dot-path strings drawn from the [classification dimensions](reference/classification.md#dimensions).
+
+#### `tool_classifications` — native tools
+
+Maps a canonical tool name to a full classification. `mechanism` is required; every other
+dimension is optional (`ToolClassificationConfig`: `mechanism: str`, `effect: str | None`, and
+`scope` / `role` / `action` / `capability` as string lists).
+
+```yaml
+# .traceforge/config.yaml
+tool_classifications:
+  deploy_service:              # your bespoke native tool
+    mechanism: network.http    # required
+    effect: mutating           # read_only | mutating | destructive
+    scope: [state.repository]
+    role: [orchestrator.ci_cd]
+    action: [deliver.push]
+    capability: [network_outbound]
+```
+
+#### `mcp_profiles` — MCP servers
+
+A list of profiles, each matched against the `mcp__<server>__<tool>` namespace by its
+`namespace_aliases`. The profile classifies every tool from that server. Required fields are
+`namespace_aliases: list[str]` and `mechanism: str`; `id`, `default_effect`, `role`, `scope`,
+`action`, `capability`, `tool_overrides`, and `disabled` are optional (`McpProfileConfig`).
+
+```yaml
+mcp_profiles:
+  - id: acme                                   # optional; reuse a built-in id to replace it
+    namespace_aliases: [acme, acme_platform]   # required — matches mcp__acme__*
+    mechanism: network.http                    # required
+    role: [retriever.api_client]
+    scope: [state.repository]
+    capability: [network_outbound]
+    default_effect: read_only
+```
+
+#### `tool_overrides` — per-tool refinement inside a profile
+
+`tool_overrides` is **nested inside an `mcp_profiles` entry**, not a top-level section. It maps
+a tool name to a partial classification that refines the server-level defaults for just that
+tool. Every field is optional — set only what differs (`McpToolOverrideConfig`: `effect`,
+`mechanism`, `role`, `action`, `scope`, `capability`).
+
+```yaml
+mcp_profiles:
+  - id: acme
+    namespace_aliases: [acme]
+    mechanism: network.http
+    role: [retriever.api_client]
+    default_effect: read_only
+    tool_overrides:
+      create_deployment:
+        effect: mutating
+        role: [orchestrator.ci_cd]
+        scope: [configuration.ci_cd]
+      delete_deployment:
+        effect: destructive
+```
+
+:::tip `tool_display` rides the same chain
+The overlay chain also carries `tool_display` — a `dict[str, str]` mapping a canonical tool
+identity to a human-facing label. It's how you relabel tools without touching their
+classification. See [Bring your own classifications](reference/classification.md#bring-your-own-classifications)
+and the `tool_display` field on the [event model](architecture/event-model.md).
+:::
+
+### Supplying an overlay
+
+The classification loader merges these layers, **highest priority first**, each overlaying the
+one below:
+
+1. An explicit `config_path=` passed to `load_config()` (programmatic; wins over everything).
+2. **`TRACEFORGE_CONFIG`** — an env var pointing at a YAML file.
+3. **`.traceforge/config.yaml`** — a project file, searched from the cwd upward (`config.yml` also accepted).
+4. `~/.config/traceforge/config.yaml` — a user-global file (`$XDG_CONFIG_HOME` honored).
+5. **`traceforge.profiles`** — entry points contributed by installed packages.
+6. TraceForge's built-in generic defaults (`classify/data/*.yaml`).
+
+The three you'll typically reach for are **2, 3, and 5** — all of which overlay the built-in
+defaults (6). Mind the precedence: a `TRACEFORGE_CONFIG` file overrides a project
+`.traceforge/config.yaml`, which overrides an entry-point profile.
+
+**Merge semantics.** Dict sections (`tool_classifications`, `tool_display`) merge **per key** —
+your key wins, untouched defaults survive. `mcp_profiles` is a list where higher-priority layers
+are prepended; give a profile the same `id` as a built-in to **replace** it, or set
+`disabled: true` to drop one.
+
+#### Ship classifications from your own package
+
+For a reusable overlay, register a `traceforge.profiles` entry point. TraceForge calls each
+entry point, expecting a **callable that returns a `dict`** (a `ClassifyConfig` shape) — or a
+path to a YAML file.
+
+```toml
+# your package's pyproject.toml
+[project.entry-points."traceforge.profiles"]
+acme = "acme_traceforge.profiles:classifications"
+```
+
+```python
+# acme_traceforge/profiles.py
+def classifications() -> dict:
+    """Return an overlay of Acme's tools and MCP servers."""
+    return {
+        "tool_classifications": {
+            "deploy_service": {
+                "mechanism": "network.http",
+                "effect": "mutating",
+                "capability": ["network_outbound"],
+            },
+        },
+        "mcp_profiles": [
+            {
+                "id": "acme",
+                "namespace_aliases": ["acme"],
+                "mechanism": "network.http",
+                "role": ["retriever.api_client"],
+                "capability": ["network_outbound"],
+            },
+        ],
+    }
+```
+
+Install that package alongside TraceForge and its classifications load automatically — no config
+file required, and still overridable by a project's `.traceforge/config.yaml`. TraceForge ships
+its own defaults as bundled data (not as an entry point), so your profiles never collide with a
+built-in registration.

--- a/website/docs/reference/classification.md
+++ b/website/docs/reference/classification.md
@@ -110,6 +110,27 @@ Classification behavior is governed entirely by YAML in `classify/data/`:
 | `risk.yaml` | Risk weights, flag modifiers, injection patterns, taint rules. |
 | `recommendation_rules.yaml` | Governance rule set → `RecommendedAction` (consumed by the [Assessor](sdk.md)). |
 
+## Bring your own classifications
+
+The tables above are TraceForge's **built-in generic defaults**. Because the engine keys off
+trace-native structure, it ships only a general vocabulary and never hard-codes a specific
+consumer's tool catalog. To add your own native tools or private MCP servers, overlay them
+through the config chain — don't edit these bundled files or fork the package.
+
+Three overlay surfaces cover the common cases:
+
+- `tool_classifications` — full classifications for your native tools.
+- `mcp_profiles` — profiles for your MCP servers, with nested `tool_overrides` for per-tool refinement.
+- `tool_display` — human-facing labels for the `tool_display` field stamped at enrichment (see the [event model](../architecture/event-model.md)).
+
+Your entries **overlay** the defaults per key; nothing is replaced wholesale. Give an
+`mcp_profiles` entry the same `id` as a built-in to supersede it, or set `disabled: true` to
+drop one. Supply the overlay via (highest priority first) the `TRACEFORGE_CONFIG` env var, a
+project `.traceforge/config.yaml`, or a `traceforge.profiles` entry point in your own package —
+each overlaying the bundled defaults. See
+[Custom tool & MCP classifications](../configuration.md#custom-tool--mcp-classifications) for the full
+schema, YAML examples, and an entry-point walkthrough.
+
 ## Workflow dimensions
 
 Derived presentation concerns are kept separate from semantic classification:


### PR DESCRIPTION
## Summary (docs-only — zero source/test changes)

Documents how an upstream consumer supplies its **own** tool + MCP classifications as an **overlay** on top of TraceForge's built-in generic defaults — no core change and no shipped consumer list. This implements the coordinator ruling (push back on shipping consumer-specific defaults): TraceForge already supports consumer-supplied classification through its existing classification config-override chain, so this PR documents that mechanism rather than changing code.

**Verification I ran:** the ruling holds against the code as-is — no discrepancy requiring a source change was found. `ruff check .` + `ruff format --check .` (pinned `ruff==0.15.20`) pass untouched (docs-only). A full Docusaurus production build (`npm ci && npm run build`, the same commands as `deploy-docs.yml`) succeeds with `onBrokenLinks: 'throw'`, so every new cross-link and anchor resolves.

## Files changed

- `website/docs/configuration.md` — new **“Custom tool & MCP classifications”** section (why-framing, the override surfaces with schemas + YAML examples, the supply mechanisms in real precedence order, and an entry-point walkthrough).
- `website/docs/reference/classification.md` — new **“Bring your own classifications”** section complementing the data-files table, cross-linking to the configuration guide.

No new sidebar entry needed — both pages are already listed in `website/sidebars.js`.

## The three override surfaces (evidence in `src/traceforge/classify/config.py`)

- **`tool_classifications`** — top-level map of native tool → full classification. Field `ClassifyConfig.tool_classifications` at `config.py:136`; schema `ToolClassificationConfig` (`mechanism` required) at `config.py:89-97`; materialized at `config.py:431-441`.
- **`mcp_profiles`** — top-level list of MCP-server profiles matched by `namespace_aliases`. Field at `config.py:133`; schema `McpProfileConfig` at `config.py:48-60`; materialized at `config.py:490-515`.
- **`tool_overrides`** — **nested inside each `mcp_profiles` entry** (not a top-level section) for per-tool refinement. Field `McpProfileConfig.tool_overrides` at `config.py:60`; schema `McpToolOverrideConfig` at `config.py:37-45`; materialized at `config.py:493-502`.
- (Also documented briefly: **`tool_display`**, the U2 resolver's canonical-tool → label map, top-level at `config.py:149`, same chain.)

## The three supply mechanisms (evidence in `load_config`, `config.py:300-368`)

Merged low→high, rightmost wins (`config.py:315-359`); actual precedence highest→lowest:

1. `TRACEFORGE_CONFIG` env var → `config.py:342-347`
2. `.traceforge/config.yaml` project file (cwd upward; `.yml` too) → `_find_project_config` `config.py:167-178`, consumed `config.py:334-339`
3. `traceforge.profiles` entry point (callable → dict or YAML path) → `_load_entry_point_configs` `config.py:191-218`, consumed `config.py:321-323`
4. …all overlaying the built-in generic defaults from `classify/data/*.yaml` → `_load_builtin_defaults` `config.py:221-243`, consumed `config.py:317-319`

Merge/replace semantics: per-key dict merge and list-prepend in `_merge_raw` (`config.py:246-265`); same-`id` replacement + `disabled: true` drop in `_apply_disabled_entries` (`config.py:268-297`).

**Precedence note for the coordinator:** in the code the env var **outranks** the project `.traceforge/config.yaml`, which outranks the entry point (i.e. `TRACEFORGE_CONFIG` > `.traceforge/config.yaml` > `traceforge.profiles`). The brief listed them project → env → entry; the docs state the actual code order. Also note the classification chain is a **separate** discovery chain from the root `TraceforgeConfig` loader (`config/loader.py`: `./traceforge.yaml`, `~/.traceforge/config.yaml`) — they share only the `TRACEFORGE_CONFIG` env var, and the classification loader filters a shared file to its own keys (`config.py:361-364`). The docs call this out explicitly.

## Status

**HELD — do not merge.** Ready for coordinator review; the merge lifecycle is yours.