### PR TITLE
Batch /api/runs DB connections to kill fleet-load fan-out (#153)

### DIFF
--- a/src/traceforge/dashboard/api.py
+++ b/src/traceforge/dashboard/api.py
@@ -86,12 +86,8 @@ def get_runs(
         return []
     limit = _runs_limit(query)
     offset = _runs_offset(query)
-    runs: list[dict[str, Any]] = []
-    for session_id in repo.list_run_ids(limit=limit, offset=offset):
-        run = repo.build_run(session_id)
-        if run is not None:
-            runs.append(run)
-    return runs
+    session_ids = repo.list_run_ids(limit=limit, offset=offset)
+    return repo.build_runs(session_ids)
 
 
 def get_run(

--- a/src/traceforge/dashboard/repository.py
+++ b/src/traceforge/dashboard/repository.py
@@ -182,9 +182,60 @@ class DashboardRepository:
         """Lightweight per-session summaries for the Fleet table (no event bodies)."""
         return [s for s in (self._run_summary(sid) for sid in self.list_run_ids()) if s]
 
-    def build_run(self, session_id: str) -> dict[str, Any] | None:
-        """Assemble the full ``Run`` shape for one session, or ``None`` if unknown."""
-        conn = _connect_ro(self._paths.output_db)
+    def build_runs(self, session_ids: list[str]) -> list[dict[str, Any]]:
+        """Assemble full ``Run`` shapes for many sessions with O(1) DB connections.
+
+        Opens one read-only ``output.db`` connection and (when governance memory
+        is present) one read-only ``system.db`` connection, then threads both
+        through :meth:`build_run` and its identity/taint/trust/model helpers, so a
+        fleet of N runs costs a small constant number of connection opens instead
+        of ~8*N. Read-only throughout; the client ``Run[]`` contract is unchanged.
+        """
+        if not session_ids:
+            return []
+        out_conn = _connect_ro(self._paths.output_db)
+        sys_available = self.has_system_memory()
+        sys_conn: sqlite3.Connection | None = None
+        if sys_available:
+            try:
+                sys_conn = _connect_ro(self._paths.system_db)
+            except sqlite3.OperationalError:
+                sys_available = False
+        try:
+            runs: list[dict[str, Any]] = []
+            for session_id in session_ids:
+                run = self.build_run(
+                    session_id,
+                    out_conn=out_conn,
+                    sys_conn=sys_conn,
+                    sys_available=sys_available,
+                )
+                if run is not None:
+                    runs.append(run)
+            return runs
+        finally:
+            out_conn.close()
+            if sys_conn is not None:
+                sys_conn.close()
+
+    def build_run(
+        self,
+        session_id: str,
+        *,
+        out_conn: sqlite3.Connection | None = None,
+        sys_conn: sqlite3.Connection | None = None,
+        sys_available: bool | None = None,
+    ) -> dict[str, Any] | None:
+        """Assemble the full ``Run`` shape for one session, or ``None`` if unknown.
+
+        When ``out_conn``/``sys_conn`` are supplied (the fleet path via
+        :meth:`build_runs`) they are reused for every query instead of opening
+        fresh read-only connections, keeping ``GET /api/runs`` at O(1) connection
+        opens rather than ~8 per run. When omitted (the single-run
+        ``/api/runs/{id}`` path) connections are opened and closed locally.
+        """
+        own_out = out_conn is None
+        conn = _connect_ro(self._paths.output_db) if own_out else out_conn
         try:
             event_rows = conn.execute(
                 """SELECT id, session_id, kind, timestamp, tool_name, risk_level,
@@ -218,47 +269,50 @@ class DashboardRepository:
                     ORDER BY gap_ordinal ASC""",
                 (session_id,),
             ).fetchall()
+
+            metas = [_loads(r["metadata_json"]) for r in event_rows]
+            events = [_map_event(r, m) for r, m in zip(event_rows, metas)]
+            seg_risk = _segment_risk(events)
+            segments = _map_segments(seg_rows, events, seg_risk)
+            peak = max((e["risk"] for e in events), default=0)
+
+            starts = [t for t in (_parse_ts(r["timestamp"]) for r in event_rows) if t]
+            dur_ms = (
+                (max(starts) - min(starts)).total_seconds() * 1000.0 if len(starts) >= 2 else 0.0
+            )
+
+            identity = self._identity(session_id, sys_conn=sys_conn, sys_available=sys_available)
+            return {
+                "id": session_id,
+                "repo": identity["repo"] or _first_meta(metas, "repo") or "",
+                "agent": identity["agent"] or _first_meta(metas, "source_framework") or "",
+                "model": identity["model"] or _dominant_model(conn, session_id),
+                "title": _session_title(seg_rows) or identity["repo"] or session_id,
+                "live": identity["live"],
+                "segs": segments,
+                "events": events,
+                "usage": {
+                    "in": int(usage["in_tok"]),
+                    "out": int(usage["out_tok"]),
+                    "cost": float(usage["cost"]),
+                },
+                "started": event_rows[0]["timestamp"],
+                "durMs": dur_ms,
+                "drift": identity["drift"],
+                "peak": peak,
+                "taint": self._taint(session_id, sys_conn=sys_conn, sys_available=sys_available),
+                "trust": self._trust(session_id, sys_conn=sys_conn, sys_available=sys_available),
+                "mcp": _mcp_alerts(metas),
+                # Additive (not in the mock's Run type): raw context gaps for the
+                # Coverage list + RunView banner, wired in D6/D8.
+                "gaps": [
+                    {"t": g["timestamp"], "dropped": g["dropped_count"], "reason": g["reason"]}
+                    for g in gap_rows
+                ],
+            }
         finally:
-            conn.close()
-
-        metas = [_loads(r["metadata_json"]) for r in event_rows]
-        events = [_map_event(r, m) for r, m in zip(event_rows, metas)]
-        seg_risk = _segment_risk(events)
-        segments = _map_segments(seg_rows, events, seg_risk)
-        peak = max((e["risk"] for e in events), default=0)
-
-        starts = [t for t in (_parse_ts(r["timestamp"]) for r in event_rows) if t]
-        dur_ms = (max(starts) - min(starts)).total_seconds() * 1000.0 if len(starts) >= 2 else 0.0
-
-        identity = self._identity(session_id)
-        return {
-            "id": session_id,
-            "repo": identity["repo"] or _first_meta(metas, "repo") or "",
-            "agent": identity["agent"] or _first_meta(metas, "source_framework") or "",
-            "model": identity["model"] or _dominant_model(self._paths.output_db, session_id),
-            "title": _session_title(seg_rows) or identity["repo"] or session_id,
-            "live": identity["live"],
-            "segs": segments,
-            "events": events,
-            "usage": {
-                "in": int(usage["in_tok"]),
-                "out": int(usage["out_tok"]),
-                "cost": float(usage["cost"]),
-            },
-            "started": event_rows[0]["timestamp"],
-            "durMs": dur_ms,
-            "drift": identity["drift"],
-            "peak": peak,
-            "taint": self._taint(session_id),
-            "trust": self._trust(session_id),
-            "mcp": _mcp_alerts(metas),
-            # Additive (not in the mock's Run type): raw context gaps for the
-            # Coverage list + RunView banner, wired in D6/D8.
-            "gaps": [
-                {"t": g["timestamp"], "dropped": g["dropped_count"], "reason": g["reason"]}
-                for g in gap_rows
-            ],
-        }
+            if own_out:
+                conn.close()
 
     def _run_summary(self, session_id: str) -> dict[str, Any] | None:
         conn = _connect_ro(self._paths.output_db)
@@ -295,6 +349,7 @@ class DashboardRepository:
                     WHERE session_id = ? AND metadata_json IS NOT NULL LIMIT 1""",
                 (session_id,),
             ).fetchone()
+            dominant_model = _dominant_model(conn, session_id)
         finally:
             conn.close()
 
@@ -308,7 +363,7 @@ class DashboardRepository:
             "id": session_id,
             "repo": identity["repo"] or meta.get("repo") or "",
             "agent": identity["agent"] or meta.get("source_framework") or "",
-            "model": identity["model"] or _dominant_model(self._paths.output_db, session_id),
+            "model": identity["model"] or dominant_model,
             "title": (title_row["title"] if title_row else None) or session_id,
             "live": identity["live"],
             "usage": {
@@ -325,15 +380,26 @@ class DashboardRepository:
 
     # -- system.db (governance memory) — optional -----------------------------
 
-    def _identity(self, session_id: str) -> dict[str, Any]:
+    def _identity(
+        self,
+        session_id: str,
+        *,
+        sys_conn: sqlite3.Connection | None = None,
+        sys_available: bool | None = None,
+    ) -> dict[str, Any]:
         """repo / agent / model / live / drift from system.db, when present."""
         blank = {"repo": None, "agent": None, "model": None, "live": False, "drift": None}
-        if not self.has_system_memory():
+        available = sys_available if sys_available is not None else self.has_system_memory()
+        if not available:
             return blank
-        try:
-            conn = _connect_ro(self._paths.system_db)
-        except sqlite3.OperationalError:
-            return blank
+        own = sys_conn is None
+        if own:
+            try:
+                conn = _connect_ro(self._paths.system_db)
+            except sqlite3.OperationalError:
+                return blank
+        else:
+            conn = sys_conn
         try:
             summ = conn.execute(
                 """SELECT repo, agent_model, ended_at, drift_max
@@ -346,7 +412,8 @@ class DashboardRepository:
                     "SELECT 1 FROM session_state WHERE session_id = ?", (session_id,)
                 ).fetchone()
         finally:
-            conn.close()
+            if own:
+                conn.close()
         if not summ:
             # Live sessions may not have a summary yet; still detect liveness.
             return {**blank, "live": active is not None}
@@ -359,24 +426,40 @@ class DashboardRepository:
             "drift": summ["drift_max"],
         }
 
-    def _taint(self, session_id: str) -> list[dict[str, Any]]:
+    def _taint(
+        self,
+        session_id: str,
+        *,
+        sys_conn: sqlite3.Connection | None = None,
+        sys_available: bool | None = None,
+    ) -> list[dict[str, Any]]:
         rows = self._system_rows(
             "taint_entries",
             """SELECT clearance, source, payload_pointer FROM taint_entries
                 WHERE session_id = ? ORDER BY ordinal ASC""",
             session_id,
+            sys_conn=sys_conn,
+            sys_available=sys_available,
         )
         return [
             {"flow": f"{r['source']} → {r['clearance']}", "det": r["payload_pointer"], "lvl": 1}
             for r in rows
         ]
 
-    def _trust(self, session_id: str) -> list[dict[str, Any]]:
+    def _trust(
+        self,
+        session_id: str,
+        *,
+        sys_conn: sqlite3.Connection | None = None,
+        sys_available: bool | None = None,
+    ) -> list[dict[str, Any]]:
         rows = self._system_rows(
             "trust_grants",
             """SELECT key, granted_at, ttl_seconds, reason FROM trust_grants
                 WHERE session_id = ? ORDER BY ordinal ASC""",
             session_id,
+            sys_conn=sys_conn,
+            sys_available=sys_available,
         )
         return [
             {
@@ -388,19 +471,33 @@ class DashboardRepository:
             for r in rows
         ]
 
-    def _system_rows(self, table: str, sql: str, session_id: str) -> list[sqlite3.Row]:
-        if not self.has_system_memory():
+    def _system_rows(
+        self,
+        table: str,
+        sql: str,
+        session_id: str,
+        *,
+        sys_conn: sqlite3.Connection | None = None,
+        sys_available: bool | None = None,
+    ) -> list[sqlite3.Row]:
+        available = sys_available if sys_available is not None else self.has_system_memory()
+        if not available:
             return []
-        try:
-            conn = _connect_ro(self._paths.system_db)
-        except sqlite3.OperationalError:
-            return []
+        own = sys_conn is None
+        if own:
+            try:
+                conn = _connect_ro(self._paths.system_db)
+            except sqlite3.OperationalError:
+                return []
+        else:
+            conn = sys_conn
         try:
             if not _has_table(conn, table):
                 return []
             return conn.execute(sql, (session_id,)).fetchall()
         finally:
-            conn.close()
+            if own:
+                conn.close()
 
 
 # --- pure mapping helpers ----------------------------------------------------
@@ -568,19 +665,12 @@ def _first_meta(metas: list[dict[str, Any]], key: str) -> str | None:
     return None
 
 
-def _dominant_model(output_db: Path, session_id: str) -> str:
-    try:
-        conn = _connect_ro(output_db)
-    except sqlite3.OperationalError:
-        return ""
-    try:
-        row = conn.execute(
-            """SELECT model, COUNT(*) c FROM usage_records
-                WHERE session_id = ? GROUP BY model ORDER BY c DESC LIMIT 1""",
-            (session_id,),
-        ).fetchone()
-    finally:
-        conn.close()
+def _dominant_model(conn: sqlite3.Connection, session_id: str) -> str:
+    row = conn.execute(
+        """SELECT model, COUNT(*) c FROM usage_records
+            WHERE session_id = ? GROUP BY model ORDER BY c DESC LIMIT 1""",
+        (session_id,),
+    ).fetchone()
     return row["model"] if row else ""
 
 

--- a/tests/e2e/test_dashboard_repository.py
+++ b/tests/e2e/test_dashboard_repository.py
@@ -19,6 +19,7 @@ import pytest
 
 from traceforge.classify.core import Classification
 from traceforge.classify.risk import RiskAssessment
+from traceforge.dashboard import api, repository
 from traceforge.dashboard.repository import DashboardPaths, DashboardRepository
 from traceforge.governance.envelope import ContextGapEvent, EnrichedEvent
 from traceforge.governance.mcp_drift import MCPIntegrityAlert
@@ -363,3 +364,120 @@ async def test_health_without_output_db(tmp_path: Path) -> None:
     health = repo.health()
     assert health["has_output_db"] is False
     assert health["has_system_memory"] is False
+
+
+# --- fleet-path connection-open guard (regression for #153) -------------------
+
+
+async def _seed_many_output(db: Path, ids: list[str]) -> None:
+    """One event + one usage record per session, via the real output sink."""
+    sink = SqliteOutputSink(path=str(db))
+    for i, sid in enumerate(ids):
+        ts = _T0 + timedelta(seconds=i)
+        await sink.on_event(
+            SessionEvent(
+                kind=EventKind.MESSAGE_USER,
+                session_id=sid,
+                timestamp=ts,
+                payload={"tool_name": "bash"},
+            )
+        )
+        await sink.on_usage(
+            UsageRecord(
+                session_id=sid,
+                timestamp=ts,
+                model="gpt-4o",
+                input_tokens=10,
+                output_tokens=5,
+                cost_usd=0.01,
+            )
+        )
+    await sink.close()
+
+
+def _seed_many_system(db: Path, ids: list[str]) -> None:
+    """A finalized summary + taint/trust row per session (exercises sys helpers)."""
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE session_summaries (
+            session_id TEXT PRIMARY KEY, repo TEXT, agent_model TEXT, started_at TEXT NOT NULL,
+            ended_at TEXT, total_events INTEGER, dropped_events INTEGER DEFAULT 0,
+            budget_snapshot_json TEXT, recommendation_counts_json TEXT, drift_max REAL);
+        CREATE TABLE session_state (session_id TEXT PRIMARY KEY, updated_at TEXT NOT NULL DEFAULT '');
+        CREATE TABLE taint_entries (
+            session_id TEXT NOT NULL, ordinal INTEGER NOT NULL, event_id TEXT NOT NULL,
+            source_event_key TEXT NOT NULL, clearance TEXT NOT NULL, source TEXT NOT NULL,
+            payload_pointer TEXT NOT NULL, PRIMARY KEY (session_id, ordinal));
+        CREATE TABLE trust_grants (
+            session_id TEXT NOT NULL, ordinal INTEGER NOT NULL, key TEXT NOT NULL,
+            granted_at TEXT NOT NULL, ttl_seconds REAL NOT NULL, reason TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (session_id, ordinal));
+        """
+    )
+    for sid in ids:
+        conn.execute(
+            "INSERT INTO session_summaries VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (
+                sid,
+                "acme/widgets",
+                "copilot/gpt-4o",
+                _T0.isoformat(),
+                _T0.isoformat(),
+                1,
+                0,
+                None,
+                None,
+                0.1,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO taint_entries VALUES (?,?,?,?,?,?,?)",
+            (sid, 0, "e1", "k1", "restricted", "user_input", "/arguments"),
+        )
+        conn.execute(
+            "INSERT INTO trust_grants VALUES (?,?,?,?,?,?)",
+            (sid, 0, "deploy-key", _T0.isoformat(), 3600.0, "approved"),
+        )
+    conn.commit()
+    conn.close()
+
+
+async def test_get_runs_opens_constant_connections_regardless_of_run_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fleet path must not fan out connections per run.
+
+    Regression guard for the ``GET /api/runs`` N+1 connection blow-up (#153): the
+    old code opened ~8 read-only connections per run (build_run + identity/taint/
+    trust/model each opening their own), so a 40-run fleet cost ~300 opens and
+    ~27s. Assemble a many-run fleet and assert the total number of ``_connect_ro``
+    calls is a small constant, independent of the run count.
+    """
+    ids = [f"sess-{i:03d}" for i in range(40)]
+    out, sysdb = tmp_path / "traceforge.db", tmp_path / "system.db"
+    await _seed_many_output(out, ids)
+    _seed_many_system(sysdb, ids)
+    repo = DashboardRepository(DashboardPaths(output_db=out, system_db=sysdb))
+
+    opens = 0
+    real_connect = repository._connect_ro
+
+    def _counting_connect(path: Path) -> sqlite3.Connection:
+        nonlocal opens
+        opens += 1
+        return real_connect(path)
+
+    monkeypatch.setattr(repository, "_connect_ro", _counting_connect)
+
+    runs = api.get_runs(repo, None, {})  # type: ignore[arg-type]
+
+    # Correctness: every run assembled, identity + model resolved via shared conns.
+    assert len(runs) == len(ids)
+    assert {r["id"] for r in runs} == set(ids)
+    assert all(r["model"] == "gpt-4o" for r in runs)
+    assert all(r["repo"] == "acme/widgets" for r in runs)
+    assert all(len(r["taint"]) == 1 and len(r["trust"]) == 1 for r in runs)
+    # O(1) opens: list_run_ids (1) + has_system_memory (1) + shared output (1) +
+    # shared system (1) = 4. The pre-fix fan-out would be in the hundreds.
+    assert opens <= 6, f"expected a small constant number of opens, got {opens} for {len(ids)} runs"


### PR DESCRIPTION
## Summary

`GET /api/runs` took **27.6s for 124 runs** even though the JSON payload is only ~3 MB — the cost was server-side connection fan-out, not transfer. `get_runs` looped `build_run` once per run, and each `build_run` opened ~8 read-only SQLite connections (its own `output.db` query, plus the `_identity`/`_taint`/`_trust`/`_dominant_model` helpers each opening another `_connect_ro`, and `has_system_memory()` re-running 3× per run). That is ~1000 `sqlite3.connect(mode=ro)` opens for 124 runs.

## Change

- Add `DashboardRepository.build_runs(ids)`, which opens **one** read-only `output.db` connection and **one** read-only `system.db` connection (only when governance memory is present, computed once) and threads both through `build_run`.
- `build_run` and the `_identity`/`_taint`/`_trust`/`_system_rows`/`_dominant_model` helpers now accept an **optional pre-opened connection** and self-open when it is omitted — so the single-run `/api/runs/{id}` path and all existing tests are unchanged.
- `get_runs` delegates to `build_runs`. The response stays a bare `Run[]` (client contract unchanged) and every read remains `mode=ro`.

## Result

A 124-run temp DB now assembles in **~66ms** (was ~27.6s), well under the ~2s target. Connection opens are now O(1) — `list_run_ids` + `has_system_memory` + one shared output + one shared system = 4 — regardless of run count.

## Test

New e2e test seeds a 40-run temp DB via the real `SqliteOutputSink` (+ matching temp `system.db`) and asserts:
- every run is assembled with identity/model/taint/trust resolved through the shared connections, and
- a **connection-open guard**: monkeypatches `repository._connect_ro` with a counter and asserts opens stay a small constant (≤6) regardless of run count — this fails the instant the per-run fan-out returns.

Full suite: 3493 passed, 8 skipped. Ruff check + format clean.

## Relation to #150

#150 proposes a *different*, larger change (an event-body-free list projection + frontend rework). This PR is orthogonal — it keeps the `Run[]` contract and only removes the connection fan-out — so #150 stays open.

Closes #153

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>