### PR TITLE
Validate persistence durability guarantees (U12)

### DIFF
--- a/docs/persistence-durability.md
+++ b/docs/persistence-durability.md
@@ -1,0 +1,115 @@
+# Traceforge Persistence Durability — Design & Guarantees
+
+Scope: `src/traceforge/governance/persistence.py::SystemStore`, the synchronous durability layer under governance session state. This document is the normative statement of *what durability the store already provides* and *how each guarantee is enforced and proven*. It documents shipped behavior; it introduces no new mechanism.
+
+An upstream consumer requested a "durable persistence engine (WAL, single-writer, migrations)". That engine already exists as `SystemStore`. This document validates that it meets those acceptance criteria and cites the exact mechanism (file:line) and the test that proves each one.
+
+---
+
+## Storage model
+
+`SystemStore` is a thin, synchronous durability layer over a **single SQLite connection** opened with `check_same_thread=False` (persistence.py:98). On construction, before any migration runs, it sets three pragmas (persistence.py:103-105):
+
+```
+PRAGMA journal_mode = WAL       # write-ahead logging: readers never block the writer
+PRAGMA busy_timeout = 5000      # 5s wait on a locked DB before raising SQLITE_BUSY
+PRAGMA synchronous = NORMAL     # fsync at WAL checkpoints, not every commit
+```
+
+* **WAL** gives us durable commits without a rollback journal: a committed transaction is appended to the `-wal` file and survives process death; a reader on a separate connection sees a consistent snapshot and is never blocked by an in-flight writer.
+* **`synchronous = NORMAL`** is the correct pairing with WAL: commits are durable across an *application* crash (the WAL is flushed), trading only the extremely narrow window of an OS/power loss between checkpoints — the standard, recommended WAL durability posture, not full `FULL` fsync-per-commit overhead.
+* **`busy_timeout`** bounds contention from any incidental second connection (e.g. a read-only reopen) rather than failing fast.
+
+The schema itself is fully normalized from revision one — `budget_counters`, `taint_entries`, `mcp_profiles` + `mcp_profile_attributes`, plus scalar columns on `session_state` (0001_initial.py). There is no JSON-blob shape to migrate away from.
+
+---
+
+## Single-writer discipline
+
+The pipeline is asyncio-single-threaded and offloads store writes to worker threads via `asyncio.to_thread`, so writes can *originate on different OS threads* even though they are never logically concurrent per session. An async primitive (`asyncio.Lock`/`Queue`) cannot serialize work that runs off-loop on arbitrary threads; the correct primitive for a synchronous store reached from many threads is a **`threading.Lock`** (persistence.py:84, :99).
+
+```python
+self._lock = threading.Lock()   # persistence.py:99 — non-reentrant, the one writer gate
+```
+
+Two write shapes, one gate:
+
+1. **Single-statement writes** take the lock around `execute` + `commit` (e.g. `record_processed` persistence.py:167-172, `reserve_event` persistence.py:178-183, `store_content_hash` persistence.py:349-351).
+2. **Multi-statement transactions MUST go through `write_transaction()`** (persistence.py:119-147) — the formal single-writer entry point. It holds `_lock` for the **entire** transaction (every statement the body issues, not merely the terminal commit), so two writers can never interleave statements on the shared connection.
+
+```python
+@contextmanager
+def write_transaction(self):          # persistence.py:119-147
+    with self._lock:                  # held for the WHOLE body
+        try:
+            yield self._conn
+        except BaseException:
+            self._conn.rollback()     # abort → nothing survives
+            raise
+        else:
+            self._conn.commit()       # clean exit → atomic commit
+```
+
+### Non-reentrancy contract
+
+`_lock` is a **non-reentrant** `threading.Lock` (not an `RLock`). Because `write_transaction` already holds it for the whole body, the body must issue its statements through the *no-lock* helpers — `execute_in_transaction` (persistence.py:363-365) and the `*_no_commit` methods (e.g. `write_mcp_profile_no_commit` persistence.py:242-272, `store_content_hash_no_commit` persistence.py:331-344). Calling a self-locking method (e.g. `commit`, persistence.py:367-370) from inside the body would deadlock. This is stated explicitly in the method contract (persistence.py:134-138) and is enforced by the lock's non-reentrancy: a same-thread re-acquire returns `False` / blocks, it does not silently pass as an `RLock` would.
+
+```mermaid
+flowchart LR
+    A[Thread A: write_transaction] -->|holds _lock| L((_lock))
+    B[Thread B: write_transaction] -.->|blocks until A releases| L
+    A --> S[(single sqlite conn)]
+    B -.-> S
+    L --> C{clean exit?}
+    C -->|yes| CM[commit — durable to WAL]
+    C -->|exception| RB[rollback — no partial write]
+```
+
+---
+
+## Transaction atomicity & crash recovery
+
+`write_transaction` is all-or-nothing:
+
+* **Commit** happens only on clean context exit; the multi-statement change lands as one atomic unit in the WAL.
+* **Rollback** happens on *any* `BaseException` (persistence.py:143-145), then the exception re-raises — no dangling open transaction, no partial write.
+
+Crash-recovery semantics follow directly from WAL + this discipline. We model a crash as **reopening a fresh `SystemStore` on the same file**: a brand-new process/connection with no cached state, so whatever the reopened store observes is exactly what was durably flushed.
+
+* A **committed** `write_transaction` is visible after reopen (WAL durability).
+* An **aborted** `write_transaction` leaves *nothing* — neither statement of a multi-statement body survives (atomic rollback), confirmed after reopen.
+* An in-flight, uncommitted write is invisible to any separate connection (WAL snapshot isolation), so a concurrent reader never observes a dirty row.
+
+---
+
+## Versioned migrations
+
+Schema is owned by Alembic migrations under `src/traceforge/migrations/`. On construction, after setting pragmas, `SystemStore` brings the database to HEAD (persistence.py:108 → `_run_alembic`).
+
+* **Single source of truth, forward-only.** There is exactly one revision, `0001_initial` (versions/0001_initial.py: `revision = "0001_initial"`, `down_revision = None`). The latest revision is named once, in one place: `LATEST_REVISION = "0001_initial"` (versions/__init__.py:4), imported by the store (persistence.py:30). Because traceforge has never shipped, schema changes rewrite `0001_initial` rather than layering expand/backfill migrations — the old shape never exists.
+* **Idempotent init with a fast path.** `_run_alembic` first checks `alembic_version` without importing SQLAlchemy; if it already equals `LATEST_REVISION` it returns immediately (persistence.py:33-37). Only a fresh or stale file takes the slow path that wraps the live connection in a SQLAlchemy engine and runs `command.upgrade(cfg, "head")` (runner.py:28-36). Reopening an up-to-date file re-applies nothing and never duplicates the stamped revision.
+* **Concurrent first-run safe.** The migration creates tables with `CREATE TABLE IF NOT EXISTS` (0001_initial.py:29-30) so two processes racing to create a fresh `system.db` cannot crash each other.
+
+---
+
+## Acceptance criteria → evidence
+
+Every acceptance criterion maps to a deterministic test. New validation lives in `tests/unit/test_persistence_durability.py` (barriers/events force contention with no wall-clock sleeps); pre-existing coverage in `tests/unit/test_governance_single_writer.py` and `tests/unit/test_governance_migrations.py` is cited where it already proves a criterion.
+
+| Acceptance criterion | Guarantee | Mechanism (file:line) | Proof (test) |
+| --- | --- | --- | --- |
+| **Durable storage model** | WAL journal, `synchronous=NORMAL`, `busy_timeout=5000` are actually in force | persistence.py:103-105 | `test_persistence_durability.py::TestStorageModel` (`test_journal_mode_is_wal`, `test_synchronous_is_normal`, `test_busy_timeout_is_set`) |
+| **Concurrent-writer safe** (no lost updates) | Whole-transaction writer lock serializes overlapping read-modify-write; final total is exact | persistence.py:99, :140 | `TestConcurrentWriterSerialization::test_barrier_forced_rmw_never_loses_updates`; also pre-existing `test_governance_single_writer.py::...::test_read_modify_write_never_loses_updates` |
+| **Concurrent-writer safe** (no interleaving / no dirty read) | Second writer cannot enter while the first holds an open transaction; uncommitted rows are invisible cross-connection | persistence.py:140-147 | `TestConcurrentWriterSerialization::test_second_writer_cannot_enter_while_first_holds_transaction` |
+| **Non-reentrancy contract** | `_lock` is a plain `threading.Lock`; the body uses `*_no_commit` helpers and never re-locks | persistence.py:99, :134-138 | `TestNonReentrancyContract` (`test_writer_lock_is_non_reentrant`, `test_write_transaction_holds_lock_across_whole_body`, `test_in_transaction_helpers_do_not_relock`) |
+| **Crash-safe** (durability) | A committed transaction survives a fresh `SystemStore` reopen on the same file | persistence.py:140-147, :103 | `TestCrashSafetyAtomicity::test_committed_write_survives_fresh_store_reopen`; `test_multi_statement_commit_is_all_or_nothing_across_reopen` |
+| **Crash-safe** (atomic rollback) | An aborted mid-transaction write leaves no partial state behind | persistence.py:143-145 | `TestCrashSafetyAtomicity::test_aborted_transaction_leaves_no_partial_write_after_reopen`; pre-existing `test_governance_single_writer.py::...::test_rolls_back_and_reraises_on_exception` |
+| **Migratable / idempotent** | Fresh file migrates to `LATEST_REVISION`; reopening applies nothing and never double-stamps | persistence.py:30, :33-37, :108; runner.py:28-36; versions/__init__.py:4 | `TestMigrationIdempotence` (`test_fresh_file_is_migrated_to_latest_revision`, `test_reopen_applies_migration_exactly_once`, `test_reopen_is_a_clean_noop`); pre-existing `test_governance_migrations.py::TestInitialSchema` |
+
+---
+
+## Non-goals & boundaries
+
+* **Not multi-process write concurrency.** The durability contract is single-writer *within one process*, reached from many threads. Cross-process writers are out of scope; `busy_timeout` merely keeps an incidental second connection from failing fast.
+* **Not power-loss `FULL` durability.** `synchronous=NORMAL` is the deliberate WAL pairing (application-crash durable). Raising to `FULL` would be a policy change, not a bug fix, and is not part of these criteria.
+* **Not a new engine.** This is a validation-and-documentation pass. No production logic, schema, or migration was changed to satisfy these criteria — the guarantees above are properties of the already-shipped `SystemStore`.

--- a/tests/unit/test_persistence_durability.py
+++ b/tests/unit/test_persistence_durability.py
@@ -1,0 +1,342 @@
+"""Durability acceptance-validation for the SystemStore persistence engine (U12).
+
+This module is *validation-only*: it proves that the persistence engine already
+shipped in ``traceforge.governance.persistence.SystemStore`` meets the durability
+acceptance criteria an upstream consumer asked for — a durable engine with WAL,
+single-writer serialization, and versioned migrations. It changes no production
+logic; every mechanism it exercises is cited by file:line in
+``docs/persistence-durability.md``.
+
+Determinism
+-----------
+None of these tests race on the wall clock. Contention is forced deterministically
+with :class:`threading.Barrier` (all writers released into the critical section at
+the same instant) and :class:`threading.Event` (one writer pinned inside an open
+transaction while another probes the lock), so the outcome is identical on every
+run regardless of scheduler timing.
+
+Acceptance criteria proven here
+-------------------------------
+* **Storage model** — WAL journal, ``synchronous=NORMAL``, ``busy_timeout=5000``
+  are actually in force (persistence.py:103-105).
+* **Concurrent-writer safe** — the whole-transaction writer lock
+  (persistence.py:99, :140) serializes overlapping writers with no lost updates
+  and no interleaving; the lock is non-reentrant, matching the ``*_no_commit``
+  contract (persistence.py:134-138).
+* **Crash-safe** — a committed ``write_transaction`` survives a fresh
+  ``SystemStore`` reopen on the same file (WAL durability), and an aborted one
+  leaves no partial write behind (atomic rollback, persistence.py:140-147).
+* **Migratable** — a fresh file is migrated to ``LATEST_REVISION`` and reopening
+  the same file re-applies nothing (idempotent, persistence.py:30-37, :108).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+from traceforge.governance.persistence import SystemStore
+from traceforge.migrations.versions import LATEST_REVISION
+
+# Generous rendezvous bound: a correct run clears these in milliseconds. The
+# timeout only exists so a genuine deadlock fails the test fast instead of
+# hanging CI — it is never reached on a passing run.
+_JOIN_TIMEOUT = 10.0
+
+
+@pytest.fixture
+def store(tmp_path):
+    """A real on-disk SystemStore (durability tests need a file, not :memory:)."""
+    s = SystemStore(tmp_path / "system.db")
+    yield s
+    s.close()
+
+
+def _counter(conn: sqlite3.Connection, session_id: str, dimension: str, key: str) -> int:
+    row = conn.execute(
+        "SELECT count FROM budget_counters WHERE session_id=? AND dimension=? AND key=?",
+        (session_id, dimension, key),
+    ).fetchone()
+    return row[0] if row else 0
+
+
+def _insert_counter(conn: sqlite3.Connection, session_id: str, count: int) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO budget_counters (session_id, dimension, key, count) "
+        "VALUES (?, 'd', 'k', ?)",
+        (session_id, count),
+    )
+
+
+class TestStorageModel:
+    """The declared storage pragmas (persistence.py:103-105) are actually in force."""
+
+    def test_journal_mode_is_wal(self, store):
+        mode = store.connection.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal"
+
+    def test_synchronous_is_normal(self, store):
+        # PRAGMA synchronous reports the numeric level: NORMAL == 1.
+        assert store.connection.execute("PRAGMA synchronous").fetchone()[0] == 1
+
+    def test_busy_timeout_is_set(self, store):
+        assert store.connection.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+
+
+class TestNonReentrancyContract:
+    """The writer lock is a plain, non-reentrant threading.Lock (persistence.py:99).
+
+    ``write_transaction`` holds it for the whole body, so the body must use the
+    ``*_no_commit`` / ``execute_in_transaction`` helpers that do NOT re-acquire it;
+    calling a self-locking method inside would deadlock (persistence.py:134-138).
+    These tests pin that contract down without ever risking a hang.
+    """
+
+    def test_writer_lock_is_non_reentrant(self, store):
+        # A reentrant lock (RLock) would return True on the second same-thread
+        # acquire; a plain Lock returns False. This is what makes the documented
+        # "do not call a self-locking method inside write_transaction" real.
+        assert store.lock.acquire() is True
+        try:
+            assert store.lock.acquire(blocking=False) is False
+        finally:
+            store.lock.release()
+
+    def test_write_transaction_holds_lock_across_whole_body(self, store):
+        assert store.lock.locked() is False
+        with store.write_transaction() as conn:
+            # The lock is held for the entire body, not just the terminal commit.
+            assert store.lock.locked() is True
+            _insert_counter(conn, "held", 1)
+            assert store.lock.locked() is True
+        # ...and released on exit.
+        assert store.lock.locked() is False
+
+    def test_in_transaction_helpers_do_not_relock(self, store):
+        # The documented in-transaction helpers run under the already-held lock
+        # without re-acquiring it. If any of them self-locked, this would deadlock
+        # (and hit the join timeout); it completing proves the contract.
+        with store.write_transaction() as conn:
+            store.execute_in_transaction(
+                "INSERT INTO budget_counters (session_id, dimension, key, count) VALUES (?,?,?,?)",
+                ("helper", "d", "k", 1),
+            )
+            store.store_content_hash_no_commit("repo", "f.py", "sha256", "sess", "t0")
+            store.write_mcp_profile_no_commit(
+                "srv",
+                "tool",
+                {
+                    "description_hash": "dh",
+                    "schema_hash": "sh",
+                    "first_seen": "t0",
+                    "last_seen": "t0",
+                },
+            )
+            assert conn is store.connection
+        # All three helper writes committed atomically together.
+        assert store.get_budget_counters("helper") == {"d": {"k": 1}}
+        assert store.get_content_hash("repo", "f.py") == "sha256"
+        assert store.get_mcp_profile("srv", "tool") is not None
+
+
+class TestConcurrentWriterSerialization:
+    """Overlapping writers are serialized with no lost updates and no interleaving."""
+
+    def test_barrier_forced_rmw_never_loses_updates(self, store):
+        """All threads read-modify-write the SAME counter, released together each round.
+
+        A :class:`threading.Barrier` rendezvous forces every one of the ``threads_n``
+        workers into the critical section at the same instant on every round — the
+        worst case for a read-modify-write race. With the whole-transaction lock,
+        the final total is exactly ``threads_n * rounds``; without it, colliding
+        reads would drop increments. The exactness is deterministic.
+        """
+        threads_n, rounds = 8, 50
+        barrier = threading.Barrier(threads_n)
+        errors: list[BaseException] = []
+
+        def worker() -> None:
+            try:
+                for _ in range(rounds):
+                    # Rendezvous: nobody proceeds until all workers are here, so the
+                    # RMWs maximally overlap this round.
+                    barrier.wait(timeout=_JOIN_TIMEOUT)
+                    with store.write_transaction() as conn:
+                        current = _counter(conn, "shared", "d", "k")
+                        _insert_counter(conn, "shared", current + 1)
+            except BaseException as exc:  # noqa: BLE001 - surface into assertion
+                errors.append(exc)
+                # Don't leave peers blocked on the barrier if we bail early.
+                barrier.abort()
+
+        threads = [threading.Thread(target=worker) for _ in range(threads_n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=_JOIN_TIMEOUT)
+            assert not t.is_alive(), "writer thread hung — possible lock deadlock"
+
+        assert errors == []
+        assert _counter(store.connection, "shared", "d", "k") == threads_n * rounds
+
+    def test_second_writer_cannot_enter_while_first_holds_transaction(self, store):
+        """While writer A holds an open transaction, writer B cannot acquire the lock.
+
+        Events pin A inside its ``write_transaction`` with an uncommitted row. From
+        the test thread we then prove (a) the writer lock cannot be taken — no
+        interleaving is possible — and (b) a wholly separate connection does not see
+        A's uncommitted row — no dirty read. Releasing A commits it.
+        """
+        a_inside = threading.Event()
+        let_a_finish = threading.Event()
+
+        def writer_a() -> None:
+            with store.write_transaction() as conn:
+                _insert_counter(conn, "A", 7)
+                a_inside.set()
+                # Hold the transaction (and thus the writer lock) open until probed.
+                let_a_finish.wait(timeout=_JOIN_TIMEOUT)
+            # commit happens here, on context exit
+
+        ta = threading.Thread(target=writer_a)
+        ta.start()
+        try:
+            assert a_inside.wait(timeout=_JOIN_TIMEOUT)
+
+            # (a) No interleaving: the writer lock is held by A, so a second writer
+            # cannot acquire it. Non-blocking so the test itself never deadlocks.
+            got = store.lock.acquire(blocking=False)
+            if got:
+                store.lock.release()
+            assert got is False
+
+            # (b) No dirty read: A's uncommitted row is invisible to a separate
+            # connection (WAL snapshot isolation).
+            other = sqlite3.connect(str(store._db_path))
+            try:
+                seen = other.execute(
+                    "SELECT count FROM budget_counters WHERE session_id='A'"
+                ).fetchone()
+            finally:
+                other.close()
+            assert seen is None
+        finally:
+            let_a_finish.set()
+            ta.join(timeout=_JOIN_TIMEOUT)
+        assert not ta.is_alive()
+
+        # After A commits and releases, the row is durably present.
+        assert _counter(store.connection, "A", "d", "k") == 7
+
+
+class TestCrashSafetyAtomicity:
+    """Committed writes survive reopen; aborted writes leave nothing behind.
+
+    Reopening a NEW SystemStore on the same file is the durability equivalent of a
+    process crash + restart: no cached state carries over, so whatever the reopened
+    store sees is exactly what was flushed to the WAL/DB.
+    """
+
+    def test_committed_write_survives_fresh_store_reopen(self, tmp_path):
+        path = tmp_path / "system.db"
+        s1 = SystemStore(path)
+        try:
+            with s1.write_transaction() as conn:
+                _insert_counter(conn, "durable", 42)
+        finally:
+            s1.close()
+
+        # Simulated crash + restart: brand-new store, same file.
+        s2 = SystemStore(path)
+        try:
+            assert _counter(s2.connection, "durable", "d", "k") == 42
+        finally:
+            s2.close()
+
+    def test_aborted_transaction_leaves_no_partial_write_after_reopen(self, tmp_path):
+        path = tmp_path / "system.db"
+        s1 = SystemStore(path)
+        try:
+            with pytest.raises(RuntimeError, match="boom"):
+                with s1.write_transaction() as conn:
+                    _insert_counter(conn, "row_one", 1)
+                    _insert_counter(conn, "row_two", 2)
+                    raise RuntimeError("boom")  # abort mid multi-statement txn
+        finally:
+            s1.close()
+
+        # Neither statement of the aborted transaction was flushed.
+        s2 = SystemStore(path)
+        try:
+            assert s2.get_budget_counters("row_one") == {}
+            assert s2.get_budget_counters("row_two") == {}
+        finally:
+            s2.close()
+
+    def test_multi_statement_commit_is_all_or_nothing_across_reopen(self, tmp_path):
+        path = tmp_path / "system.db"
+        s1 = SystemStore(path)
+        try:
+            with s1.write_transaction() as conn:
+                _insert_counter(conn, "first", 1)
+                _insert_counter(conn, "second", 2)
+                _insert_counter(conn, "third", 3)
+        finally:
+            s1.close()
+
+        s2 = SystemStore(path)
+        try:
+            assert _counter(s2.connection, "first", "d", "k") == 1
+            assert _counter(s2.connection, "second", "d", "k") == 2
+            assert _counter(s2.connection, "third", "d", "k") == 3
+        finally:
+            s2.close()
+
+
+def _alembic_versions(path) -> list[str]:
+    conn = sqlite3.connect(str(path))
+    try:
+        return [r[0] for r in conn.execute("SELECT version_num FROM alembic_version")]
+    finally:
+        conn.close()
+
+
+class TestMigrationIdempotence:
+    """Migrations are applied once and reopening the same file re-applies nothing."""
+
+    def test_fresh_file_is_migrated_to_latest_revision(self, tmp_path):
+        path = tmp_path / "system.db"
+        s = SystemStore(path)
+        try:
+            assert _alembic_versions(path) == [LATEST_REVISION]
+        finally:
+            s.close()
+
+    def test_reopen_applies_migration_exactly_once(self, tmp_path):
+        path = tmp_path / "system.db"
+        s1 = SystemStore(path)
+        try:
+            with s1.write_transaction() as conn:
+                _insert_counter(conn, "pre_reopen", 5)
+        finally:
+            s1.close()
+
+        # Reopen: the fast-path (persistence.py:33-37) sees HEAD and re-runs nothing.
+        s2 = SystemStore(path)
+        try:
+            # Exactly one stamped revision — the migration did not run twice.
+            assert _alembic_versions(path) == [LATEST_REVISION]
+            # Pre-reopen data is intact (a re-run would risk clobbering it).
+            assert _counter(s2.connection, "pre_reopen", "d", "k") == 5
+        finally:
+            s2.close()
+
+    def test_reopen_is_a_clean_noop(self, tmp_path):
+        # Opening many times on the same path must never raise or duplicate state.
+        path = tmp_path / "system.db"
+        for _ in range(3):
+            s = SystemStore(path)
+            s.close()
+        assert _alembic_versions(path) == [LATEST_REVISION]


### PR DESCRIPTION
## Summary

Upstream story **U12** asked for a "durable PersistenceEngine (WAL, single-writer, migrations)". The audit ruling was **push back — already built**: `src/traceforge/governance/persistence.py::SystemStore` already provides this. This PR is a **validate-only + document** pass that proves the engine meets its acceptance criteria and documents the guarantees.

**No production logic changed (validate-only).** Only two new files: a focused test module and a design doc. No `src/` change, no schema/migration change, no frozen-file touches.

## Ground-truth evidence (file:line)

| Mechanism | Location |
| --- | --- |
| WAL + pragmas (`journal_mode=WAL`, `busy_timeout=5000`, `synchronous=NORMAL`) | `persistence.py:103-105` |
| Non-reentrant single-writer lock (`threading.Lock()`) | `persistence.py:99` |
| `write_transaction()` — holds lock for the whole txn, atomic commit/rollback | `persistence.py:119-147` (rollback path `:143-145`) |
| Non-reentrancy contract (`*_no_commit` helpers, no self-lock inside body) | `persistence.py:134-138` |
| Versioned migration applied at init (`LATEST_REVISION`, fast-path, `_run_alembic`) | `persistence.py:30`, `:33-37`, `:108`; `runner.py:28-36`; `versions/__init__.py:4` (`LATEST_REVISION="0001_initial"`); `versions/0001_initial.py` |

## Validation tests — `tests/unit/test_persistence_durability.py` (14 tests, deterministic)

Contention is forced with `threading.Barrier`/`Event` — **no wall-clock sleeps**, identical outcome every run.

**Concurrent-writer safe**
- `TestConcurrentWriterSerialization::test_barrier_forced_rmw_never_loses_updates` — 8 threads × 50 rounds, all released into the RMW critical section together each round; final counter is exactly `N*K` (no lost updates). Proves the whole-transaction lock serializes writers.
- `::test_second_writer_cannot_enter_while_first_holds_transaction` — pins writer A inside an open txn; a second writer's lock acquire returns `False` (no interleaving) and a separate connection cannot see A's uncommitted row (no dirty read).

**Non-reentrancy contract**
- `TestNonReentrancyContract::test_writer_lock_is_non_reentrant` — same-thread re-acquire returns `False` (an `RLock` would return `True`).
- `::test_write_transaction_holds_lock_across_whole_body` — lock is `locked()` for the entire body, released on exit.
- `::test_in_transaction_helpers_do_not_relock` — `execute_in_transaction` / `*_no_commit` helpers run under the held lock without deadlocking, committing atomically.

**Crash-safe (durability + atomicity)** — a fresh `SystemStore` reopen on the same file models crash+restart
- `TestCrashSafetyAtomicity::test_committed_write_survives_fresh_store_reopen` — committed txn is present after reopen (WAL durability).
- `::test_aborted_transaction_leaves_no_partial_write_after_reopen` — a mid-transaction `raise` leaves neither statement behind after reopen (atomic rollback).
- `::test_multi_statement_commit_is_all_or_nothing_across_reopen` — a 3-statement txn lands as one unit.

**Storage model**
- `TestStorageModel::{test_journal_mode_is_wal, test_synchronous_is_normal, test_busy_timeout_is_set}` — the declared pragmas are actually in force.

**Migratable / idempotent**
- `TestMigrationIdempotence::{test_fresh_file_is_migrated_to_latest_revision, test_reopen_applies_migration_exactly_once, test_reopen_is_a_clean_noop}` — fresh file → `LATEST_REVISION`; reopening applies nothing and never double-stamps.

## Durability doc

`docs/persistence-durability.md` — storage model, single-writer discipline, atomicity/crash-recovery, versioned single-source migrations, plus an **acceptance-criteria → evidence** table mapping each criterion to its proving test with file:line citations. Matches `docs/governance-extensions-design.md` tone.

## Verification

- Full suite: `uv run --no-progress python -m pytest -q -p no:cacheprovider` → **3442 passed, 8 skipped** (includes the 14 new tests; concurrency/crash tests re-run 3× — stable).
- `ruff check .` + `ruff format --check .` (pinned `ruff==0.15.20`) → **clean** (440 files formatted).

## Status

**HELD for coordinator review — do not merge.** Branch `dfinson-persistence-durability-validation`, based on fresh `main` (`e4ef467`).