### PR TITLE
Fix watch collapsing per-session files into one run (#151)

### DIFF
--- a/src/traceforge/cli/watch.py
+++ b/src/traceforge/cli/watch.py
@@ -218,22 +218,37 @@ async def _run_once(
 
 
 async def _watch_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePipeline") -> None:
-    """Watch a single pipeline's source and feed events through the unified pipeline."""
+    """Watch a single pipeline's source and feed events through the unified pipeline.
+
+    The shared event pipeline is built once, but a *fresh* adapter is created
+    lazily per source file — keyed to that file's session id (the filename stem)
+    — so each file becomes its own run and no session's stateful adapter bleeds
+    into another.
+    """
+    from traceforge.adapters.mapped_json import MappedJsonAdapter
+
     logger.info("Starting watcher for %s at %s", pipeline.name, pipeline.source_path)
 
     if not (pipeline.source_path.is_dir() or pipeline.source_path.is_file()):
         logger.warning("Source path does not exist: %s", pipeline.source_path)
         return
 
-    adapter, event_pipeline = _build_pipeline_runtime(pipeline, governance)
+    event_pipeline = _build_event_pipeline(pipeline, governance)
     try:
         if pipeline.source_path.is_dir():
-            # Watch directory for JSONL files
+            # Watch directory for JSONL files. One adapter per file, keyed to that
+            # file's session id, created lazily as each file first yields a line.
             pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
-            async for _file_path, line in watch_directory(pipeline.source_path, pattern=pattern):
+            adapters: dict[Path, MappedJsonAdapter] = {}
+            async for file_path, line in watch_directory(pipeline.source_path, pattern=pattern):
+                adapter = adapters.get(file_path)
+                if adapter is None:
+                    adapter = _build_adapter(pipeline, _session_id_for_source(file_path))
+                    adapters[file_path] = adapter
                 await _feed_line(line, adapter, event_pipeline)
         else:
-            # Watch single file
+            # Watch single file; one adapter keyed to that file's session id.
+            adapter = _build_adapter(pipeline, _session_id_for_source(pipeline.source_path))
             async for line in watch_jsonl_file(pipeline.source_path, start_at="end"):
                 await _feed_line(line, adapter, event_pipeline)
     finally:
@@ -244,23 +259,30 @@ async def _watch_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePip
 async def _process_pipeline_once(
     pipeline: ResolvedPipeline, governance: "GovernancePipeline"
 ) -> None:
-    """Process existing content in a pipeline's source once (no watching)."""
+    """Process existing content in a pipeline's source once (no watching).
+
+    The shared event pipeline is built once, but a *fresh* adapter is built per
+    source file keyed to that file's session id (the filename stem), so each file
+    becomes its own run instead of collapsing into a single ``pipeline.name`` run.
+    """
     logger.info("Processing %s at %s", pipeline.name, pipeline.source_path)
 
     if not (pipeline.source_path.is_dir() or pipeline.source_path.is_file()):
         return
 
-    adapter, event_pipeline = _build_pipeline_runtime(pipeline, governance)
+    event_pipeline = _build_event_pipeline(pipeline, governance)
     try:
         if pipeline.source_path.is_dir():
             pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
             for f in pipeline.source_path.rglob(pattern):
                 if f.is_file():
+                    adapter = _build_adapter(pipeline, _session_id_for_source(f))
                     for line in f.read_text(encoding="utf-8").splitlines():
                         stripped = line.strip()
                         if stripped:
                             await _feed_line(stripped, adapter, event_pipeline)
         else:
+            adapter = _build_adapter(pipeline, _session_id_for_source(pipeline.source_path))
             for line in pipeline.source_path.read_text(encoding="utf-8").splitlines():
                 stripped = line.strip()
                 if stripped:
@@ -281,8 +303,8 @@ def _build_sinks(pipeline: ResolvedPipeline) -> list:
     return build_sinks(pipeline.sinks)
 
 
-def _build_pipeline_runtime(pipeline: ResolvedPipeline, governance: "GovernancePipeline"):
-    """Build the ``(adapter, EventPipeline)`` runtime for a resolved pipeline.
+def _build_event_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePipeline"):
+    """Build the shared ``EventPipeline`` for a resolved pipeline (built once).
 
     The daemon runs the same unified pipeline as the SDK: adapt -> enrich ->
     classify -> govern -> sinks, with ``governance`` wired in as a *stage* so every
@@ -291,19 +313,47 @@ def _build_pipeline_runtime(pipeline: ResolvedPipeline, governance: "GovernanceP
     servers, so session budget/drift state stays unified across observation and
     preflight. Live ML structuring (phase + boundary labeling) is enabled by
     default, matching the SDK ``Pipeline``.
+
+    The event pipeline is stateless with respect to *which* source file feeds it,
+    so it is constructed a single time and reused across every file in the source
+    directory — models load once. Per-file *session identity* is supplied by a
+    fresh adapter per file (see :func:`_build_adapter`), not by this pipeline.
     """
-    from traceforge.adapters.mapped_json import MappedJsonAdapter
     from traceforge.enricher import Enricher
     from traceforge.pipeline import EventPipeline
 
-    mapping_path = load_mapping_path(pipeline.adapter.mapping)
-    adapter = MappedJsonAdapter.from_yaml(str(mapping_path), session_id=pipeline.name)
-    event_pipeline = EventPipeline(
+    return EventPipeline(
         sinks=_build_sinks(pipeline),
         enricher=Enricher(),
         governance=governance,
     )
-    return adapter, event_pipeline
+
+
+def _build_adapter(pipeline: ResolvedPipeline, session_id: str):
+    """Build a fresh ``MappedJsonAdapter`` for one source file.
+
+    A new adapter is created per source file for two reasons: (1) it stamps the
+    given ``session_id`` onto every event it emits, so each file's events carry
+    that file's own session identity instead of sharing the framework name; and
+    (2) ``MappedJsonAdapter`` is *stateful* (tool-call pairing, latest
+    intent/reasoning), so a fresh instance stops one session's trailing state
+    from bleeding into the next file.
+    """
+    from traceforge.adapters.mapped_json import MappedJsonAdapter
+
+    mapping_path = load_mapping_path(pipeline.adapter.mapping)
+    return MappedJsonAdapter.from_yaml(str(mapping_path), session_id=session_id)
+
+
+def _session_id_for_source(path: Path) -> str:
+    """Return the session id for a single source file.
+
+    File-per-session frameworks (claude/codex/cline/opencode) name each file
+    after the session it contains — the filename stem is the real session UUID
+    (it equals the ``sessionId`` recorded inside the file). So the stem is the
+    correct per-file session id.
+    """
+    return path.stem
 
 
 async def _feed_line(line: str, adapter, event_pipeline) -> None:

--- a/tests/unit/test_watch_session_split.py
+++ b/tests/unit/test_watch_session_split.py
@@ -1,0 +1,108 @@
+"""Regression test for issue #151 — per-session files must not collapse into one run.
+
+``traceforge watch`` over a directory of per-session trace files used to build ONE
+stateful :class:`MappedJsonAdapter` keyed to ``session_id = pipeline.name`` and reuse
+it across every file. Every file's events therefore inherited the framework name
+(e.g. ``"claude"``) as their session id, so all runs merged into a single giant run.
+
+Ground truth for file-per-session frameworks: each file under
+``~/.claude/projects/**/*.jsonl`` is exactly one session and the filename **stem** is
+the real session UUID. This test feeds a temp directory of >=2 distinct Claude session
+files through the ``--once`` path (:func:`_process_pipeline_once`) and asserts the
+emitted events carry **distinct** per-file session ids (each equal to that file's stem),
+and that **no** event carries the framework name. It fails on ``main`` (all events share
+``"claude"``) and passes after the per-file-adapter fix.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from pathlib import Path
+
+from tests.conftest import RecordingSink
+
+from traceforge.cli.runner import ADAPTER_MAP, ResolvedPipeline
+from traceforge.cli.watch import _process_pipeline_once
+
+# ``traceforge.cli`` re-exports the ``watch`` Command, which shadows the submodule
+# attribute, so ``import traceforge.cli.watch as x`` would bind the Command, not the
+# module. Fetch the real module object from sys.modules to monkeypatch its internals.
+watch_mod = importlib.import_module("traceforge.cli.watch")
+
+# Two distinct sessions; the filename stem IS the session id we expect downstream.
+_SESSION_A = "11111111-1111-4111-8111-111111111111"
+_SESSION_B = "22222222-2222-4222-8222-222222222222"
+
+
+def _claude_lines(tag: str) -> list[str]:
+    """A couple of minimal, valid Claude wire-format JSONL lines."""
+    return [
+        json.dumps({"type": "user", "message": {"content": f"hello from {tag}"}}),
+        json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": tag}]}}),
+    ]
+
+
+def _write_session_file(directory: Path, session_id: str, tag: str) -> None:
+    (directory / f"{session_id}.jsonl").write_text(
+        "\n".join(_claude_lines(tag)) + "\n", encoding="utf-8"
+    )
+
+
+def test_once_directory_splits_runs_by_file_stem(tmp_path, monkeypatch) -> None:
+    """--once over a directory yields one session id per file (the stem), never
+    the framework name."""
+    source = tmp_path / "projects"
+    source.mkdir()
+    _write_session_file(source, _SESSION_A, "A")
+    _write_session_file(source, _SESSION_B, "B")
+
+    pipeline = ResolvedPipeline(
+        name="claude",
+        source_path=source,
+        ingestion_mode="file_watch",
+        adapter=ADAPTER_MAP["claude"],
+        sinks=[],  # real sinks are swapped for a recording sink below
+    )
+
+    recording = RecordingSink()
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [recording.sink])
+
+    asyncio.run(_process_pipeline_once(pipeline, governance=None))
+
+    session_ids = {e.session_id for e in recording.events}
+
+    # Sanity: the pipeline actually emitted events (test isn't vacuously green).
+    assert recording.events, "no events were emitted through the --once path"
+    # (b) The framework name must NEVER be used as a session id.
+    assert pipeline.name not in session_ids
+    assert all(e.session_id != pipeline.name for e in recording.events)
+    # (a) Exactly N distinct session ids for N files, each equal to that file's stem.
+    assert session_ids == {_SESSION_A, _SESSION_B}
+
+
+def test_once_single_file_uses_file_stem(tmp_path, monkeypatch) -> None:
+    """--once over a single file keys the run to that file's stem, not the
+    framework name (single-file ingest still produces one adapter, one run)."""
+    source = tmp_path / f"{_SESSION_A}.jsonl"
+    source.write_text("\n".join(_claude_lines("A")) + "\n", encoding="utf-8")
+
+    pipeline = ResolvedPipeline(
+        name="claude",
+        source_path=source,
+        ingestion_mode="file_watch",
+        adapter=ADAPTER_MAP["claude"],
+        sinks=[],
+    )
+
+    recording = RecordingSink()
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [recording.sink])
+
+    asyncio.run(_process_pipeline_once(pipeline, governance=None))
+
+    session_ids = {e.session_id for e in recording.events}
+
+    assert recording.events, "no events were emitted through the --once path"
+    assert session_ids == {_SESSION_A}
+    assert pipeline.name not in session_ids


### PR DESCRIPTION
## Summary

`traceforge watch` over a directory of per-session trace files collapsed **all** files into a **single** run (`session_id="claude"`) instead of one run per file. Verified on `~/.claude/projects` (124 `.jsonl` files → 1 run of 1,997 events); the dashboard Fleet then shows one giant fake run on real data.

## Root cause

Both ingest paths in `src/traceforge/cli/watch.py` — the `--once` path (`_process_pipeline_once`) and the live path (`_watch_pipeline`) — built **one** `MappedJsonAdapter` with `session_id = pipeline.name` and reused that single **stateful** adapter across **every** file in the source directory. The adapter stamps its constructor `session_id` onto every event, and the Claude mapping extracts no per-record session id, so every file's events inherited the framework name. Two problems compound:

1. **Identity** — every file's events get `session_id="claude"` → runs merge.
2. **State bleed** — the adapter is stateful (tool-call pairing, latest intent/reasoning), so reusing one instance leaks one session's trailing state into the next file.

Ground truth: each file under `~/.claude/projects/**/*.jsonl` is exactly one session, and the filename **stem** is the real session UUID — which was simply discarded.

## Fix

Build the shared `EventPipeline` **once** (models load once), but create a **fresh adapter per source file** keyed to that file's session id (`path.stem`). New helpers in `watch.py`:

- `_build_event_pipeline(pipeline, governance)` — the shared pipeline (sinks + `Enricher()` + governance), built once.
- `_build_adapter(pipeline, session_id)` — a fresh `MappedJsonAdapter` per file.
- `_session_id_for_source(path)` — returns `path.stem`.

`_process_pipeline_once` now iterates directory files and builds a fresh adapter per file (single-file → one adapter keyed to its stem). `_watch_pipeline` keeps a `dict[Path, MappedJsonAdapter]` and lazily creates a per-file adapter, using the `file_path` that `watch_directory` already yields. Framework-specific glob logic (e.g. `continue` uses `*.json`) is unchanged, and single-file ingest still produces one adapter / one run.

## Test

`tests/unit/test_watch_session_split.py` feeds a temp directory of ≥2 distinct Claude session files through the `--once` path and asserts (a) N distinct `session_id`s equal to the file stems and (b) **no** event carries the framework name. It **fails on `main`** (`assert 'claude' not in {'claude'}`) and **passes** after the fix.

## Verification

- New test fails-on-main / passes-after (verified locally by reverting `watch.py`).
- Full suite: **3492 passed, 8 skipped**.
- `ruff check` and `ruff format --check` (pinned `ruff==0.15.20`): clean.

Diff is scoped to `src/traceforge/cli/watch.py` (+64/−14) and one new test file (+108).

Closes #151

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>