### PR TITLE
watch: enrich dashboard-feeding path with chapter titles + cost (#155)

### DIFF
--- a/src/traceforge/cli/watch.py
+++ b/src/traceforge/cli/watch.py
@@ -21,6 +21,7 @@ from traceforge.cli.runner import (
 )
 from traceforge.cli.score import ScoreServer
 from traceforge.sources.auto_detect import detect_frameworks
+from traceforge.types import EventKind, UsageRecord
 
 logger = logging.getLogger(__name__)
 
@@ -74,10 +75,24 @@ def _warn_gating_inactive() -> None:
 @click.option("--once", is_flag=True, help="Process existing files then exit (no watching).")
 @click.option("--no-score", is_flag=True, help="Don't start the Score API server.")
 @click.option(
+    "--titles/--no-titles",
+    "titles",
+    default=True,
+    help=(
+        "Infer chapter/segment titles (feeds the dashboard chapter tree). "
+        "Default on; --no-titles skips per-segment ONNX inference for max throughput."
+    ),
+)
+@click.option(
     "--log-level", default="INFO", type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"])
 )
 def watch(
-    config_path: str | None, frameworks: str | None, once: bool, no_score: bool, log_level: str
+    config_path: str | None,
+    frameworks: str | None,
+    once: bool,
+    no_score: bool,
+    titles: bool,
+    log_level: str,
 ) -> None:
     """Watch detected frameworks, run governance pipeline, emit to sinks."""
     logging.basicConfig(
@@ -154,9 +169,9 @@ def watch(
     # Run async event loop
     try:
         if once:
-            asyncio.run(_run_once(pipelines, pipeline, store))
+            asyncio.run(_run_once(pipelines, pipeline, store, titles))
         else:
-            asyncio.run(_run_watch(pipelines, pipeline, store))
+            asyncio.run(_run_watch(pipelines, pipeline, store, titles))
     except KeyboardInterrupt:
         click.echo("\nShutting down...")
     finally:
@@ -173,11 +188,16 @@ async def _run_watch(
     pipelines: list[ResolvedPipeline],
     governance: "GovernancePipeline",
     store: "SystemStore",
+    enable_title: bool = False,
 ) -> None:
     """Run all pipeline watchers concurrently."""
     tasks = []
     for p in pipelines:
-        tasks.append(asyncio.create_task(_watch_pipeline(p, governance), name=f"watch-{p.name}"))
+        tasks.append(
+            asyncio.create_task(
+                _watch_pipeline(p, governance, enable_title), name=f"watch-{p.name}"
+            )
+        )
 
     # Handle graceful shutdown
     loop = asyncio.get_event_loop()
@@ -211,13 +231,16 @@ async def _run_once(
     pipelines: list[ResolvedPipeline],
     governance: "GovernancePipeline",
     store: "SystemStore",
+    enable_title: bool = False,
 ) -> None:
     """Process existing files once and exit."""
     for p in pipelines:
-        await _process_pipeline_once(p, governance)
+        await _process_pipeline_once(p, governance, enable_title)
 
 
-async def _watch_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePipeline") -> None:
+async def _watch_pipeline(
+    pipeline: ResolvedPipeline, governance: "GovernancePipeline", enable_title: bool = False
+) -> None:
     """Watch a single pipeline's source and feed events through the unified pipeline.
 
     The shared event pipeline is built once, but a *fresh* adapter is created
@@ -233,7 +256,7 @@ async def _watch_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePip
         logger.warning("Source path does not exist: %s", pipeline.source_path)
         return
 
-    event_pipeline = _build_event_pipeline(pipeline, governance)
+    event_pipeline = _build_event_pipeline(pipeline, governance, enable_title)
     try:
         if pipeline.source_path.is_dir():
             # Watch directory for JSONL files. One adapter per file, keyed to that
@@ -257,7 +280,7 @@ async def _watch_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePip
 
 
 async def _process_pipeline_once(
-    pipeline: ResolvedPipeline, governance: "GovernancePipeline"
+    pipeline: ResolvedPipeline, governance: "GovernancePipeline", enable_title: bool = False
 ) -> None:
     """Process existing content in a pipeline's source once (no watching).
 
@@ -270,7 +293,7 @@ async def _process_pipeline_once(
     if not (pipeline.source_path.is_dir() or pipeline.source_path.is_file()):
         return
 
-    event_pipeline = _build_event_pipeline(pipeline, governance)
+    event_pipeline = _build_event_pipeline(pipeline, governance, enable_title)
     try:
         if pipeline.source_path.is_dir():
             pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
@@ -303,7 +326,9 @@ def _build_sinks(pipeline: ResolvedPipeline) -> list:
     return build_sinks(pipeline.sinks)
 
 
-def _build_event_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePipeline"):
+def _build_event_pipeline(
+    pipeline: ResolvedPipeline, governance: "GovernancePipeline", enable_title: bool = False
+):
     """Build the shared ``EventPipeline`` for a resolved pipeline (built once).
 
     The daemon runs the same unified pipeline as the SDK: adapt -> enrich ->
@@ -312,7 +337,10 @@ def _build_event_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePip
     the pipeline itself. The shared governance engine also backs the Gate/Score IPC
     servers, so session budget/drift state stays unified across observation and
     preflight. Live ML structuring (phase + boundary labeling) is enabled by
-    default, matching the SDK ``Pipeline``.
+    default, matching the SDK ``Pipeline``. Per-segment title inference is gated by
+    ``enable_title`` (driven by the ``watch --titles/--no-titles`` flag): when on,
+    the titler is built and its :class:`TitleUpdate`\\ s are flushed to sinks on
+    ``close()``, populating ``segment_titles`` for the dashboard chapter tree.
 
     The event pipeline is stateless with respect to *which* source file feeds it,
     so it is constructed a single time and reused across every file in the source
@@ -326,6 +354,7 @@ def _build_event_pipeline(pipeline: ResolvedPipeline, governance: "GovernancePip
         sinks=_build_sinks(pipeline),
         enricher=Enricher(),
         governance=governance,
+        enable_title=enable_title,
     )
 
 
@@ -357,7 +386,16 @@ def _session_id_for_source(path: Path) -> str:
 
 
 async def _feed_line(line: str, adapter, event_pipeline) -> None:
-    """Parse one raw line and push each resulting event through the pipeline."""
+    """Parse one raw line and push each resulting event through the pipeline.
+
+    Every event is pushed once via :meth:`EventPipeline.push`. Usage-kind events
+    (:data:`EventKind.USAGE`, e.g. Claude's ``result`` record) are *additionally*
+    dual-emitted as a :class:`~traceforge.types.UsageRecord` via
+    :meth:`EventPipeline.push_usage`, so token/cost totals land in ``usage_records``
+    (the Cost lens source) instead of only ``enriched_events``. This is purely
+    additive: it does not change enriched-event counts. ``model`` is absent from the
+    Claude ``result`` record, so it is left ``""`` (no synthesized identity).
+    """
     try:
         data = json.loads(line)
     except json.JSONDecodeError:
@@ -366,6 +404,17 @@ async def _feed_line(line: str, adapter, event_pipeline) -> None:
 
     for event in adapter.parse_dict(data):
         await event_pipeline.push(event)
+        if event.kind == EventKind.USAGE:
+            await event_pipeline.push_usage(
+                UsageRecord(
+                    session_id=event.session_id,
+                    timestamp=event.timestamp,
+                    model=str(event.payload.get("model") or ""),
+                    input_tokens=int(event.payload.get("input_tokens") or 0),
+                    output_tokens=int(event.payload.get("output_tokens") or 0),
+                    cost_usd=event.payload.get("cost_usd"),
+                )
+            )
 
 
 def _load_config(config_path: str | None) -> dict | None:

--- a/tests/e2e/test_watch_enrichment.py
+++ b/tests/e2e/test_watch_enrichment.py
@@ -1,0 +1,118 @@
+"""End-to-end enrichment tests for the watch dashboard-feeding path (issue #155).
+
+The zero-config way to populate the dashboard is ``traceforge watch --once``. These
+tests feed the real Claude fixture through that same code path
+(:func:`traceforge.cli.watch._process_pipeline_once`) into an **isolated** temp
+:class:`SqliteOutputSink` — never the live ``~/.traceforge/*.db`` — then reopen the
+DB read-only and query it directly to prove the two enrichment gaps are closed:
+
+* **Cost (Gap 3):** usage-kind events are bridged to ``usage_records`` (the Cost
+  lens source) carrying the fixture's *real* token/cost totals — independent of
+  titles.
+* **Titles (Gap 2):** enabling the titler persists ``segment_titles`` (the chapter
+  tree); ``--no-titles`` leaves it empty while usage still populates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from traceforge.cli.runner import ADAPTER_MAP, ResolvedPipeline
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+
+pytestmark = pytest.mark.e2e
+
+# ``traceforge.cli`` re-exports the ``watch`` Command, shadowing the submodule, so
+# fetch the real module object to reach ``_process_pipeline_once`` / monkeypatch
+# ``_build_sinks``.
+watch_mod = importlib.import_module("traceforge.cli.watch")
+
+# The real Claude fixture. Its ``result`` line carries total_cost_usd=0.0089 and
+# usage.{input_tokens=3500, output_tokens=450}. The per-file adapter stamps the
+# file stem as the session id, so the run's session id is ``claude_session``.
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "claude_session.jsonl"
+_SESSION_ID = "claude_session"
+_EXPECTED_INPUT_TOKENS = 3500
+_EXPECTED_OUTPUT_TOKENS = 450
+_EXPECTED_COST_USD = 0.0089
+
+
+def _run_fixture_once(tmp_path: Path, monkeypatch, *, enable_title: bool) -> Path:
+    """Ingest the fixture once into a fresh temp sqlite DB and return its path."""
+    db_path = tmp_path / "out.db"
+    sink = SqliteOutputSink(path=str(db_path))
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [sink])
+
+    pipeline = ResolvedPipeline(
+        name="claude",
+        source_path=_FIXTURE,
+        ingestion_mode="file_watch",
+        adapter=ADAPTER_MAP["claude"],
+        sinks=[],  # swapped for the isolated temp sink above
+    )
+    asyncio.run(
+        watch_mod._process_pipeline_once(pipeline, governance=None, enable_title=enable_title)
+    )
+    return db_path
+
+
+def _query_one(db_path: Path, sql: str):
+    """Reopen the temp DB read-only with a fresh connection and fetch one row."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return conn.execute(sql).fetchone()
+    finally:
+        conn.close()
+
+
+def _assert_fixture_usage(db_path: Path) -> None:
+    (usage_count,) = _query_one(db_path, "SELECT COUNT(*) FROM usage_records")
+    assert usage_count >= 1, "usage bridge did not populate usage_records"
+
+    total_in, total_out, total_cost = _query_one(
+        db_path,
+        "SELECT SUM(input_tokens), SUM(output_tokens), SUM(cost_usd) FROM usage_records",
+    )
+    assert total_in == _EXPECTED_INPUT_TOKENS
+    assert total_out == _EXPECTED_OUTPUT_TOKENS
+    assert total_cost == pytest.approx(_EXPECTED_COST_USD)
+
+    (usage_session,) = _query_one(db_path, "SELECT DISTINCT session_id FROM usage_records")
+    assert usage_session == _SESSION_ID
+
+
+def test_watch_once_persists_usage_and_titles(tmp_path, monkeypatch) -> None:
+    """With titles on, the --once path persists both real usage/cost and titles."""
+    db_path = _run_fixture_once(tmp_path, monkeypatch, enable_title=True)
+
+    # Sanity: the run actually processed events (test isn't vacuously green).
+    (event_count,) = _query_one(db_path, "SELECT COUNT(*) FROM enriched_events")
+    assert event_count > 0, "no events were emitted through the --once path"
+
+    # Gap 3: real tokens/cost land in usage_records.
+    _assert_fixture_usage(db_path)
+
+    # Gap 2: enabling the titler persists segment titles for the chapter tree.
+    (title_count,) = _query_one(db_path, "SELECT COUNT(*) FROM segment_titles")
+    assert title_count > 0, "titler enabled but no segment_titles were persisted"
+
+
+def test_watch_once_no_titles_disables_titler_but_keeps_usage(tmp_path, monkeypatch) -> None:
+    """--no-titles suppresses titles, but the usage/cost bridge is independent."""
+    db_path = _run_fixture_once(tmp_path, monkeypatch, enable_title=False)
+
+    # Sanity: events still flowed.
+    (event_count,) = _query_one(db_path, "SELECT COUNT(*) FROM enriched_events")
+    assert event_count > 0, "no events were emitted through the --once path"
+
+    # Titler off → no titles persisted.
+    (title_count,) = _query_one(db_path, "SELECT COUNT(*) FROM segment_titles")
+    assert title_count == 0, "titles were persisted despite enable_title=False"
+
+    # ...but usage/cost still populates (bridge does not depend on the titler).
+    _assert_fixture_usage(db_path)

--- a/tests/unit/test_watch_enrichment.py
+++ b/tests/unit/test_watch_enrichment.py
@@ -1,0 +1,63 @@
+"""Unit tests for the ``watch`` enrichment toggles (issue #155).
+
+Two knobs on the dashboard-feeding ``watch`` path are wired here, exercised
+without running the daemon:
+
+* ``_build_event_pipeline(..., enable_title=...)`` decides whether the per-segment
+  title inferencer is constructed. The internal helpers keep the historical
+  ``enable_title=False`` default so existing positional callers (e.g. the session
+  -split regression test) never start loading the title model.
+* the user-facing ``--titles/--no-titles`` click flag defaults **on**, because
+  watch's job here is feeding the rich dashboard chapter tree; the opt-out only
+  exists for max-throughput users.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from traceforge.cli.runner import ADAPTER_MAP, ResolvedPipeline
+
+# ``traceforge.cli`` re-exports the ``watch`` Command, which shadows the submodule
+# attribute, so fetch the real module object to reach its private helpers and the
+# Command's declared params.
+watch_mod = importlib.import_module("traceforge.cli.watch")
+
+
+def _minimal_pipeline() -> ResolvedPipeline:
+    """A resolved pipeline whose ``source_path`` is never read by pipeline build."""
+    return ResolvedPipeline(
+        name="claude",
+        source_path=Path("."),
+        ingestion_mode="file_watch",
+        adapter=ADAPTER_MAP["claude"],
+        sinks=[],
+    )
+
+
+def test_build_event_pipeline_title_toggle(monkeypatch) -> None:
+    """``enable_title`` decides whether the titler is built; default stays off."""
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [])
+    pipeline = _minimal_pipeline()
+
+    with_titles = watch_mod._build_event_pipeline(pipeline, governance=None, enable_title=True)
+    assert with_titles._title_inferencer is not None
+
+    without_titles = watch_mod._build_event_pipeline(pipeline, governance=None, enable_title=False)
+    assert without_titles._title_inferencer is None
+
+    # The default must remain off so internal positional callers do not silently
+    # start loading the ONNX title model (preserves existing test behavior).
+    default_pipeline = watch_mod._build_event_pipeline(pipeline, governance=None)
+    assert default_pipeline._title_inferencer is None
+
+
+def test_watch_titles_flag_defaults_on() -> None:
+    """The ``--titles/--no-titles`` boolean flag exists and defaults to True."""
+    titles_opt = next(p for p in watch_mod.watch.params if p.name == "titles")
+
+    assert titles_opt.is_flag
+    assert titles_opt.default is True
+    assert "--titles" in titles_opt.opts
+    assert "--no-titles" in titles_opt.secondary_opts


### PR DESCRIPTION
## What & why

The zero-config way to populate the dashboard from existing agent sessions is `traceforge watch --once --frameworks claude --no-score`. It ran the full pipeline but left the dashboard **sparse**: after `watch --once`, `segment_titles` and `usage_records` were both empty, so runs showed raw-UUID titles (empty chapter tree) and the Cost lens showed nothing. This PR enriches that path on two axes — all in `cli/watch.py`.

### Change 1 — chapter titles (Gap 2)
`EventPipeline.__init__` defaults `enable_title=False`, and `_build_event_pipeline` built the pipeline without it, so the titler was never created and no title streams were ever flushed. `close()` → `flush()` → `_flush_title_streams()` already persists titles via `SqliteOutputSink.on_title_update`, so enabling the titler is sufficient.

- Add a `--titles/--no-titles` click flag (**default ON** — watch's job here is feeding the rich dashboard; the opt-out preserves max throughput).
- Thread an `enable_title` bool through `_run_once`/`_run_watch` → `_process_pipeline_once`/`_watch_pipeline` → `_build_event_pipeline` → `EventPipeline(enable_title=...)`.
- The **internal helpers default to `enable_title=False`** so existing positional callers (e.g. the session-split regression test) keep their behavior and don't load the ONNX title model. Only the user-facing flag defaults True.

### Change 2 — usage/cost bridge (Gap 3)
`usage_records` is only written by `SqliteOutputSink.on_usage`, reached only via `EventPipeline.push_usage(UsageRecord)`. The watch path's `_feed_line` only called `push(event)`, so `telemetry.usage` events (Claude's `result` record, already mapped by `mappings/claude.yaml`) landed in `enriched_events` and never `usage_records`.

- In `_feed_line`, keep `push(event)` for every event and **additionally** emit a `UsageRecord` for `EventKind.USAGE` events. Purely additive (dual-emit): enriched-event counts are unchanged; it only adds `usage_records` rows.
- `model` is legitimately absent from Claude's `result` record, so it's left `""` (no synthesized identity — that's a deeper per-framework change, out of scope).

## Verification
Fed the real `tests/fixtures/claude_session.jsonl` through the `--once` path into an **isolated temp** `SqliteOutputSink` (never `~/.traceforge/*.db`) and queried the temp DB directly:

| enable_title | enriched_events | segment_titles | usage_records (count, Σin, Σout, Σcost) |
|---|---|---|---|
| `True`  | 11 | **4** | (1, 3500, 450, 0.0089) |
| `False` | 11 | **0** | (1, 3500, 450, 0.0089) |

Titles populate only when enabled; the usage/cost bridge is independent of titles.

## Tests
- **unit** `test_watch_enrichment.py`: title toggle on `_build_event_pipeline` (built/None/default-off), and the `--titles/--no-titles` flag defaults ON.
- **e2e** `test_watch_enrichment.py`: fixture → temp `SqliteOutputSink`, asserting `usage_records` totals (3500/450/≈0.0089, session `claude_session`) + `segment_titles > 0`; and `--no-titles` disables titles while usage still populates.

Full suite: **3497 passed, 8 skipped**. Ruff check + format clean (0.15.20).

Diff is scoped to `src/traceforge/cli/watch.py` + tests only (nothing under `dashboard/`).

Closes #155