### PR TITLE
feat(ingest): wire GitHub Copilot CLI session ingestion into auto-detection (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `copilot` (GitHub Copilot CLI) recognized by ingest auto-detection, reading the
+  per-session `~/.copilot/session-state/<uuid>/events.jsonl` streams (override the
+  root with `COPILOT_SESSION_STATE_DIR`).
+
 ## [0.1.1] - 2026-07-09
 
 ### Added

--- a/src/traceforge/cli/runner.py
+++ b/src/traceforge/cli/runner.py
@@ -38,6 +38,7 @@ def load_mapping_path(name: str) -> Path:
 
 ADAPTER_MAP: dict[str, MappedJsonAdapterConfig] = {
     "claude": MappedJsonAdapterConfig(type="mapped_json", mapping="claude"),
+    "copilot": MappedJsonAdapterConfig(type="mapped_json", mapping="copilot"),
     "codex": MappedJsonAdapterConfig(type="mapped_json", mapping="codex"),
     "continue": MappedJsonAdapterConfig(type="mapped_json", mapping="continue_dev"),
     "cline": MappedJsonAdapterConfig(type="mapped_json", mapping="cline"),

--- a/src/traceforge/cli/watch.py
+++ b/src/traceforge/cli/watch.py
@@ -244,9 +244,9 @@ async def _watch_pipeline(
     """Watch a single pipeline's source and feed events through the unified pipeline.
 
     The shared event pipeline is built once, but a *fresh* adapter is created
-    lazily per source file — keyed to that file's session id (the filename stem)
-    — so each file becomes its own run and no session's stateful adapter bleeds
-    into another.
+    lazily per source file — keyed to that file's session id (see
+    :func:`_session_id_for_source`) — so each file becomes its own run and no
+    session's stateful adapter bleeds into another.
     """
     from traceforge.adapters.mapped_json import MappedJsonAdapter
 
@@ -267,13 +267,17 @@ async def _watch_pipeline(
             async for file_path, line in watch_directory(pipeline.source_path, pattern=pattern):
                 adapter = adapters.get(file_path)
                 if adapter is None:
-                    adapter = _build_adapter(pipeline, _session_id_for_source(file_path))
+                    adapter = _build_adapter(
+                        pipeline, _session_id_for_source(file_path, pipeline.name)
+                    )
                     adapters[file_path] = adapter
                     seen_by_file[file_path] = set()
                 await _feed_line(line, adapter, event_pipeline, seen_by_file[file_path])
         else:
             # Watch single file; one adapter keyed to that file's session id.
-            adapter = _build_adapter(pipeline, _session_id_for_source(pipeline.source_path))
+            adapter = _build_adapter(
+                pipeline, _session_id_for_source(pipeline.source_path, pipeline.name)
+            )
             seen: set[str] = set()
             async for line in watch_jsonl_file(pipeline.source_path, start_at="end"):
                 await _feed_line(line, adapter, event_pipeline, seen)
@@ -288,8 +292,9 @@ async def _process_pipeline_once(
     """Process existing content in a pipeline's source once (no watching).
 
     The shared event pipeline is built once, but a *fresh* adapter is built per
-    source file keyed to that file's session id (the filename stem), so each file
-    becomes its own run instead of collapsing into a single ``pipeline.name`` run.
+    source file keyed to that file's session id (see
+    :func:`_session_id_for_source`), so each file becomes its own run instead of
+    collapsing into a single ``pipeline.name`` run.
     """
     logger.info("Processing %s at %s", pipeline.name, pipeline.source_path)
 
@@ -302,14 +307,16 @@ async def _process_pipeline_once(
             pattern = "*.jsonl" if pipeline.name != "continue" else "*.json"
             for f in pipeline.source_path.rglob(pattern):
                 if f.is_file():
-                    adapter = _build_adapter(pipeline, _session_id_for_source(f))
+                    adapter = _build_adapter(pipeline, _session_id_for_source(f, pipeline.name))
                     seen: set[str] = set()
                     for line in f.read_text(encoding="utf-8").splitlines():
                         stripped = line.strip()
                         if stripped:
                             await _feed_line(stripped, adapter, event_pipeline, seen)
         else:
-            adapter = _build_adapter(pipeline, _session_id_for_source(pipeline.source_path))
+            adapter = _build_adapter(
+                pipeline, _session_id_for_source(pipeline.source_path, pipeline.name)
+            )
             seen = set()
             for line in pipeline.source_path.read_text(encoding="utf-8").splitlines():
                 stripped = line.strip()
@@ -379,14 +386,21 @@ def _build_adapter(pipeline: ResolvedPipeline, session_id: str):
     return MappedJsonAdapter.from_yaml(str(mapping_path), session_id=session_id)
 
 
-def _session_id_for_source(path: Path) -> str:
+def _session_id_for_source(path: Path, framework: str | None = None) -> str:
     """Return the session id for a single source file.
 
     File-per-session frameworks (claude/codex/cline/opencode) name each file
     after the session it contains — the filename stem is the real session UUID
     (it equals the ``sessionId`` recorded inside the file). So the stem is the
     correct per-file session id.
+
+    GitHub Copilot CLI is *dir*-per-session instead: every session's stream is
+    literally ``<session-uuid>/events.jsonl``, so the stem is always ``"events"``
+    and would collapse every session into one run. For ``copilot`` the session id
+    is the **parent directory** name (the session UUID) rather than the stem.
     """
+    if framework == "copilot":
+        return path.parent.name
     return path.stem
 
 

--- a/src/traceforge/sources/auto_detect.py
+++ b/src/traceforge/sources/auto_detect.py
@@ -81,6 +81,7 @@ def detect_frameworks(frameworks: list[str] | None = None) -> list[DetectedFrame
     """
     all_detectors = {
         "claude": _detect_claude,
+        "copilot": _detect_copilot,
         "codex": _detect_codex,
         "continue": _detect_continue,
         "cline": _detect_cline,
@@ -116,6 +117,21 @@ def _detect_claude() -> DetectedFramework | None:
     path = _expand("~/.claude/projects")
     if path.is_dir():
         return DetectedFramework("claude", path, "claude", "file_watch")
+    return None
+
+
+def _detect_copilot() -> DetectedFramework | None:
+    # GitHub Copilot CLI is dir-per-session: each session is a directory
+    # ``<session-uuid>/`` whose event stream is always literally ``events.jsonl``,
+    # under ``~/.copilot/session-state``. Pointing the file-watch source at that
+    # root lets the directory rglob pick up every ``<uuid>/events.jsonl``
+    # automatically. The copilot mapping already ships; this only wires the
+    # existing ingestion support into auto-detection. Override the root with
+    # ``COPILOT_SESSION_STATE_DIR`` (points directly at the session-state dir).
+    custom = os.environ.get("COPILOT_SESSION_STATE_DIR")
+    path = Path(custom) if custom else _expand("~/.copilot/session-state")
+    if path.is_dir():
+        return DetectedFramework("copilot", path, "copilot", "file_watch")
     return None
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -65,7 +65,12 @@ def tmp_traceforge_home(
     # and drop source-specific overrides so detection is deterministic.
     monkeypatch.setenv("APPDATA", str(home / "AppData" / "Roaming"))
     monkeypatch.setenv("LOCALAPPDATA", str(home / "AppData" / "Local"))
-    for var in ("CODEX_HOME", "CONTINUE_GLOBAL_DIR", "TRACEFORGE_CONFIG"):
+    for var in (
+        "CODEX_HOME",
+        "CONTINUE_GLOBAL_DIR",
+        "COPILOT_SESSION_STATE_DIR",
+        "TRACEFORGE_CONFIG",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     (home / ".traceforge").mkdir(parents=True, exist_ok=True)

--- a/tests/e2e/test_auto_detect_e2e.py
+++ b/tests/e2e/test_auto_detect_e2e.py
@@ -50,6 +50,9 @@ def _framework_layout(home: Path) -> dict[str, tuple[Path, bool, str, str]]:
 
     return {
         "claude": (home / ".claude" / "projects", False, "claude", "file_watch"),
+        # Copilot CLI is dir-per-session under ~/.copilot/session-state; the
+        # detector points the file-watch source at that root (a directory).
+        "copilot": (home / ".copilot" / "session-state", False, "copilot", "file_watch"),
         "codex": (home / ".codex" / "sessions", False, "codex", "file_watch"),
         "continue": (home / ".continue" / "sessions", False, "continue", "file_watch"),
         "cline": (
@@ -133,6 +136,34 @@ def test_continue_global_dir_env_var_is_honored(
     detected = detect_frameworks(["continue"])
     assert len(detected) == 1
     assert _same_path(detected[0].path, custom / "sessions")
+
+
+def test_copilot_session_state_dir_env_var_is_honored(
+    tmp_traceforge_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Unlike CODEX_HOME/CONTINUE_GLOBAL_DIR (which point at a parent and get
+    # "/sessions" appended), COPILOT_SESSION_STATE_DIR points directly at the
+    # session-state root the detector watches.
+    custom = tmp_traceforge_home / "xdg-copilot" / "session-state"
+    custom.mkdir(parents=True)
+    monkeypatch.setenv("COPILOT_SESSION_STATE_DIR", str(custom))
+
+    detected = detect_frameworks(["copilot"])
+    assert len(detected) == 1
+    found = detected[0]
+    assert found.name == "copilot"
+    assert found.adapter == "copilot"
+    assert found.ingestion_mode == "file_watch"
+    assert _same_path(found.path, custom)
+
+
+def test_copilot_missing_session_state_dir_is_clean_no_match(
+    tmp_traceforge_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No ~/.copilot/session-state on disk and no override → the detector returns
+    # no match rather than fabricating a detection for an absent store.
+    monkeypatch.delenv("COPILOT_SESSION_STATE_DIR", raising=False)
+    assert detect_frameworks(["copilot"]) == []
 
 
 def test_framework_filter_limits_detection(tmp_traceforge_home: Path) -> None:

--- a/tests/e2e/test_copilot_watch_e2e.py
+++ b/tests/e2e/test_copilot_watch_e2e.py
@@ -1,0 +1,188 @@
+"""End-to-end test that GitHub Copilot CLI sessions are ingested by ``watch``.
+
+The Copilot mapping and the file-watch source already exist; the gap this closes is
+that ingestion was never wired into auto-detection, plus a session-id bug. Copilot CLI
+is *dir-per-session*: every session is a directory ``<uuid>/`` whose stream is literally
+``events.jsonl`` under ``~/.copilot/session-state``. These tests drive the real wiring —
+
+    detect_frameworks(["copilot"])  ->  resolve_pipelines(...)  ->  watch._run_once(...)
+
+— into an **isolated** temp :class:`SqliteOutputSink` (never the live ``~/.traceforge/*``)
+and prove:
+
+* auto-detection recognizes copilot at the configured session-state root;
+* resolution maps it to a runnable pipeline (it would be silently dropped if
+  ``ADAPTER_MAP`` had no ``copilot`` entry);
+* the two session directories become **two distinct runs** keyed to their UUIDs —
+  NOT the shared ``"events"`` filename stem — and events carry the expected canonical
+  kinds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from traceforge.cli.runner import load_mapping_path, resolve_pipelines
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+from traceforge.sources.auto_detect import detect_frameworks
+
+pytestmark = pytest.mark.e2e
+
+# ``traceforge.cli`` re-exports the ``watch`` Command, shadowing the submodule, so
+# fetch the real module object to reach ``_run_once`` / monkeypatch ``_build_sinks``.
+watch_mod = importlib.import_module("traceforge.cli.watch")
+
+_UUID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_UUID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+
+def _copilot_lines(tag: str) -> list[str]:
+    """A few real-shaped Copilot CLI ``events.jsonl`` lines: a session start, a
+    user/assistant exchange, and one paired tool call."""
+    return [
+        json.dumps(
+            {
+                "type": "session.start",
+                "id": f"evt-start-{tag}",
+                "timestamp": "2024-06-01T10:00:00Z",
+                "data": {
+                    "sessionId": f"inner-{tag}",
+                    "selectedModel": "gpt-5",
+                    "copilotVersion": "1.2.3",
+                    "context": {"cwd": "/home/user/project"},
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "user.message",
+                "id": f"evt-user-{tag}",
+                "timestamp": "2024-06-01T10:00:01Z",
+                "data": {"content": f"do the thing for {tag}"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant.message",
+                "id": f"evt-asst-{tag}",
+                "timestamp": "2024-06-01T10:00:02Z",
+                "data": {"content": f"on it, {tag}"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "tool.execution_start",
+                "id": f"evt-tstart-{tag}",
+                "timestamp": "2024-06-01T10:00:03Z",
+                "data": {
+                    "toolCallId": f"tc-{tag}",
+                    "toolName": "create",
+                    "arguments": {"path": "hello.py"},
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "id": f"evt-tdone-{tag}",
+                "timestamp": "2024-06-01T10:00:04Z",
+                "data": {
+                    "toolCallId": f"tc-{tag}",
+                    "success": True,
+                    "result": {"content": "File created: hello.py"},
+                },
+            }
+        ),
+    ]
+
+
+def _seed_copilot_state(root: Path, sessions: list[tuple[str, str]]) -> None:
+    """Write ``<root>/<uuid>/events.jsonl`` for each (uuid, tag) session."""
+    for uuid, tag in sessions:
+        session_dir = root / uuid
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "events.jsonl").write_text(
+            "\n".join(_copilot_lines(tag)) + "\n", encoding="utf-8"
+        )
+
+
+def _query_col(db_path: Path, sql: str) -> set[str]:
+    """Reopen the temp DB read-only and return the first column as a set."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return {row[0] for row in conn.execute(sql).fetchall()}
+    finally:
+        conn.close()
+
+
+def _same_path(a: Path, b: Path) -> bool:
+    return os.path.normcase(str(a)) == os.path.normcase(str(b))
+
+
+def test_copilot_autodetect_once_splits_runs_into_isolated_db(tmp_path, monkeypatch) -> None:
+    state = tmp_path / "session-state"
+    _seed_copilot_state(state, [(_UUID_A, "A"), (_UUID_B, "B")])
+    monkeypatch.setenv("COPILOT_SESSION_STATE_DIR", str(state))
+
+    # (1) Auto-detection recognizes copilot at the configured session-state root.
+    detected = detect_frameworks(["copilot"])
+    assert [d.name for d in detected] == ["copilot"]
+    fw = detected[0]
+    assert fw.adapter == "copilot"
+    assert fw.ingestion_mode == "file_watch"
+    assert _same_path(fw.path, state)
+
+    # (2) Resolution maps the detected framework to a runnable pipeline. This is the
+    # step that would silently drop copilot if ADAPTER_MAP had no copilot entry.
+    pipelines = resolve_pipelines(detected, default_sinks=[])
+    assert len(pipelines) == 1
+    assert pipelines[0].name == "copilot"
+
+    # (3) Run the --once ingest into an ISOLATED temp SqliteOutputSink.
+    db_path = tmp_path / "out.db"
+    sink = SqliteOutputSink(path=str(db_path))
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [sink])
+    asyncio.run(watch_mod._run_once(pipelines, None, None))
+
+    # Exactly two distinct runs, keyed to the session-dir UUIDs. The critical
+    # assertion: the shared ``events.jsonl`` stem must NOT collapse the sessions
+    # into a single run named "events".
+    runs = _query_col(db_path, "SELECT DISTINCT session_id FROM enriched_events")
+    assert runs == {_UUID_A, _UUID_B}
+    assert "events" not in runs
+    assert "copilot" not in runs
+
+    # Events mapped to the expected canonical kinds. The enricher pairs
+    # tool.call.started into its matching tool.call.completed, so only completed
+    # rides the persisted timeline (started is covered directly below).
+    kinds = _query_col(db_path, "SELECT DISTINCT kind FROM enriched_events")
+    assert {"message.user", "message.assistant", "tool.call.completed"} <= kinds
+    assert "session.started" in kinds
+
+
+def test_copilot_mapping_emits_tool_lifecycle_started_and_completed() -> None:
+    """The copilot mapping emits BOTH ``tool.call.started`` and ``tool.call.completed``.
+
+    The pipeline's enricher merges the paired start into the completed event (so only
+    completed persists to the timeline); this guards the raw mapping at the adapter
+    boundary so the started kind can't silently regress.
+    """
+    from traceforge.adapters.mapped_json import MappedJsonAdapter
+
+    adapter = MappedJsonAdapter.from_yaml(str(load_mapping_path("copilot")), session_id="s")
+
+    kinds = [
+        event.kind for line in _copilot_lines("A") for event in adapter.parse_dict(json.loads(line))
+    ]
+
+    assert "tool.call.started" in kinds
+    assert "tool.call.completed" in kinds
+    assert "message.user" in kinds
+    assert "message.assistant" in kinds

--- a/tests/unit/test_watch_session_split.py
+++ b/tests/unit/test_watch_session_split.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from tests.conftest import RecordingSink
 
 from traceforge.cli.runner import ADAPTER_MAP, ResolvedPipeline
-from traceforge.cli.watch import _process_pipeline_once
+from traceforge.cli.watch import _process_pipeline_once, _session_id_for_source
 
 # ``traceforge.cli`` re-exports the ``watch`` Command, which shadows the submodule
 # attribute, so ``import traceforge.cli.watch as x`` would bind the Command, not the
@@ -106,3 +106,95 @@ def test_once_single_file_uses_file_stem(tmp_path, monkeypatch) -> None:
     assert recording.events, "no events were emitted through the --once path"
     assert session_ids == {_SESSION_A}
     assert pipeline.name not in session_ids
+
+
+# ─── Copilot CLI: dir-per-session (<uuid>/events.jsonl) ──────────────────────
+#
+# GitHub Copilot CLI does NOT name each file after its session. Every session is a
+# directory ``<uuid>/`` whose stream is literally ``events.jsonl``, so the filename
+# stem is always ``"events"``. Keying runs on the stem would collapse EVERY copilot
+# session into one run named ``"events"``. The correct session id is the parent
+# directory name. These tests pin that contract.
+
+
+def _copilot_lines(tag: str) -> list[str]:
+    """A few minimal, real-shaped GitHub Copilot CLI ``events.jsonl`` lines."""
+    return [
+        json.dumps(
+            {
+                "type": "session.start",
+                "id": f"evt-start-{tag}",
+                "timestamp": "2024-06-01T10:00:00Z",
+                "data": {"selectedModel": "gpt-5", "context": {"cwd": "/proj"}},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "user.message",
+                "id": f"evt-user-{tag}",
+                "timestamp": "2024-06-01T10:00:01Z",
+                "data": {"content": f"hello from {tag}"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant.message",
+                "id": f"evt-asst-{tag}",
+                "timestamp": "2024-06-01T10:00:02Z",
+                "data": {"content": f"done {tag}"},
+            }
+        ),
+    ]
+
+
+def _write_copilot_session(state_dir: Path, session_id: str, tag: str) -> None:
+    """Copilot is dir-per-session: ``<state_dir>/<uuid>/events.jsonl``."""
+    session_dir = state_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "events.jsonl").write_text(
+        "\n".join(_copilot_lines(tag)) + "\n", encoding="utf-8"
+    )
+
+
+def test_session_id_for_source_copilot_uses_parent_dir() -> None:
+    """For copilot, the session id is the parent directory (the session UUID)."""
+    path = Path("/home/u/.copilot/session-state") / _SESSION_A / "events.jsonl"
+    assert _session_id_for_source(path, "copilot") == _SESSION_A
+
+
+def test_session_id_for_source_non_copilot_uses_stem() -> None:
+    """File-per-session frameworks (and the default) key on the filename stem."""
+    path = Path("/home/u/.claude/projects") / f"{_SESSION_A}.jsonl"
+    assert _session_id_for_source(path, "claude") == _SESSION_A
+    # No framework given → stem (backward-compatible default).
+    assert _session_id_for_source(path) == _SESSION_A
+
+
+def test_once_copilot_dir_splits_runs_by_parent_dir(tmp_path, monkeypatch) -> None:
+    """--once over a copilot session-state dir yields one run per session directory
+    (the dir UUID), never the ``"events"`` stem or the framework name."""
+    state = tmp_path / "session-state"
+    _write_copilot_session(state, _SESSION_A, "A")
+    _write_copilot_session(state, _SESSION_B, "B")
+
+    pipeline = ResolvedPipeline(
+        name="copilot",
+        source_path=state,
+        ingestion_mode="file_watch",
+        adapter=ADAPTER_MAP["copilot"],
+        sinks=[],  # real sinks are swapped for a recording sink below
+    )
+
+    recording = RecordingSink()
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [recording.sink])
+
+    asyncio.run(_process_pipeline_once(pipeline, governance=None))
+
+    session_ids = {e.session_id for e in recording.events}
+
+    assert recording.events, "no events were emitted through the --once path"
+    # The critical regression: the shared ``events.jsonl`` stem must NEVER be the id.
+    assert "events" not in session_ids
+    assert pipeline.name not in session_ids
+    # Exactly one session id per session directory, each equal to that dir's UUID.
+    assert session_ids == {_SESSION_A, _SESSION_B}


### PR DESCRIPTION
Closes #161

## What

The GitHub Copilot CLI mapping (`copilot.yaml`) and the generic file-watch source already
existed and worked — the only gap was that Copilot ingestion was never reachable from
`traceforge watch`, plus a session-id collapse bug. This PR is a tight, single-concern
wiring change.

Copilot writes one JSONL stream per session at
`~/.copilot/session-state/<session-uuid>/events.jsonl` (dir-per-session; the file is
always literally `events.jsonl`). The directory rglob in `_process_pipeline_once` /
`watch_directory` already discovers every `<uuid>/events.jsonl` once a detector points at
the root.

## Changes

- **`sources/auto_detect.py`** — add `_detect_copilot()` and register `"copilot"`.
  Defaults to `~/.copilot/session-state`, overridable via `COPILOT_SESSION_STATE_DIR`,
  returns `None` when the directory is absent. Follows the existing `CODEX_HOME` /
  `CONTINUE_GLOBAL_DIR` pattern.
- **`cli/runner.py`** — add a `copilot` entry to `ADAPTER_MAP`. Without it,
  `resolve_pipelines` drops the detected framework, so auto-detection would be dead on
  arrival. (Small, on-topic, and required for the wiring to actually run.)
- **`cli/watch.py`** — make `_session_id_for_source(path, framework=None)`
  framework-aware. For `copilot` (dir-per-session) the id is the **parent directory** name
  (the session UUID) instead of `path.stem`, which is always `"events"` and would collapse
  every session into one run. All callers now thread `pipeline.name`; docstrings updated.
- **`CHANGELOG.md`** — one-line `[Unreleased] > Added` note.

## Tests

- Unit (`tests/unit/test_watch_session_split.py`): `_session_id_for_source` returns the
  parent-dir UUID for a copilot `.../<uuid>/events.jsonl` path and still returns the stem
  for a claude-style `.../<uuid>.jsonl` path; plus a `_process_pipeline_once` test proving
  two copilot session dirs split into two runs keyed by UUID (not `"events"`).
- E2E (`tests/e2e/test_auto_detect_e2e.py`): detector honors `COPILOT_SESSION_STATE_DIR`
  and stays clean when the directory is missing.
- E2E (`tests/e2e/test_copilot_watch_e2e.py`, new): seed
  `session-state/<uuidA>/events.jsonl` and `<uuidB>/events.jsonl` with real-shaped copilot
  lines, run the detect→resolve→once path into an **isolated temp** `SqliteOutputSink`, and
  assert exactly two distinct runs with ids `== {uuidA, uuidB}` and the expected canonical
  kinds (`message.user`, `message.assistant`, `tool.call.completed`, `session.started`). A
  companion direct-adapter test proves the mapping emits `tool.call.started` and
  `tool.call.completed` (the enricher merges the paired `started` into `completed` before
  persistence, so the DB timeline shows `completed`).

## Verification

- `uv run --no-progress python -m pytest -q -p no:cacheprovider` → **3528 passed, 8 skipped**.
- `uv run --with ruff==0.15.20 ruff check` and `ruff format --check` → clean.

## Out of scope (separate follow-up)

- Token/usage fidelity (`outputTokens` lives on `assistant.message`, not a dedicated
  `assistant.usage` event, so the Cost lens stays empty for Copilot for now).
- Tool argument/result parsing (`tool.execution_*` `arguments`/`result` are Python-repr
  strings).
- Anything under `dashboard/`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>