### PR TITLE
Fix Chapters tree to render the step layer (activity ▸ step ▸ events) (#167)

### DIFF
--- a/dashboard/src/lib/chapters.ts
+++ b/dashboard/src/lib/chapters.ts
@@ -1,0 +1,229 @@
+// Builds the Chapters navigator tree for a run: activity ▸ step ▸ events.
+//
+// The backend ships a flat `run.segs` list of segment nodes
+// (`session | activity | step`, each with a `parent`) plus a flat `run.events`
+// list where every event carries `e.seg` — the id of the *step* it belongs to
+// (occasionally an activity id as a fallback, or "" when it has no segment).
+//
+// Two things make the grouping subtle, and both are handled here so the view
+// stays declarative:
+//
+//   1. Id collision across kinds. The titler reuses an activity's id for that
+//      activity's "lead" step, so an `activity` node and one `step` node can
+//      share the same id. Nodes must therefore be identified by (kind, id), not
+//      id alone.
+//   2. Zero event loss. Every event with a non-empty `seg` must land under
+//      exactly one step. Events whose `seg` matches no titled step (a few
+//      untitled steps exist) or is empty are routed into synthetic buckets
+//      instead of being dropped — the previous implementation grouped by
+//      `e.seg === activity.id`, which silently hid ~77% of events.
+
+import type { RiskLevel, Seg, TEvent } from "@/lib/types";
+
+// One event plus its original index in `run.events` (needed for `setSel`, the
+// active-row highlight, and the inspector).
+export interface ChapterEvent {
+  e: TEvent;
+  i: number;
+}
+
+export interface ChapterStep {
+  key: string; // stable React key (unique across the whole tree)
+  id: string; // segment id ("" for the no-segment bucket)
+  title: string;
+  risk: RiskLevel;
+  synthetic: boolean; // true for "Untitled step" / "Ungrouped" buckets
+  events: ChapterEvent[];
+}
+
+export interface ChapterActivity {
+  key: string;
+  id: string;
+  title: string;
+  risk: RiskLevel;
+  synthetic: boolean; // true for the catch-all "Unassigned" activity
+  steps: ChapterStep[];
+  count: number; // total events across the activity's steps
+}
+
+const UNASSIGNED_ID = "__unassigned__";
+const NO_SEGMENT_ID = "__no_segment__";
+
+function maxRisk(events: ChapterEvent[]): RiskLevel {
+  let r: RiskLevel = 0;
+  for (const { e } of events) if (e.risk > r) r = e.risk;
+  return r;
+}
+
+/**
+ * Group a run's events under their titled step, and steps under their activity.
+ *
+ * All real activities are returned (even those with no events) to preserve the
+ * existing "one row per activity" overview; empty *steps* are omitted to keep
+ * the tree readable, and a trailing synthetic "Unassigned" activity is appended
+ * only when some event could not be placed under a real step.
+ */
+export function buildChapters(segs: Seg[], events: TEvent[]): ChapterActivity[] {
+  const activitySegs = segs.filter((s) => s.kind === "activity");
+  const stepSegs = segs.filter((s) => s.kind === "step");
+
+  // Real activity nodes, in segment order. First wins on the (unexpected) case
+  // of a duplicate activity id.
+  const activityById = new Map<string, ChapterActivity>();
+  const activities: ChapterActivity[] = [];
+  for (const a of activitySegs) {
+    if (activityById.has(a.id)) continue;
+    const node: ChapterActivity = {
+      key: `act:${a.id}`,
+      id: a.id,
+      title: a.title,
+      risk: a.risk,
+      synthetic: false,
+      steps: [],
+      count: 0,
+    };
+    activityById.set(a.id, node);
+    activities.push(node);
+  }
+
+  // Lazily-created catch-all activity for events we cannot attribute to a real
+  // activity (unknown/empty seg, or a step whose parent activity is missing).
+  let unassigned: ChapterActivity | null = null;
+  const unassignedActivity = (): ChapterActivity => {
+    if (!unassigned) {
+      unassigned = {
+        key: `act:${UNASSIGNED_ID}`,
+        id: UNASSIGNED_ID,
+        title: "Unassigned",
+        risk: 0,
+        synthetic: true,
+        steps: [],
+        count: 0,
+      };
+      activities.push(unassigned);
+    }
+    return unassigned;
+  };
+
+  // Real step nodes keyed by step id (first wins on cross-activity id reuse).
+  // A step whose id equals its parent activity id (the "lead" step) is still a
+  // distinct node here and nests under that activity.
+  const stepById = new Map<string, ChapterStep>();
+  for (const s of stepSegs) {
+    if (stepById.has(s.id)) continue;
+    const step: ChapterStep = {
+      key: `step:${s.parent ?? ""}:${s.id}`,
+      id: s.id,
+      title: s.title,
+      risk: s.risk,
+      synthetic: false,
+      events: [],
+    };
+    stepById.set(s.id, step);
+    const parent = s.parent ? activityById.get(s.parent) : undefined;
+    (parent ?? unassignedActivity()).steps.push(step);
+  }
+
+  // Per-activity synthetic "Ungrouped" step for events whose seg is that
+  // activity's id but has no matching titled step.
+  const ungroupedByActivity = new Map<string, ChapterStep>();
+  const ungroupedStep = (activity: ChapterActivity): ChapterStep => {
+    let step = ungroupedByActivity.get(activity.id);
+    if (!step) {
+      step = {
+        key: `step:${activity.id}:${UNASSIGNED_ID}`,
+        id: `${activity.id}:${UNASSIGNED_ID}`,
+        title: "Ungrouped events",
+        risk: 0,
+        synthetic: true,
+        events: [],
+      };
+      ungroupedByActivity.set(activity.id, step);
+      activity.steps.push(step);
+    }
+    return step;
+  };
+
+  // Synthetic "Untitled step" nodes (one per unknown seg id) and a single
+  // "No segment" bucket, all hung off the catch-all activity.
+  const untitledBySeg = new Map<string, ChapterStep>();
+  const untitledStep = (seg: string): ChapterStep => {
+    let step = untitledBySeg.get(seg);
+    if (!step) {
+      step = {
+        key: `step:${UNASSIGNED_ID}:${seg}`,
+        id: seg,
+        title: `Untitled step · ${seg.slice(0, 8)}`,
+        risk: 0,
+        synthetic: true,
+        events: [],
+      };
+      untitledBySeg.set(seg, step);
+      unassignedActivity().steps.push(step);
+    }
+    return step;
+  };
+  let noSegment: ChapterStep | null = null;
+  const noSegmentStep = (): ChapterStep => {
+    if (!noSegment) {
+      noSegment = {
+        key: `step:${UNASSIGNED_ID}:${NO_SEGMENT_ID}`,
+        id: NO_SEGMENT_ID,
+        title: "Ungrouped (no segment)",
+        risk: 0,
+        synthetic: true,
+        events: [],
+      };
+      unassignedActivity().steps.push(noSegment);
+    }
+    return noSegment;
+  };
+
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i];
+    const seg = e.seg;
+    let target: ChapterStep;
+    if (seg && stepById.has(seg)) {
+      target = stepById.get(seg)!;
+    } else if (seg && activityById.has(seg)) {
+      target = ungroupedStep(activityById.get(seg)!);
+    } else if (seg) {
+      target = untitledStep(seg);
+    } else {
+      target = noSegmentStep();
+    }
+    target.events.push({ e, i });
+  }
+
+  // Drop steps with no events, finalize synthetic risk + counts.
+  for (const activity of activities) {
+    activity.steps = activity.steps.filter((s) => s.events.length > 0);
+    for (const step of activity.steps) {
+      if (step.synthetic) step.risk = maxRisk(step.events);
+    }
+    activity.count = activity.steps.reduce((n, s) => n + s.events.length, 0);
+    if (activity.synthetic) {
+      activity.risk = activity.steps.reduce<RiskLevel>((r, s) => (s.risk > r ? s.risk : r), 0);
+    }
+  }
+
+  return activities;
+}
+
+/**
+ * Locate the node keys for the event at `index`, so the view can highlight and
+ * auto-expand the activity/step that owns the currently-inspected event.
+ */
+export function locateEvent(
+  chapters: ChapterActivity[],
+  index: number,
+): { activityKey: string; stepKey: string } | null {
+  for (const activity of chapters) {
+    for (const step of activity.steps) {
+      if (step.events.some((ce) => ce.i === index)) {
+        return { activityKey: activity.key, stepKey: step.key };
+      }
+    }
+  }
+  return null;
+}

--- a/dashboard/src/views/RunView.tsx
+++ b/dashboard/src/views/RunView.tsx
@@ -4,6 +4,7 @@ import { useRuns } from "@/lib/queries";
 import type { TEvent } from "@/lib/types";
 import { useApp } from "@/store";
 import { dmin, hhmm, money, money3, fmtVal } from "@/lib/format";
+import { buildChapters, locateEvent } from "@/lib/chapters";
 import { G, mtip } from "@/data/tips";
 import { Tip } from "@/components/Tip";
 import { RiskBadge, RiskDot } from "@/components/RiskBadge";
@@ -20,6 +21,7 @@ export function RunView() {
   const { data: runs = [], isLoading } = useRuns();
   const [open, setOpen] = useState<Record<string, boolean>>({});
   const run = runId ? runs.find((r) => r.id === runId) : null;
+  const chapters = useMemo(() => (run ? buildChapters(run.segs, run.events) : []), [run]);
   if (isLoading && !run) {
     return (
       <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
@@ -29,8 +31,9 @@ export function RunView() {
   }
   if (!run) return null;
   const evs = run.events;
-  const cur = evs[Math.min(sel, evs.length - 1)];
-  const activities = run.segs.filter((s) => s.kind === "activity");
+  const selIdx = Math.min(sel, evs.length - 1);
+  const cur = evs[selIdx];
+  const active = locateEvent(chapters, selIdx);
   const identity = [run.repo, run.agent, run.model].filter(Boolean).join(" · ");
 
   return (
@@ -103,57 +106,102 @@ export function RunView() {
                 </CardTitle>
               </Tip>
               <CardDescription>
-                Titler tree — activity ▸ step. Click a step to inspect it.
+                Titler tree — activity ▸ step ▸ event. Click an event to inspect it.
               </CardDescription>
             </CardHeader>
             <CardContent className="p-2">
               <ScrollArea className="h-[300px] pr-2">
                 <div className="space-y-0.5">
-                  {activities.map((a) => {
-                    const steps = evs.map((e, i) => ({ e, i })).filter((x) => x.e.seg === a.id);
-                    const activeChapter = cur.seg === a.id;
-                    const isOpen = open[a.id] ?? activeChapter;
+                  {chapters.map((a) => {
+                    const activityActive = a.key === active?.activityKey;
+                    const activityOpen = open[a.key] ?? activityActive;
                     return (
-                      <div key={a.id}>
+                      <div key={a.key}>
                         <button
-                          onClick={() => setOpen((o) => ({ ...o, [a.id]: !isOpen }))}
+                          onClick={() => setOpen((o) => ({ ...o, [a.key]: !activityOpen }))}
                           className={`flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors ${
-                            activeChapter ? "bg-muted/60" : "hover:bg-muted/50"
+                            activityActive ? "bg-muted/60" : "hover:bg-muted/50"
                           }`}
                         >
                           <ChevronRight
                             className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
-                              isOpen ? "rotate-90" : ""
+                              activityOpen ? "rotate-90" : ""
                             }`}
                           />
                           <RiskDot level={a.risk} />
-                          <span className="flex-1 truncate font-medium">{a.title}</span>
+                          <span
+                            className={`flex-1 truncate font-medium ${
+                              a.synthetic ? "text-muted-foreground" : ""
+                            }`}
+                          >
+                            {a.title}
+                          </span>
                           <span className="text-[11px] tabular-nums text-muted-foreground">
-                            {steps.length}
+                            {a.count}
                           </span>
                         </button>
-                        {isOpen && (
+                        {activityOpen && (
                           <div className="ml-[15px] space-y-0.5 border-l border-border/70 py-0.5 pl-1.5">
-                            {steps.map(({ e, i }) => (
-                              <button
-                                key={e.id}
-                                onClick={() => setSel(i)}
-                                className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors ${
-                                  i === sel ? "bg-muted" : "hover:bg-muted/40"
-                                }`}
-                              >
-                                <span className="w-5 shrink-0 text-right text-[10.5px] tabular-nums text-muted-foreground">
-                                  {i + 1}
-                                </span>
-                                <RiskDot level={e.risk} />
-                                <span className="w-14 shrink-0 truncate font-mono text-[11px]">
-                                  {e.tool.n}
-                                </span>
-                                <span className="flex-1 truncate text-[11.5px] text-muted-foreground">
-                                  {e.summary}
-                                </span>
-                              </button>
-                            ))}
+                            {a.steps.map((s) => {
+                              const stepActive = s.key === active?.stepKey;
+                              const stepOpen = open[s.key] ?? stepActive;
+                              return (
+                                <div key={s.key}>
+                                  <button
+                                    onClick={() => setOpen((o) => ({ ...o, [s.key]: !stepOpen }))}
+                                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors ${
+                                      stepActive ? "bg-muted/60" : "hover:bg-muted/50"
+                                    }`}
+                                  >
+                                    <ChevronRight
+                                      className={`size-3 shrink-0 text-muted-foreground transition-transform ${
+                                        stepOpen ? "rotate-90" : ""
+                                      }`}
+                                    />
+                                    <RiskDot level={s.risk} />
+                                    <span
+                                      className={`flex-1 truncate text-[12.5px] ${
+                                        s.synthetic ? "italic text-muted-foreground" : "font-medium"
+                                      }`}
+                                    >
+                                      {s.title}
+                                    </span>
+                                    <span className="text-[10.5px] tabular-nums text-muted-foreground">
+                                      {s.events.length}
+                                    </span>
+                                  </button>
+                                  {stepOpen && (
+                                    <div className="ml-[15px] space-y-0.5 border-l border-border/70 py-0.5 pl-1.5">
+                                      {s.events.map(({ e, i }) => (
+                                        <button
+                                          key={e.id}
+                                          onClick={() => setSel(i)}
+                                          className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors ${
+                                            i === sel ? "bg-muted" : "hover:bg-muted/40"
+                                          }`}
+                                        >
+                                          <span className="w-5 shrink-0 text-right text-[10.5px] tabular-nums text-muted-foreground">
+                                            {i + 1}
+                                          </span>
+                                          <RiskDot level={e.risk} />
+                                          <span className="w-14 shrink-0 truncate font-mono text-[11px]">
+                                            {e.tool.n}
+                                          </span>
+                                          <span className="flex-1 truncate text-[11.5px] text-muted-foreground">
+                                            {e.summary}
+                                          </span>
+                                        </button>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })}
+                            {a.steps.length === 0 && (
+                              <div className="px-2 py-1.5 text-[11.5px] italic text-muted-foreground">
+                                No steps recorded.
+                              </div>
+                            )}
                           </div>
                         )}
                       </div>
@@ -203,7 +251,7 @@ export function RunView() {
           </Card>
         </div>
 
-        <Inspector e={cur} idx={Math.min(sel, evs.length - 1)} />
+        <Inspector e={cur} idx={selIdx} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #167

## Problem
The run view's **Chapters** navigator rendered **activity → raw events**, labeling each leaf with the event's tool name (`e.tool.n`: `view`, `powershell`, `edit`, `grep`, …). Those one-word verbs are what users saw — *"why are step titles meaningless one word verbs in the ui?"* — and the meaningful **step** layer (multi-word titler titles) was never rendered.

Worse, events were grouped with `e.seg === activity.id`, but `e.seg` is a **step id**, so only the minority of events whose step id happened to coincide with an activity id were shown. On a real 4012-event run, only **924 (23%)** rendered and **3078 (77%) silently vanished**.

## Fix (frontend-only, under `dashboard/`)
Render the full three-level tree **activity ▸ step ▸ events**:
- Activities = `run.segs` where `kind === "activity"`.
- Steps of an activity = `run.segs` where `kind === "step" && parent === activity.id`.
- Events of a step = `run.events` where `e.seg === step.id` (original index preserved for `setSel`).
- Level 2 now shows the meaningful **step title**; events stay as leaves (tool name + summary).

New pure module `dashboard/src/lib/chapters.ts` (`buildChapters` + `locateEvent`) does the grouping so `RunView` stays declarative. It:
- keys nodes by **(kind, id)** so an activity and its "lead" step sharing an id don't collide;
- guarantees **zero event loss** — an event whose `seg` matches no titled step goes to an "Untitled step" bucket, and an empty `seg` goes to an "Ungrouped (no segment)" bucket, so every event still appears exactly once;
- drops empty steps to keep large trees (~70 activities / ~360 steps / thousands of events) readable.

Everything that worked before is preserved: risk dots at every level, per-node counts, expand/collapse chevrons, the active-chapter highlight (now activity **and** step), and click-to-inspect on event leaves.

## Verification
- `pnpm build` (tsc -b typecheck + vite) — clean.
- `pnpm lint` (oxlint) — no new warnings (only the 4 pre-existing `only-export-components` warnings in untouched files).
- `git diff --name-only origin/main` — only `dashboard/` files (`views/RunView.tsx`, new `lib/chapters.ts`); zero Python changes.
- `ruff check .` + `ruff format --check .` (pinned `ruff==0.15.20`) — All checks passed / 461 files already formatted.
- Full Python suite — **3543 passed, 8 skipped** (backend untouched).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>