### PR TITLE
watch: populate Copilot run model, repo, and per-session usage from shutdown metrics (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-session `~/.copilot/session-state/<uuid>/events.jsonl` streams (override the
   root with `COPILOT_SESSION_STATE_DIR`).
 
+### Fixed
+
+- GitHub Copilot CLI runs no longer render blank `model` / `repo` and an empty Cost
+  lens. A new `copilot` preprocessor synthesizes per-model `assistant.usage` records
+  from the authoritative `session.shutdown.data.modelMetrics` (Copilot emits no
+  per-turn usage event), and the mapping surfaces `session.start`'s
+  `data.context.cwd` as `EventMetadata.repo` via `repo_field`. Input tokens aggregate
+  uncached + cache-read + cache-write with the split preserved in
+  `usage_records.attributes`; `cost_usd` stays `None` (Copilot's `requests.cost` is a
+  premium-request count, not dollars — never synthesized). Ingestion-side only; usage
+  rides `usage_records` (Cost lens), never the enriched-events timeline.
+
 ## [0.1.1] - 2026-07-09
 
 ### Added

--- a/docs/dashboard-spec.md
+++ b/docs/dashboard-spec.md
@@ -211,6 +211,32 @@ degraded modes + the data-source indicator.
 > shows real tokens with honest null/`$0.00` dollars). A `<synthetic>`/absent model
 > normalizes to `""` so it never wins `_dominant_model`, while its real tokens still count.
 
+> **Usage token semantics (Copilot CLI shutdown-metrics path).** GitHub Copilot CLI
+> emits **no** per-turn usage event, so the authoritative whole-session token accounting
+> lives on the terminal `session.shutdown` event as `data.modelMetrics` — a per-model
+> map `{<model>: {requests: {count, cost}, usage: {inputTokens, outputTokens,
+> cacheReadTokens, cacheWriteTokens, reasoningTokens}}}` (`modelMetrics` may be a JSON
+> string or an object; both are decoded). The `copilot` preprocessor synthesizes one
+> `assistant.usage` block **per model** from it (stable dedup id `<shutdown-id>:<model>`),
+> leaving every other event untouched so the enriched timeline is unchanged. Copilot's
+> `usage.inputTokens` is a **grand total** that already includes the cache tokens —
+> verified against `tokenDetails` on real `~/.copilot` streams and the pinned
+> `claude-opus-4.8` golden fixture, where `inputTokens == uncached_input + cacheRead +
+> cacheWrite` (e.g. `407996 = 211 + 394185 + 13600`). The watch bridge, however, treats
+> its `input_tokens` field as the *uncached* delta and rebuilds the headline as
+> `uncached + cacheRead + cacheWrite` (the Claude-path convention). So the preprocessor
+> emits the **uncached** input (grand total minus the cache components, clamped at zero),
+> which makes the headline land back on **exactly Copilot's reported `inputTokens`**, with
+> the lossless split kept in `usage_records.attributes` as
+> `{input_uncached, cache_read_tokens, cache_creation_tokens}`.
+> `reasoningTokens` is not surfaced separately (Copilot reports it as `0`; the provider
+> folds reasoning into output accounting). `cost_usd` is **`None`**: Copilot's
+> `requests.cost` is a **premium-request count**, not a dollar amount, so none is
+> derivable and none is synthesized (`build_run` degrades cost to `0.0` via `COALESCE`).
+> `run.repo` comes from `session.start`'s `data.context.cwd` (surfaced as
+> `EventMetadata.repo` via the mapping's `repo_field`); `run.model` is the deduped
+> `usage_records` dominant model (e.g. `claude-sonnet-4.5`, `gpt-5`).
+
 ### `TEvent` (timeline + inspector)
 | mock field | real source |
 |---|---|

--- a/src/traceforge/mappings/copilot.yaml
+++ b/src/traceforge/mappings/copilot.yaml
@@ -16,6 +16,13 @@ ingestion_mode: file_watch
 type_field: type
 timestamp_field: timestamp
 default_kind: raw
+preprocessor: copilot
+# GitHub Copilot CLI stamps the working directory on ``session.start`` as
+# ``data.context.cwd``. Surfacing it as ``EventMetadata.repo`` lets the dashboard
+# resolve a run's repo (``_first_meta`` reads the first non-empty repo, and
+# ``session.started`` — which carries this — leads the timeline). Populated only
+# when present; never synthesized.
+repo_field: data.context.cwd
 
 motivation:
   sources:
@@ -181,6 +188,18 @@ events:
       tool_call_id: data.toolCallId
 
   # ── Usage ──────────────────────────────────────────────────────────────────
+  # GitHub Copilot CLI emits no per-turn usage event; the ``copilot`` preprocessor
+  # synthesizes one ``assistant.usage`` block per model from
+  # ``session.shutdown.data.modelMetrics`` (the authoritative whole-session token
+  # accounting). Copilot's ``usage.inputTokens`` is a grand total that already
+  # includes cache tokens, so the preprocessor emits ``inputTokens`` as the
+  # *uncached* delta (grand total minus cache read/write); the watch usage bridge
+  # then rebuilds the headline as ``uncached + cacheRead + cacheWrite`` — exactly
+  # Copilot's reported ``inputTokens`` — and keeps the split in
+  # ``UsageRecord.attributes``.
+  # ``msg_id`` (``<shutdown-id>:<model>``) dedups a replayed shutdown. No dollar
+  # cost exists in the wire, so ``cost_usd`` stays null. ``cost``/``duration`` remain
+  # mapped for back-compat with producers that carry them.
   assistant.usage:
     kind: telemetry.usage
     payload:
@@ -191,6 +210,7 @@ events:
       cache_write_tokens: data.cacheWriteTokens
       cost_usd: data.cost
       duration_ms: data.duration
+      msg_id: data.messageId
 
   # ── Hooks ──────────────────────────────────────────────────────────────────
   hook.start:

--- a/src/traceforge/preprocessors/__init__.py
+++ b/src/traceforge/preprocessors/__init__.py
@@ -25,6 +25,7 @@ import traceforge.preprocessors.amazonq  # noqa: F401
 import traceforge.preprocessors.maf_transcript  # noqa: F401
 import traceforge.preprocessors.opencode  # noqa: F401
 import traceforge.preprocessors.copilot_vscode  # noqa: F401
+import traceforge.preprocessors.copilot  # noqa: F401
 import traceforge.preprocessors.antigravity  # noqa: F401
 
 __all__ = [

--- a/src/traceforge/preprocessors/copilot.py
+++ b/src/traceforge/preprocessors/copilot.py
@@ -1,0 +1,137 @@
+"""Copilot (GitHub Copilot CLI) preprocessor — synthesize usage from shutdown metrics.
+
+GitHub Copilot CLI never emits a per-turn ``assistant.usage`` event, so the Cost
+lens (``usage_records``) would stay empty. The authoritative token accounting for a
+whole session lives on the terminal ``session.shutdown`` event as
+``data.modelMetrics`` — a per-model map of the complete input/output/cache token
+totals. This preprocessor decodes it and appends one synthetic ``assistant.usage``
+block per model so the existing YAML mapping can bridge each into ``usage_records``.
+
+Every original event is preserved verbatim (returned first), so the enriched-events
+timeline is unchanged. Only ``session.shutdown`` ever produces extra dicts.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from traceforge.preprocessors.registry import register_preprocessor
+
+
+@register_preprocessor("copilot")
+def preprocess_copilot(obj: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pass Copilot events through unchanged, plus synthesize usage from shutdown.
+
+    For every event other than ``session.shutdown`` this is the identity
+    transform (``[obj]``). For a ``session.shutdown`` carrying a non-empty
+    ``data.modelMetrics``, the original event is returned first (so ``session.ended``
+    still rides the timeline exactly once) followed by one synthetic
+    ``assistant.usage`` block per model. Each block mirrors Copilot's own
+    ``{type, id, timestamp, data}`` wire shape so it flows through the mapping with
+    no special-casing.
+    """
+    if obj.get("type") != "session.shutdown":
+        return [obj]
+
+    data = obj.get("data")
+    if not isinstance(data, dict):
+        return [obj]
+
+    metrics = _decode_model_metrics(data.get("modelMetrics"))
+    if not metrics:
+        return [obj]
+
+    shutdown_id = str(obj.get("id") or "")
+    timestamp = obj.get("timestamp")
+
+    usage_blocks: list[dict[str, Any]] = []
+    for model, entry in metrics.items():
+        if not model or not isinstance(entry, dict):
+            continue
+        usage = entry.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        usage_blocks.append(_usage_block(str(model), usage, shutdown_id, timestamp))
+
+    return [obj, *usage_blocks]
+
+
+def _decode_model_metrics(raw: Any) -> dict[str, Any]:
+    """Return ``modelMetrics`` as a dict, decoding a JSON string when needed.
+
+    Copilot serializes ``modelMetrics`` as a plain object in recorded streams but
+    a JSON *string* in some producers; both are accepted. Anything empty,
+    malformed, or of an unexpected type yields an empty mapping (no usage
+    synthesized) — usage is never fabricated.
+    """
+    if isinstance(raw, str):
+        raw = raw.strip()
+        if not raw:
+            return {}
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError):
+            return {}
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+def _usage_block(
+    model: str, usage: dict[str, Any], shutdown_id: str, timestamp: Any
+) -> dict[str, Any]:
+    """Build one synthetic ``assistant.usage`` event for a single model.
+
+    ``data.messageId`` is a stable ``<shutdown-id>:<model>`` key so the watch usage
+    bridge dedups it even if a shutdown is ever replayed. Token counts are coerced
+    to ints; a record whose tokens are entirely zero is dropped downstream by the
+    usage bridge, so no all-zero noise reaches ``usage_records``.
+
+    Copilot's ``usage.inputTokens`` is a **grand total** that already includes the
+    cache-read and cache-write tokens (verified against ``tokenDetails`` on newer
+    streams, where ``inputTokens == tokenDetails.input + cacheRead + cacheWrite``,
+    and against the pinned ``claude-opus-4.8`` golden fixture). The watch bridge,
+    however, treats the ``input_tokens`` field as the *uncached* delta and rebuilds
+    the headline total as ``uncached + cacheRead + cacheWrite`` (the Claude Code
+    convention). So we emit the **uncached** input here — ``inputTokens`` minus the
+    cache components (clamped at zero) — which makes the bridge's headline exactly
+    equal Copilot's own reported ``inputTokens`` and keeps the split faithful in
+    ``UsageRecord.attributes``. ``reasoningTokens`` is not surfaced separately
+    (Copilot reports it as ``0`` and the provider folds reasoning into output
+    accounting). No dollar cost exists in the wire (``requests.cost`` is a
+    premium-request count), so none is emitted and ``cost_usd`` stays null.
+    """
+    input_total = _as_int(usage.get("inputTokens"))
+    cache_read = _as_int(usage.get("cacheReadTokens"))
+    cache_write = _as_int(usage.get("cacheWriteTokens"))
+    input_uncached = input_total - cache_read - cache_write
+    if input_uncached < 0:
+        input_uncached = 0
+
+    msg_id = f"{shutdown_id}:{model}"
+    block: dict[str, Any] = {
+        "type": "assistant.usage",
+        "id": msg_id,
+        "data": {
+            "model": model,
+            "inputTokens": input_uncached,
+            "outputTokens": _as_int(usage.get("outputTokens")),
+            "cacheReadTokens": cache_read,
+            "cacheWriteTokens": cache_write,
+            "messageId": msg_id,
+        },
+    }
+    if timestamp is not None:
+        block["timestamp"] = timestamp
+    return block
+
+
+def _as_int(value: Any) -> int:
+    """Coerce a token count to ``int``, treating missing/malformed values as 0."""
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return 0

--- a/tests/e2e/test_copilot_identity_cost_enrichment.py
+++ b/tests/e2e/test_copilot_identity_cost_enrichment.py
@@ -1,0 +1,276 @@
+"""End-to-end Copilot identity + cost enrichment tests (the three blank run fields).
+
+Proves that ``run.model`` / ``run.repo`` / the Cost lens populate for **real-shaped
+GitHub Copilot CLI sessions**, where Copilot emits no per-turn usage event and the
+authoritative token accounting rides ``session.shutdown.data.modelMetrics`` (a
+per-model input/output/cache totals map — verified against real ``~/.copilot``
+streams). Copilot is *dir-per-session*: each session is ``<uuid>/events.jsonl``.
+
+Everything is verified against an **isolated** temp :class:`SqliteOutputSink` (seed
+dir-per-session state, ingest ``--once``, reopen read-only) — never the live
+``~/.traceforge/*.db`` and never the real ``~/.copilot`` files.
+
+Two seeded sessions:
+
+* ``UUID_A`` — model ``claude-sonnet-4.5``, cwd ``/home/user/project-a``, shutdown
+  usage input=36882 (a GRAND TOTAL that already includes the 7058 cache-read) output=354
+  → ONE usage record, headline input 36882 (= 29824 uncached + 7058 cache-read), output 354.
+* ``UUID_B`` — model ``gpt-5``, cwd ``/home/user/project-b``, shutdown usage
+  input=100 output=20 cacheRead=0 → ONE usage record, headline input 100, output 20.
+
+Deduped truth: 2 usage rows (one per session — the shared ``events.jsonl`` stem does
+not collapse them), cost NULL (Copilot's ``requests.cost`` is a premium-request
+count, not dollars — never synthesized), dominant model per run from its own tokens,
+repo from ``session.start``'s ``context.cwd``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from traceforge.cli.runner import ADAPTER_MAP, ResolvedPipeline
+from traceforge.dashboard.repository import DashboardRepository, resolve_paths
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+
+pytestmark = pytest.mark.e2e
+
+watch_mod = importlib.import_module("traceforge.cli.watch")
+
+_UUID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_UUID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+
+
+def _session_lines(*, tag: str, model: str, cwd: str, usage: dict) -> list[str]:
+    """Real-shaped Copilot ``events.jsonl`` lines: start, exchange, tool, shutdown.
+
+    ``session.shutdown`` carries ``modelMetrics`` (the whole-session token accounting)
+    — the only place Copilot records usage. ``requests.cost`` is a premium-request
+    *count*, not a dollar amount, so no cost is derivable.
+    """
+    return [
+        json.dumps(
+            {
+                "type": "session.start",
+                "id": f"evt-start-{tag}",
+                "timestamp": "2024-06-01T10:00:00Z",
+                "data": {
+                    "sessionId": f"inner-{tag}",
+                    "selectedModel": model,
+                    "copilotVersion": "1.2.3",
+                    "context": {"cwd": cwd},
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "user.message",
+                "id": f"evt-user-{tag}",
+                "timestamp": "2024-06-01T10:00:01Z",
+                "data": {"content": f"do the thing for {tag}"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant.message",
+                "id": f"evt-asst-{tag}",
+                "timestamp": "2024-06-01T10:00:02Z",
+                "data": {"content": f"on it, {tag}", "outputTokens": "42"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "tool.execution_start",
+                "id": f"evt-tstart-{tag}",
+                "timestamp": "2024-06-01T10:00:03Z",
+                "data": {
+                    "toolCallId": f"tc-{tag}",
+                    "toolName": "create",
+                    "arguments": {"path": "hello.py"},
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "tool.execution_complete",
+                "id": f"evt-tdone-{tag}",
+                "timestamp": "2024-06-01T10:00:04Z",
+                "data": {
+                    "toolCallId": f"tc-{tag}",
+                    "success": True,
+                    "result": {"content": "File created: hello.py"},
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "session.shutdown",
+                "id": f"evt-shutdown-{tag}",
+                "timestamp": "2024-06-01T10:00:05Z",
+                "data": {
+                    "shutdownType": "routine",
+                    "totalApiDurationMs": 3500,
+                    "modelMetrics": {model: {"requests": {"count": 1, "cost": 1}, "usage": usage}},
+                },
+            }
+        ),
+    ]
+
+
+def _seed_state(root: Path) -> None:
+    """Write ``<root>/<uuid>/events.jsonl`` for the two seeded sessions."""
+    sessions = [
+        (
+            _UUID_A,
+            "A",
+            "claude-sonnet-4.5",
+            "/home/user/project-a",
+            {
+                "inputTokens": 36882,
+                "outputTokens": 354,
+                "cacheReadTokens": 7058,
+                "cacheWriteTokens": 0,
+                "reasoningTokens": 0,
+            },
+        ),
+        (
+            _UUID_B,
+            "B",
+            "gpt-5",
+            "/home/user/project-b",
+            {
+                "inputTokens": 100,
+                "outputTokens": 20,
+                "cacheReadTokens": 0,
+                "cacheWriteTokens": 0,
+                "reasoningTokens": 0,
+            },
+        ),
+    ]
+    for uuid, tag, model, cwd, usage in sessions:
+        session_dir = root / uuid
+        session_dir.mkdir(parents=True, exist_ok=True)
+        lines = _session_lines(tag=tag, model=model, cwd=cwd, usage=usage)
+        (session_dir / "events.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _run_once(tmp_path: Path, monkeypatch) -> Path:
+    """Ingest the seeded dir-per-session state once into a fresh temp sqlite DB."""
+    state = tmp_path / "session-state"
+    _seed_state(state)
+
+    db_path = tmp_path / "out.db"
+    sink = SqliteOutputSink(path=str(db_path))
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [sink])
+
+    pipeline = ResolvedPipeline(
+        name="copilot",
+        source_path=state,  # dir-per-session root; rglob finds each <uuid>/events.jsonl
+        ingestion_mode="file_watch",
+        adapter=ADAPTER_MAP["copilot"],
+        sinks=[],  # swapped for the isolated temp sink above
+    )
+    # Titler off: identity/cost never touch it and it would load the ONNX model.
+    asyncio.run(watch_mod._process_pipeline_once(pipeline, governance=None, enable_title=False))
+    return db_path
+
+
+def _query(db_path: Path, sql: str) -> list:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return conn.execute(sql).fetchall()
+    finally:
+        conn.close()
+
+
+def test_shutdown_metrics_become_deduped_usage_records(tmp_path, monkeypatch) -> None:
+    """Each session's shutdown modelMetrics yields exactly one usage record."""
+    db_path = _run_once(tmp_path, monkeypatch)
+
+    (row_count,) = _query(db_path, "SELECT COUNT(*) FROM usage_records")[0]
+    assert row_count == 2  # one per session — the shared events.jsonl stem never merges them
+
+    # Session A headline input = 29824 uncached + 7058 cache-read = 36882 (Copilot's
+    # own reported grand-total inputTokens); B = 100.
+    rows = _query(
+        db_path,
+        "SELECT session_id, model, input_tokens, output_tokens, cost_usd FROM usage_records",
+    )
+    by_session = {r[0]: r for r in rows}
+    assert by_session[_UUID_A][1] == "claude-sonnet-4.5"
+    assert by_session[_UUID_A][2] == 36882
+    assert by_session[_UUID_A][3] == 354
+    assert by_session[_UUID_B][1] == "gpt-5"
+    assert by_session[_UUID_B][2] == 100
+    assert by_session[_UUID_B][3] == 20
+
+    # Cost is honestly NULL — Copilot carries no dollar cost, and none is synthesized.
+    assert all(r[4] is None for r in rows)
+
+
+def test_usage_input_breakdown_is_preserved(tmp_path, monkeypatch) -> None:
+    """The uncached/cache-read split is stashed losslessly in attributes (ruling A)."""
+    db_path = _run_once(tmp_path, monkeypatch)
+
+    (attrs_json,) = _query(
+        db_path,
+        f"SELECT attributes_json FROM usage_records WHERE session_id = '{_UUID_A}'",
+    )[0]
+    attrs = json.loads(attrs_json)
+    assert attrs == {
+        "input_uncached": 29824,
+        "cache_read_tokens": 7058,
+        "cache_creation_tokens": 0,
+    }
+
+
+def test_usage_stays_off_the_enriched_timeline(tmp_path, monkeypatch) -> None:
+    """Ruling C: usage rides usage_records ONLY, never the enriched-events timeline."""
+    db_path = _run_once(tmp_path, monkeypatch)
+
+    (event_count,) = _query(db_path, "SELECT COUNT(*) FROM enriched_events")[0]
+    assert event_count > 0, "no events were emitted through the --once path"
+
+    (timeline_usage,) = _query(
+        db_path,
+        "SELECT COUNT(*) FROM enriched_events WHERE kind = 'telemetry.usage'",
+    )[0]
+    assert timeline_usage == 0, "usage must not ride the enriched-events timeline"
+
+    # The rest of the timeline is unchanged: canonical kinds still present, and the
+    # shutdown still lands exactly one session.ended per run.
+    kinds = {r[0] for r in _query(db_path, "SELECT DISTINCT kind FROM enriched_events")}
+    assert {"session.started", "message.user", "message.assistant", "tool.call.completed"} <= kinds
+    (ended,) = _query(db_path, "SELECT COUNT(*) FROM enriched_events WHERE kind = 'session.ended'")[
+        0
+    ]
+    assert ended == 2
+
+
+def test_build_run_surfaces_repo_model_and_usage(tmp_path, monkeypatch) -> None:
+    """build_run returns non-empty repo + model + usage per run, cost honestly 0.0."""
+    db_path = _run_once(tmp_path, monkeypatch)
+
+    paths = resolve_paths(output_db=db_path, system_db=tmp_path / "system.db")
+    repo = DashboardRepository(paths)
+
+    run_a = repo.build_run(_UUID_A)
+    assert run_a is not None
+    assert run_a["repo"] == "/home/user/project-a"
+    assert run_a["model"] == "claude-sonnet-4.5"
+    assert run_a["usage"]["in"] == 36882
+    assert run_a["usage"]["out"] == 354
+    # No wire cost → COALESCE(SUM(NULL), 0.0) → 0.0 (no NaN, no crash).
+    assert run_a["usage"]["cost"] == 0.0
+
+    run_b = repo.build_run(_UUID_B)
+    assert run_b is not None
+    assert run_b["repo"] == "/home/user/project-b"
+    assert run_b["model"] == "gpt-5"
+    assert run_b["usage"]["in"] == 100
+    assert run_b["usage"]["cost"] == 0.0

--- a/tests/fixtures/raw_traces/copilot/demo_issue_tracker_get_endpoint.expected.json
+++ b/tests/fixtures/raw_traces/copilot/demo_issue_tracker_get_endpoint.expected.json
@@ -1,5 +1,5 @@
 {
-  "event_count": 59,
+  "event_count": 60,
   "kinds": {
     "hook.completed": 9,
     "hook.started": 9,
@@ -8,6 +8,7 @@
     "message.user": 1,
     "session.ended": 1,
     "session.started": 1,
+    "telemetry.usage": 1,
     "tool.call.completed": 9,
     "tool.call.started": 9,
     "turn.ended": 6,

--- a/tests/unit/test_copilot_identity_cost_enrichment.py
+++ b/tests/unit/test_copilot_identity_cost_enrichment.py
@@ -1,0 +1,228 @@
+"""Unit tests for Copilot identity + cost enrichment (the three blank run fields).
+
+GitHub Copilot CLI populates ``model`` / ``repo`` / Cost the same way Claude does
+(issue #159 / PR #160), but adapted to Copilot's real wire shape:
+
+* the ``copilot`` preprocessor synthesizes a per-model ``assistant.usage`` block from
+  ``session.shutdown.data.modelMetrics`` (Copilot emits no per-turn usage event) and
+  leaves every other event untouched, so the enriched timeline is unchanged;
+* the mapped adapter surfaces ``session.start``'s ``data.context.cwd`` as
+  ``EventMetadata.repo`` via ``repo_field``;
+* the synthetic ``assistant.usage`` block maps to a ``telemetry.usage`` event whose
+  payload feeds the framework-agnostic watch usage bridge (dedup + aggregate).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from pathlib import Path
+
+from traceforge.adapters.mapped_json import MappedJsonAdapter
+from traceforge.preprocessors.copilot import preprocess_copilot
+from traceforge.types import EventKind, SessionEvent
+
+MAPPINGS_DIR = Path(__file__).resolve().parents[2] / "src" / "traceforge" / "mappings"
+watch_mod = importlib.import_module("traceforge.cli.watch")
+
+_MODEL = "claude-sonnet-4.5"
+# One real-shaped model entry. Copilot's ``usage.inputTokens`` is a GRAND TOTAL
+# that already includes the cache tokens (verified against ``tokenDetails`` on real
+# ~/.copilot streams and the pinned golden fixture:
+# ``inputTokens == uncached + cacheRead + cacheWrite``). The preprocessor emits the
+# *uncached* delta so the watch bridge rebuilds exactly this reported total.
+_INPUT_TOTAL = 36882
+_CACHE_READ = 7058
+_OUTPUT = 354
+_UNCACHED = _INPUT_TOTAL - _CACHE_READ  # 29824
+_USAGE = {
+    "inputTokens": _INPUT_TOTAL,
+    "outputTokens": _OUTPUT,
+    "cacheReadTokens": _CACHE_READ,
+    "cacheWriteTokens": 0,
+    "reasoningTokens": 0,
+}
+
+
+def _copilot_adapter(session_id: str = "test-session") -> MappedJsonAdapter:
+    return MappedJsonAdapter.from_yaml(str(MAPPINGS_DIR / "copilot.yaml"), session_id=session_id)
+
+
+def _shutdown(model_metrics, *, shutdown_id: str = "sh1") -> dict:
+    return {
+        "type": "session.shutdown",
+        "id": shutdown_id,
+        "timestamp": "2024-06-01T10:05:00Z",
+        "data": {"shutdownType": "routine", "modelMetrics": model_metrics},
+    }
+
+
+def _start(cwd: str | None = "/home/user/project") -> dict:
+    context = {"cwd": cwd} if cwd is not None else {}
+    return {
+        "type": "session.start",
+        "id": "s1",
+        "timestamp": "2024-06-01T10:00:00Z",
+        "data": {"selectedModel": _MODEL, "context": context},
+    }
+
+
+# ─── Preprocessor ────────────────────────────────────────────────────────────
+
+
+def test_preprocessor_passes_non_shutdown_through_unchanged() -> None:
+    obj = {"type": "assistant.message", "id": "m1", "data": {"content": "hi"}}
+    assert preprocess_copilot(obj) == [obj]
+
+
+def test_preprocessor_emits_usage_block_from_dict_metrics() -> None:
+    blocks = preprocess_copilot(_shutdown({_MODEL: {"usage": dict(_USAGE)}}))
+    # Original shutdown is preserved FIRST (so session.ended still rides the timeline
+    # exactly once), followed by one synthetic usage block.
+    assert [b["type"] for b in blocks] == ["session.shutdown", "assistant.usage"]
+
+    usage = blocks[-1]
+    assert usage["data"]["model"] == _MODEL
+    # Emitted input is the UNCACHED delta (grand total minus cache), so the bridge's
+    # re-aggregation lands back on Copilot's reported inputTokens.
+    assert usage["data"]["inputTokens"] == _UNCACHED
+    assert usage["data"]["outputTokens"] == _OUTPUT
+    assert usage["data"]["cacheReadTokens"] == _CACHE_READ
+    assert usage["data"]["cacheWriteTokens"] == 0
+    # Stable dedup id: <shutdown-id>:<model>.
+    assert usage["data"]["messageId"] == "sh1:claude-sonnet-4.5"
+    assert usage["id"] == "sh1:claude-sonnet-4.5"
+    assert usage["timestamp"] == "2024-06-01T10:05:00Z"
+
+
+def test_preprocessor_decodes_json_string_metrics() -> None:
+    # Real streams may serialize modelMetrics as a JSON string; both are accepted.
+    raw = json.dumps({_MODEL: {"usage": dict(_USAGE)}})
+    blocks = preprocess_copilot(_shutdown(raw))
+    assert [b["type"] for b in blocks] == ["session.shutdown", "assistant.usage"]
+    assert blocks[-1]["data"]["inputTokens"] == _UNCACHED
+
+
+def test_preprocessor_emits_one_block_per_model() -> None:
+    blocks = preprocess_copilot(
+        _shutdown(
+            {
+                "gpt-5": {"usage": {"inputTokens": 10, "outputTokens": 2}},
+                "claude-sonnet-4.5": {"usage": {"inputTokens": 20, "outputTokens": 4}},
+            }
+        )
+    )
+    usage_blocks = [b for b in blocks if b["type"] == "assistant.usage"]
+    assert len(usage_blocks) == 2
+    models = sorted(b["data"]["model"] for b in usage_blocks)
+    assert models == ["claude-sonnet-4.5", "gpt-5"]
+    # Distinct dedup ids so both survive the usage-bridge dedup.
+    assert len({b["data"]["messageId"] for b in usage_blocks}) == 2
+
+
+def test_preprocessor_no_usage_when_metrics_empty() -> None:
+    # The idealized fixture ships ``modelMetrics: {}`` — must stay a pure pass-through.
+    obj = _shutdown({})
+    assert preprocess_copilot(obj) == [obj]
+
+
+def test_preprocessor_no_usage_when_metrics_malformed() -> None:
+    assert preprocess_copilot(_shutdown("not json")) == [_shutdown("not json")]
+    assert preprocess_copilot(_shutdown(None)) == [_shutdown(None)]
+
+
+def test_preprocessor_skips_blank_model_and_missing_usage() -> None:
+    blocks = preprocess_copilot(
+        _shutdown(
+            {
+                "": {"usage": {"inputTokens": 5}},  # blank model key → skipped
+                _MODEL: {"requests": {"count": 1}},  # no usage sub-object → skipped
+            }
+        )
+    )
+    assert [b["type"] for b in blocks] == ["session.shutdown"]
+
+
+# ─── Adapter (repo_field → EventMetadata.repo) ───────────────────────────────
+
+
+def test_adapter_surfaces_cwd_as_repo() -> None:
+    adapter = _copilot_adapter()
+    events = list(adapter.parse_dict(_start("/home/user/project")))
+    assert events
+    assert all(e.metadata.repo == "/home/user/project" for e in events)
+
+
+def test_adapter_repo_none_without_cwd() -> None:
+    adapter = _copilot_adapter()
+    events = list(adapter.parse_dict(_start(cwd=None)))
+    assert events
+    assert all(e.metadata.repo is None for e in events)
+
+
+def test_adapter_maps_synthetic_usage_to_telemetry_usage() -> None:
+    adapter = _copilot_adapter()
+    events = list(adapter.parse_dict(_shutdown({_MODEL: {"usage": dict(_USAGE)}})))
+    usage_events = [e for e in events if e.kind == EventKind.USAGE]
+    assert len(usage_events) == 1
+    payload = usage_events[0].payload
+    assert payload["model"] == _MODEL
+    assert payload["input_tokens"] == _UNCACHED
+    assert payload["output_tokens"] == _OUTPUT
+    assert payload["cache_read_tokens"] == _CACHE_READ
+    assert payload["cache_write_tokens"] == 0
+    assert payload["msg_id"] == "sh1:claude-sonnet-4.5"
+    # No dollar cost in the wire → cost_usd never mapped (stays absent → None).
+    assert "cost_usd" not in payload
+
+    # The shutdown itself still maps to session.ended (rides the timeline).
+    assert any(e.kind == EventKind.SESSION_ENDED for e in events)
+
+
+# ─── _feed_line (copilot-shaped: aggregate + dedup + off-timeline) ────────────
+
+
+class _RecordingPipeline:
+    """Captures push()/push_usage() calls without a real pipeline."""
+
+    def __init__(self) -> None:
+        self.pushed: list[SessionEvent] = []
+        self.usage: list = []
+
+    async def push(self, event: SessionEvent) -> None:
+        self.pushed.append(event)
+
+    async def push_usage(self, record) -> None:
+        self.usage.append(record)
+
+
+def test_feed_line_builds_aggregated_usage_off_timeline_and_dedups() -> None:
+    adapter = _copilot_adapter("cp-sess")
+    pipeline = _RecordingPipeline()
+    seen: set[str] = set()
+
+    line = json.dumps(_shutdown({_MODEL: {"usage": dict(_USAGE)}}))
+
+    # Replaying the SAME shutdown (e.g. a resumed/re-read stream) must not
+    # double-count: dedup keys on the stable <shutdown-id>:<model> messageId.
+    asyncio.run(watch_mod._feed_line(line, adapter, pipeline, seen))
+    asyncio.run(watch_mod._feed_line(line, adapter, pipeline, seen))
+
+    assert len(pipeline.usage) == 1
+    record = pipeline.usage[0]
+    # Ruling A: headline input aggregates uncached + cache-read + cache-write, which
+    # by construction equals Copilot's own reported grand-total inputTokens.
+    assert record.input_tokens == _INPUT_TOTAL
+    assert record.output_tokens == _OUTPUT
+    assert record.model == _MODEL
+    assert record.cost_usd is None
+    assert record.attributes == {
+        "input_uncached": _UNCACHED,
+        "cache_read_tokens": _CACHE_READ,
+        "cache_creation_tokens": 0,
+    }
+
+    # Off-timeline: session.ended rides the timeline; the usage event never does.
+    assert all(e.kind != EventKind.USAGE for e in pipeline.pushed)
+    assert any(e.kind == EventKind.SESSION_ENDED for e in pipeline.pushed)


### PR DESCRIPTION
Closes #165.

Ingestion-only fix that populates the three run-level fields that render blank for GitHub Copilot CLI runs — the exact analog of the merged Claude fix #160, adapted to Copilot's real wire shape.

## What was blank (real re-ingest, before)
- `run.model == ""` — `copilot.yaml` mapped `model` only into the `session.started` payload, never into `usage_records.model`.
- `run.repo == ""` — `data.context.cwd` mapped only into the `session.started` payload, never into `EventMetadata.repo`.
- Cost lens empty / `usage_records == 0` — the existing `assistant.usage` mapping never fired because real Copilot streams emit no such event.

## Root cause / where usage actually lives
Real Copilot streams carry no `assistant.usage` event. Authoritative whole-session token accounting is on the terminal `session.shutdown` event as `data.modelMetrics` — a per-model map `{<model>: {requests, usage:{inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, reasoningTokens}}}` (dict or JSON string).

`usage.inputTokens` is a **grand total that already includes cache** (verified against `tokenDetails` on real streams and the `claude-opus-4.8` golden fixture: `407996 = 211 + 394185 + 13600`). The #160 watch bridge treats the payload `input_tokens` as **uncached** and reconstitutes `total_input = uncached + cache_read + cache_write`. So the preprocessor emits the **uncached delta** (`inputTokens − cacheRead − cacheWrite`, clamped ≥0); the bridge rebuilds exactly Copilot's reported `inputTokens`, with the split preserved in `UsageRecord.attributes`.

There is no dollar cost in the wire (`requests.cost` is a premium-request count), so `cost_usd = None` — never synthesized.

## Changes (100% ingestion-side)
- **`preprocessors/copilot.py`** (new): synthesize one `assistant.usage` block per model from `session.shutdown.data.modelMetrics`; emit uncached input; carry a stable `<shutdown-id>:<model>` dedup id; pass every other event through untouched (enriched timeline unchanged).
- **`preprocessors/__init__.py`**: register the preprocessor.
- **`mappings/copilot.yaml`**: `preprocessor: copilot`; `repo_field: data.context.cwd`; `msg_id: data.messageId` on the `assistant.usage` mapping.
- **`cli/watch.py` / `adapters/mapped_json.py`**: no change — the #160 dedup / off-timeline `push_usage` / aggregate-with-breakdown / `cost_usd=None` bridge and the `repo_field` → `EventMetadata.repo` support already exist on `main`.
- Tests: `tests/unit/test_copilot_identity_cost_enrichment.py` (11), `tests/e2e/test_copilot_identity_cost_enrichment.py` (4).
- Golden snapshot **intentionally regenerated**: `tests/fixtures/raw_traces/copilot/demo_issue_tracker_get_endpoint.expected.json` (event_count 59→60, `+telemetry.usage:1`) — the fixture's shutdown carries `claude-opus-4.8` metrics, so it now emits one synthetic usage block. All 22 other snapshots byte-identical.
- Docs: `docs/dashboard-spec.md` grand-total→uncached note; `CHANGELOG.md` entry.

## Verification — isolated re-ingest of 40 REAL `~/.copilot/session-state` sessions
Isolated exactly as #160's e2e (copied read-only into a temp dir, ingested via the real pipeline into a temp `SqliteOutputSink`; live `~/.traceforge/*` never touched):

| metric | value |
|---|---|
| `usage_records` | **40** (one per session, deduped by `<shutdown-id>:<model>`) |
| Σ input_tokens | **1,678,406** |
| Σ output_tokens | **53,028** |
| cost NULL | **40 / 40** |
| `telemetry.usage` rows on enriched timeline | **0** |
| model histogram | `claude-sonnet-4.5` ×39, `claude-sonnet-4.6` ×1 |
| `run.model` populated | 40 / 40 |
| `run.repo` populated | 40 / 40 |
| `run.usage.cost` | 0.0 (no NaN) |

Real `run.repo` sample: `C:\Users\davidfinson\.copilot\repos\copilot-worktrees\coderecon\dfinson-stunning-telegram`. (Most sampled sessions are internal/automation runs whose recorded cwd is a temp path — `run.repo` still populates from the real recorded cwd, which is the fix.)

## Test suite / lint
- Full suite: `37 failed, 3487 passed, 25 skipped`. The 37 failures are all pre-existing environmental cases (`ModuleNotFoundError: crewai` / `langchain_core` — uninstalled optional agent-framework deps) that fail identically on clean `main`; baseline was 38 failed (the Copilot snapshot moved fail→pass). Zero ingestion failures.
- `ruff check .` and `ruff format --check .` clean (pinned `ruff==0.15.20`).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
