### PR TITLE
docs: trim defensive prose and fix docs-site mobile layout

### DIFF
--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -150,19 +150,14 @@ back to the heuristic, a missing key never errors or blocks.
 ## Custom tool & MCP classifications
 
 TraceForge classifies by **trace-native structure** — the shape of each tool call and, for
-shell, its parsed AST — and ships only a small, *general* set of tool and MCP-server
-classifications as built-in defaults. It deliberately does **not** hard-code any one consumer's
-tool catalog. If you run bespoke native tools or private MCP servers, you attach your own
-taxonomy as an **overlay**: TraceForge merges your entries on top of its generic defaults,
-per key, so you own your vocabulary with no change to — and no fork of — TraceForge itself.
+shell, its parsed AST — and ships a small, general set of tool and MCP-server classifications
+as built-in defaults. Consumers overlay their own native tools and MCP servers on top of those
+defaults through the config chain.
 
-:::note Separate discovery chain from the root config
-The classification overlay is loaded by `traceforge.classify.config.load_config()`, a
-**different** discovery chain from the [root config precedence](#loading-precedence) above. It
-shares the `TRACEFORGE_CONFIG` environment variable (each subsystem reads only the keys it
-owns from a shared file), but its project- and user-level files live at their own paths (listed
-below). Put classification sections in one of those files — not in `./traceforge.yaml`.
-:::
+The classification overlay is loaded by `traceforge.classify.config.load_config()`, a separate
+discovery chain that shares only the `TRACEFORGE_CONFIG` environment variable with the [root
+config](#loading-precedence) above. Put classification sections in the classify config file
+(its own project- and user-level paths are listed below), not in `./traceforge.yaml`.
 
 ### The override surfaces
 
@@ -229,12 +224,10 @@ mcp_profiles:
         effect: destructive
 ```
 
-:::tip `tool_display` rides the same chain
 The overlay chain also carries `tool_display` — a `dict[str, str]` mapping a canonical tool
-identity to a human-facing label. It's how you relabel tools without touching their
-classification. See [Bring your own classifications](reference/classification.md#bring-your-own-classifications)
+identity to a human-facing label, so you can relabel tools without touching their classification.
+See [Bring your own classifications](reference/classification.md#bring-your-own-classifications)
 and the `tool_display` field on the [event model](architecture/event-model.md).
-:::
 
 ### Supplying an overlay
 
@@ -249,8 +242,7 @@ one below:
 6. TraceForge's built-in generic defaults (`classify/data/*.yaml`).
 
 The three you'll typically reach for are **2, 3, and 5** — all of which overlay the built-in
-defaults (6). Mind the precedence: a `TRACEFORGE_CONFIG` file overrides a project
-`.traceforge/config.yaml`, which overrides an entry-point profile.
+defaults (6).
 
 **Merge semantics.** Dict sections (`tool_classifications`, `tool_display`) merge **per key** —
 your key wins, untouched defaults survive. `mcp_profiles` is a list where higher-priority layers

--- a/website/docs/reference/classification.md
+++ b/website/docs/reference/classification.md
@@ -112,10 +112,8 @@ Classification behavior is governed entirely by YAML in `classify/data/`:
 
 ## Bring your own classifications
 
-The tables above are TraceForge's **built-in generic defaults**. Because the engine keys off
-trace-native structure, it ships only a general vocabulary and never hard-codes a specific
-consumer's tool catalog. To add your own native tools or private MCP servers, overlay them
-through the config chain — don't edit these bundled files or fork the package.
+The tables above are TraceForge's **built-in generic defaults**. To add your own native tools or
+private MCP servers, overlay them through the config chain instead of editing these bundled files.
 
 Three overlay surfaces cover the common cases:
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,6 +56,7 @@ const config = {
       image: 'img/og-card.png',
       colorMode: {
         defaultMode: 'dark',
+        disableSwitch: true,
         respectPrefersColorScheme: false,
       },
       navbar: {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -116,3 +116,64 @@
   max-width: 100%;
   height: auto;
 }
+
+/* ============================================================
+ * Responsive / mobile layout
+ * ------------------------------------------------------------
+ * These docs are table- and code-dense (the CLI, adapters, and
+ * architecture pages carry very wide tables). By default those
+ * tables and long code lines overflow the viewport horizontally
+ * on a phone. The rules below keep them inside their own scroll
+ * region and tighten typography on narrow screens.
+ * No brand color tokens are changed here.
+ * ============================================================ */
+
+/* Wide markdown tables scroll within their own region instead of
+ * forcing the whole page sideways. Docusaurus renders bare <table>
+ * elements inside .markdown; the .table-wrapper selector covers the
+ * case where a table is wrapped. This is the GitHub-markdown pattern:
+ * the table sizes to its content but is capped at the column width. */
+.markdown table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.markdown .table-wrapper {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Code blocks scroll horizontally rather than overflow the page. */
+.markdown pre {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 768px) {
+  /* Denser tables: smaller type + tighter cells so more columns fit
+   * before the horizontal scroll kicks in. */
+  .markdown table {
+    font-size: 0.85rem;
+  }
+  .markdown table th,
+  .markdown table td {
+    padding: 0.35rem 0.5rem;
+  }
+
+  /* Slightly smaller code so long YAML / CLI lines are easier to read
+   * while scrolling. */
+  .markdown pre code {
+    font-size: 0.82rem;
+  }
+
+  /* Keep the largest headings from wrapping awkwardly on phones. */
+  .markdown h1 {
+    font-size: 1.75rem;
+  }
+  .markdown h2 {
+    font-size: 1.4rem;
+  }
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -64,12 +64,7 @@
   --docusaurus-highlighted-code-line-bg: rgba(255, 153, 33, 0.18);
 }
 
-/* ---- light theme (kept usable via the toggle) ---- */
-[data-theme='light'] {
-  --ifm-background-color: #ffffff;
-  --ifm-heading-color: #0b1020;
-  --ifm-blockquote-border-color: var(--tf-orange);
-}
+/* ---- dark theme is the only theme (the light/dark toggle is disabled) ---- */
 
 [data-theme='dark'] .navbar {
   border-bottom: 1px solid #12182a;


### PR DESCRIPTION
Docs-site-only PR (everything under `website/`). Held for coordinator review.

## A — Mobile responsiveness (`website/src/css/custom.css`)
`custom.css` previously had **zero** `@media` queries and no table/code overflow handling, so wide tables and long YAML/CLI lines overflowed the viewport on phones. Appended a clearly-commented responsive section (brand color tokens untouched):

- Wide markdown tables scroll within their own region (GitHub-markdown pattern: `display:block; width:max-content; max-width:100%; overflow-x:auto`) instead of forcing horizontal page scroll — covers bare `<table>` and `.table-wrapper`.
- `pre`/code blocks scroll horizontally rather than overflow the page.
- `@media (max-width: 768px)`: smaller table font (0.85rem) + tighter cell padding, smaller code font (0.82rem), and trimmed `h1`/`h2` so headings don't wrap awkwardly.
- `index.module.css` left unchanged — the `.stage` `white-space: nowrap` does **not** cause mobile overflow (verified at 375px).

## B — Light prose de-cruft (facts preserved, surgical)
- `configuration.md` → **Custom tool & MCP classifications**: de-hedged the intro, folded the `:::note` (separate discovery chain) and `:::tip` (`tool_display`) admonitions into plain sentences, and deleted the paragraph restating the numbered precedence list.
- `reference/classification.md` → **Bring your own classifications**: removed the duplicated "never hard-codes … fork the package" hedge; it stays a brief description that links to `configuration.md` for the full schema.
- No front-matter, code/YAML, config keys, paths, links, or heading text changed. Legitimate design-rationale (pipeline "no opentelemetry-sdk / no cross-process broker", live-structuring zero-network, external-gating fail_open/DENY) was preserved.

## C — Lock site to dark mode
- `docusaurus.config.js`: added `colorMode.disableSwitch: true` (kept `defaultMode: 'dark'`, `respectPrefersColorScheme: false`) — removes the navbar light/dark toggle and forces dark everywhere.
- `custom.css`: removed the now-dead `[data-theme='light']` override block and fixed its stale "kept usable via the toggle" comment. All `[data-theme='dark']` and `:root` brand tokens untouched.

## Verification
- `npm ci && npm run build` — **green**, no broken links (`onBrokenLinks: 'throw'`).
- Headless Edge at **375px** across 7 table/code-dense pages (cli, sdk, adapters, architecture/overview, configuration, classification, landing): `document.scrollWidth == 375` on every page (**zero horizontal page overflow**); every table and code block sits within the viewport in its own scroll region, and wide tables actually scroll.
- Built HTML confirmed to contain **no** color-mode toggle and no `data-theme='light'` reference.

Held open for the coordinator to verify and merge.