### PR TITLE
Fix dashboard render fidelity for non-tool events and object payloads (#157)

### DIFF
--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -12,6 +12,14 @@ export const dmin = (ms: number) =>
 export const rlab = (l: RiskLevel) => RISK[l];
 export const riskVar = (l: number) => `var(--risk-${l})`;
 
+/** Render a payload value for display: objects/arrays as pretty JSON, primitives
+ * as-is, and null/undefined as an empty string (never "[object Object]"). */
+export function fmtVal(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "object") return JSON.stringify(v, null, 2);
+  return String(v);
+}
+
 export function peakOf(evs: TEvent[]): RiskLevel {
   return Math.max(0, ...evs.map((e) => e.risk)) as RiskLevel;
 }

--- a/dashboard/src/views/RunView.tsx
+++ b/dashboard/src/views/RunView.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, ArrowLeft, ChevronRight, FileText } from "lucide-react";
 import { useRuns } from "@/lib/queries";
 import type { TEvent } from "@/lib/types";
 import { useApp } from "@/store";
-import { dmin, hhmm, money, money3 } from "@/lib/format";
+import { dmin, hhmm, money, money3, fmtVal } from "@/lib/format";
 import { G, mtip } from "@/data/tips";
 import { Tip } from "@/components/Tip";
 import { RiskBadge, RiskDot } from "@/components/RiskBadge";
@@ -308,7 +308,7 @@ function Inspector({ e, idx }: { e: TEvent; idx: number }) {
             {payload.map(([k, v]) => (
               <div key={k} className="flex gap-2">
                 <span className="shrink-0 text-muted-foreground">{k}:</span>
-                <span className="min-w-0 break-all">{String(v)}</span>
+                <span className="min-w-0 whitespace-pre-wrap break-all">{fmtVal(v)}</span>
               </div>
             ))}
           </div>

--- a/src/traceforge/dashboard/repository.py
+++ b/src/traceforge/dashboard/repository.py
@@ -514,7 +514,9 @@ def _map_event(row: sqlite3.Row, meta: dict[str, Any]) -> dict[str, Any]:
 
     mechanism = cls.get("mechanism") or ""
     effect = cls.get("effect") or ""
-    tool_name = row["tool_name"] or row["tool_display"] or mechanism or "event"
+    tool_name = (
+        row["tool_name"] or row["tool_display"] or mechanism or _label_from_kind(row["kind"])
+    )
     action = row["action"] or rec.get("recommended_action") or "allow"
     confidence = _CONFIDENCE_NUM.get(risk_a.get("confidence") or "", 0.9)
 
@@ -565,11 +567,49 @@ def _map_evidence(evd: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_KIND_LABELS: dict[str, str] = {
+    "message.user": "User",
+    "message.assistant": "Assistant",
+    "message.system": "System",
+    "telemetry.usage": "Usage",
+}
+
+
+def _label_from_kind(kind: str | None) -> str:
+    """Human label for a non-tool event, derived from its ``kind``.
+
+    Tool events carry their own name; message / telemetry / lifecycle events do
+    not, so fall back to a readable label instead of the literal ``"event"``.
+    Unknown kinds use their last dotted segment, Title-cased (``foo.bar`` -> ``Bar``).
+    """
+    key = (kind or "").strip()
+    if not key:
+        return "Event"
+    if key in _KIND_LABELS:
+        return _KIND_LABELS[key]
+    if key.startswith("session"):
+        return "Session"
+    last = key.rsplit(".", 1)[-1]
+    return last.replace("_", " ").title() or "Event"
+
+
+def _snippet(text: str, limit: int = 140) -> str:
+    """One-line preview of free text: collapse whitespace/newlines and truncate."""
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[:limit].rstrip() + "\u2026"
+
+
 def _summarize(tool_name: str, payload: dict[str, Any]) -> str:
     for key in ("command", "url", "path", "file", "query"):
         val = payload.get(key)
         if isinstance(val, str) and val:
             return val
+    for key in ("content", "text", "message"):
+        val = payload.get(key)
+        if isinstance(val, str) and val.strip():
+            return _snippet(val)
     return tool_name
 
 

--- a/tests/unit/test_dashboard_mappers.py
+++ b/tests/unit/test_dashboard_mappers.py
@@ -8,10 +8,13 @@ sink lives in ``tests/e2e/test_dashboard_repository.py``.
 
 from __future__ import annotations
 
+import json
+
 from traceforge.dashboard.repository import (
     DEFAULT_OUTPUT_DB,
     DEFAULT_SYSTEM_DB,
     _format_ttl,
+    _label_from_kind,
     _map_evidence,
     _map_event,
     _map_segments,
@@ -19,6 +22,7 @@ from traceforge.dashboard.repository import (
     _mcp_message,
     _risk_from_level,
     _segment_risk,
+    _summarize,
     resolve_paths,
 )
 
@@ -110,6 +114,103 @@ def test_map_event_bare_row_has_no_evidence() -> None:
     assert ev["ev"] is None
     assert ev["risk"] == 0
     assert ev["reco"]["action"] == "allow"
+
+
+def _message_row(kind: str, **payload: object) -> dict[str, object]:
+    """A non-tool event row (message/telemetry/lifecycle): no tool identity."""
+    return _event_row(
+        kind=kind,
+        tool_name="",
+        tool_display="",
+        risk_level="safe",
+        risk_score=1,
+        action="allow",
+        payload_json=json.dumps(payload),
+    )
+
+
+def test_map_event_message_uses_kind_label_and_content_summary() -> None:
+    user = _map_event(_message_row("message.user", content="Reply with exactly: PONG"), {})
+    assert user["tool"]["n"] == "User"
+    assert user["tool"]["n"] != "event"
+    assert user["summary"] == "Reply with exactly: PONG"
+    assert user["summary"] != "event"
+
+    asst = _map_event(
+        _message_row("message.assistant", content="Not logged in \u00b7 Please run /login"),
+        {},
+    )
+    assert asst["tool"]["n"] == "Assistant"
+    assert asst["summary"] == "Not logged in \u00b7 Please run /login"
+
+
+def test_map_event_message_summary_accepts_text_and_message_keys() -> None:
+    assert _map_event(_message_row("message.system", text="be concise"), {})["summary"] == (
+        "be concise"
+    )
+    assert _map_event(_message_row("message.user", message="hi there"), {})["summary"] == (
+        "hi there"
+    )
+
+
+def test_map_event_unknown_kind_falls_back_to_titlecased_last_segment() -> None:
+    ev = _map_event(_message_row("foo.bar"), {})
+    assert ev["tool"]["n"] == "Bar"  # last dotted segment, Title-cased
+    assert ev["tool"]["n"] != "event"
+
+    deep = _map_event(_message_row("lifecycle.tool_result"), {})
+    assert deep["tool"]["n"] == "Tool Result"
+
+
+def test_map_event_lifecycle_and_usage_kind_labels() -> None:
+    assert _map_event(_message_row("session.started"), {})["tool"]["n"] == "Session"
+    assert _map_event(_message_row("session.ended"), {})["tool"]["n"] == "Session"
+    assert _map_event(_message_row("telemetry.usage"), {})["tool"]["n"] == "Usage"
+
+
+def test_map_event_tool_row_label_and_summary_unchanged() -> None:
+    # A real tool call keeps its tool_name and tool_display-derived summary; the
+    # kind-label / content-snippet fallbacks must not touch this path.
+    ev = _map_event(_event_row(), _governed_meta())
+    assert ev["tool"]["n"] == "rm"
+    assert ev["summary"] == "rm -rf /tmp/x"
+
+    # tool_display empty -> summary comes from the command payload, not content.
+    cmd = _map_event(
+        _event_row(
+            tool_display="",
+            payload_json=json.dumps({"command": "ls -la", "content": "ignored"}),
+        ),
+        {},
+    )
+    assert cmd["tool"]["n"] == "rm"
+    assert cmd["summary"] == "ls -la"
+
+
+def test_label_from_kind_variants() -> None:
+    assert _label_from_kind("message.user") == "User"
+    assert _label_from_kind("message.assistant") == "Assistant"
+    assert _label_from_kind("message.system") == "System"
+    assert _label_from_kind("telemetry.usage") == "Usage"
+    assert _label_from_kind("session.started") == "Session"
+    assert _label_from_kind("foo.bar") == "Bar"
+    assert _label_from_kind("") == "Event"
+    assert _label_from_kind(None) == "Event"
+
+
+def test_summarize_prefers_tool_payload_then_content_then_label() -> None:
+    assert _summarize("Shell", {"command": "ls -la", "content": "ignored"}) == "ls -la"
+    assert _summarize("User", {"content": "hello world"}) == "hello world"
+    assert _summarize("Bar", {}) == "Bar"  # no signal -> falls through to the label
+
+
+def test_summarize_collapses_whitespace_and_truncates_content() -> None:
+    long = "line one\n\nline two   with   spaces " + "x" * 200
+    out = _summarize("User", {"content": long})
+    assert "\n" not in out
+    assert "   " not in out  # runs of whitespace collapsed to single spaces
+    assert len(out) <= 141  # ~140 chars plus a one-char ellipsis
+    assert out.endswith("\u2026")
 
 
 def test_map_evidence_pairs_mitre_and_defaults_pii_ifc() -> None:


### PR DESCRIPTION
## Summary

Two render-fidelity bugs found by running the shipped dashboard against real ingested Claude sessions.

### Bug 1 (backend) — non-tool events rendered as "event / event"
In the Timeline and Chapters lists, every non-tool event (user/assistant messages, telemetry, lifecycle) showed primary label `event` and subtitle `event`, because `_map_event` fell back to the literal `"event"` when there was no tool identity and `_summarize` only inspected command/url/path/file/query payload keys.

`src/traceforge/dashboard/repository.py`:
- New `_label_from_kind()` derives a human label from the event `kind`: `message.user`→`User`, `message.assistant`→`Assistant`, `message.system`→`System`, `telemetry.usage`→`Usage`, anything starting `session`→`Session`; unknown kinds use the Title-cased last dotted segment (`foo.bar`→`Bar`). Never emits the literal `event`. Wired into the `tool_name` fallback chain.
- `_summarize()` now falls back to a one-line, whitespace-collapsed, ~140-char truncated snippet of payload `content`/`text`/`message` (existing tool behavior takes precedence).
- Both Timeline and Chapters render `e.tool.n` + `e.summary`, so this one change fixes both. Rows now read e.g. `User | Reply with exactly: PONG`, `Assistant | Not logged in · Please run /login`.

### Bug 2 (frontend) — payload objects rendered as "[object Object]"
In the Inspector Payload panel, object-valued fields (e.g. `arguments`, `_enrichment`) rendered via `String(v)` as `[object Object]`.

`dashboard/src/views/RunView.tsx` + `dashboard/src/lib/format.ts`:
- New `fmtVal()` helper pretty-prints objects/arrays with `JSON.stringify(v, null, 2)`; primitives unchanged; `null`/`undefined` → empty string.
- The value span uses `whitespace-pre-wrap` (keeps `break-all`) so multi-line JSON is readable. No other keys dropped, no other styling changes.

## Tests / verification
- Extended `tests/unit/test_dashboard_mappers.py` with cases proving: message rows map to a kind-derived label (not `event`) + content-derived summary; unknown kinds fall back to the Title-cased last segment; session/usage labels; tool rows unchanged; `_summarize` ordering (tool payload → content → label); whitespace-collapse + truncation.
- Full backend suite: `uv run --no-progress python -m pytest -q -p no:cacheprovider` → **3501 passed, 8 skipped**.
- Lint pinned to ruff 0.15.20: `ruff check` and `ruff format --check` both clean.
- Frontend: `pnpm install` + `pnpm build` (`tsc -b && vite build`) clean; oxlint reports only pre-existing warnings in untouched files.

## Out of scope
Empty Chapters (segment_titles) is a separate in-flight fix. This PR does not touch `watch.py`, the titler, mappings, or segment logic.

Closes #157

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>