### PR TITLE
Scope classification Coverage metric to classifiable events (#177)

### DIFF
--- a/dashboard/src/components/charts/CoverageDonut.tsx
+++ b/dashboard/src/components/charts/CoverageDonut.tsx
@@ -1,19 +1,16 @@
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 import { useRuns } from "@/lib/queries";
+import { coverageStats, effectMix } from "@/lib/coverage";
 import { CHART_FILL, tooltipItemStyle, tooltipLabelStyle, tooltipStyle } from "./chartTheme";
 
 export function CoverageDonut() {
   const { data: runs = [] } = useRuns();
-  const m: Record<string, number> = {};
-  runs.forEach((r) =>
-    r.events.forEach((e) => {
-      m[e.cls.cat] = (m[e.cls.cat] || 0) + 1;
-    })
-  );
-  const data = Object.entries(m)
-    .map(([k, v]) => ({ k, v }))
-    .sort((a, b) => b.v - a.v);
-  const total = data.reduce((a, d) => a + d.v, 0);
+  const events = runs.flatMap((r) => r.events);
+  // Scored over classifiable events only (tool calls + permissions); each slice
+  // is an effect category, plus one honest "unclassified" slice for classifiable
+  // events the classifier has not resolved yet.
+  const data = effectMix(events).map(({ label, value }) => ({ k: label, v: value }));
+  const { classifiable } = coverageStats(events);
   return (
     <div className="relative">
       <ResponsiveContainer width="100%" height={220}>
@@ -41,8 +38,8 @@ export function CoverageDonut() {
         </PieChart>
       </ResponsiveContainer>
       <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-        <span className="text-2xl font-semibold tabular-nums">{total}</span>
-        <span className="text-[11px] text-muted-foreground">classified</span>
+        <span className="text-2xl font-semibold tabular-nums">{classifiable}</span>
+        <span className="text-[11px] text-muted-foreground">classifiable</span>
       </div>
     </div>
   );

--- a/dashboard/src/lib/coverage.ts
+++ b/dashboard/src/lib/coverage.ts
@@ -1,0 +1,128 @@
+// Honest scoping for the classification-"Coverage" metric.
+//
+// `cls.cat` is the EFFECT taxonomy (`read_only` / `mutating` / `destructive`).
+// An effect is a TOOL-ACTION property, so only tool-call and permission events
+// can carry one. Measuring "classified vs unclassified" against ALL events is a
+// framing bug: it drags in events that have no effect BY NATURE and makes the
+// classifier look broken when it is not.
+//
+//   * lifecycle events (session / turn / message / llm markers) never have an
+//     effect;
+//   * hook wrapper events (`hook.started` / `hook.completed`) DUPLICATE the
+//     already-classified `tool.call.*` events, so classifying them would
+//     double-count and counting them as "unclassified" is pure noise.
+//
+// So the coverage DENOMINATOR is scoped to *classifiable* events (tool calls +
+// permission requests). Lifecycle and hook events get their own labelled
+// buckets — visible, but never masquerading as classification failures. Events
+// that are classifiable yet still carry no effect (shell commands, whose effect
+// is statically indeterminate today; `permission.*`, until governance
+// classification lands) stay counted as a REAL, honest gap — the dashboard must
+// not paper over pipeline deficiencies in either direction.
+
+import type { TEvent } from "@/lib/types";
+
+const isToolCall = (kind: string): boolean => kind.startsWith("tool.call.");
+const isPermission = (kind: string): boolean => kind.startsWith("permission.");
+const isHook = (kind: string): boolean => kind.startsWith("hook.");
+
+// An effect only applies to tool actions. Permission events are included even
+// though they carry no effect YET — a sibling change adds governance
+// classification to them, so counting them now keeps the metric honest before
+// (a visible gap) and after (they flip to classified) that lands. Any event the
+// classifier actually resolved (non-empty effect) is classifiable by
+// definition, so it is never hidden away in a non-tool bucket.
+export function isClassifiable(e: TEvent): boolean {
+  return isToolCall(e.kind) || isPermission(e.kind) || Boolean(e.cls?.cat);
+}
+
+export type CoverageBucket = "classified" | "unclassified" | "hook" | "lifecycle";
+
+// Which honest bucket an event belongs to. `classified` / `unclassified` are the
+// two halves of the classifiable denominator; `hook` and `lifecycle` are out of
+// scope for classification but kept visible.
+export function coverageBucket(e: TEvent): CoverageBucket {
+  if (e.cls?.cat) return "classified";
+  if (isToolCall(e.kind) || isPermission(e.kind)) return "unclassified";
+  if (isHook(e.kind)) return "hook";
+  return "lifecycle";
+}
+
+export interface CoverageStats {
+  classified: number; // classifiable events the classifier resolved (effect set)
+  unclassified: number; // classifiable events with no effect yet (the real gap)
+  hook: number; // hook wrappers (duplicate the tool.call.* events)
+  lifecycle: number; // non-tool events (session / turn / message / llm markers)
+  classifiable: number; // classified + unclassified — the honest denominator
+  total: number;
+  pct: number; // classified / classifiable, 0..100 (0 when nothing is classifiable)
+}
+
+export function coverageStats(events: TEvent[]): CoverageStats {
+  let classified = 0;
+  let unclassified = 0;
+  let hook = 0;
+  let lifecycle = 0;
+  for (const e of events) {
+    switch (coverageBucket(e)) {
+      case "classified":
+        classified++;
+        break;
+      case "unclassified":
+        unclassified++;
+        break;
+      case "hook":
+        hook++;
+        break;
+      case "lifecycle":
+        lifecycle++;
+        break;
+    }
+  }
+  const classifiable = classified + unclassified;
+  return {
+    classified,
+    unclassified,
+    hook,
+    lifecycle,
+    classifiable,
+    total: events.length,
+    pct: classifiable ? Math.round((classified / classifiable) * 100) : 0,
+  };
+}
+
+// Effect-category breakdown over CLASSIFIABLE events only: each real effect
+// (`read_only` / `mutating` / `destructive`) plus a single honest
+// `"unclassified"` slice for classifiable events the classifier has not
+// resolved. Lifecycle and hook events are excluded — they get their own
+// breakdown so the classifier is never blamed for events it is not meant to
+// touch. Sorted by count, descending.
+export function effectMix(events: TEvent[]): { label: string; value: number }[] {
+  const cats: Record<string, number> = {};
+  for (const e of events) {
+    const bucket = coverageBucket(e);
+    if (bucket === "classified") {
+      const cat = e.cls?.cat;
+      if (cat) cats[cat] = (cats[cat] || 0) + 1;
+    } else if (bucket === "unclassified") {
+      cats.unclassified = (cats.unclassified || 0) + 1;
+    }
+  }
+  return Object.entries(cats)
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value);
+}
+
+// Honest "event scope" split for a distribution bar: how the full event volume
+// divides into the classifiable denominator vs. the two out-of-scope buckets.
+// Zero-count buckets are dropped so the bar only shows what is present.
+export function scopeSplit(
+  stats: CoverageStats,
+  colors: { classifiable: string; hook: string; lifecycle: string },
+): { label: string; value: number; color: string }[] {
+  return [
+    { label: "classifiable", value: stats.classifiable, color: colors.classifiable },
+    { label: "hook wrappers", value: stats.hook, color: colors.hook },
+    { label: "non-tool / lifecycle", value: stats.lifecycle, color: colors.lifecycle },
+  ].filter((s) => s.value > 0);
+}

--- a/dashboard/src/views/Coverage.tsx
+++ b/dashboard/src/views/Coverage.tsx
@@ -4,6 +4,7 @@ import { useApp } from "@/store";
 import { G } from "@/data/tips";
 import { Tip } from "@/components/Tip";
 import { CoverageDonut } from "@/components/charts/CoverageDonut";
+import { coverageStats, effectMix } from "@/lib/coverage";
 import { CHART_FILL } from "@/components/charts/chartTheme";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -19,13 +20,14 @@ export function Coverage() {
   const { openRun } = useApp();
   const { data: runs = [], isLoading } = useRuns();
 
-  const cats = useMemo(() => {
-    const m: Record<string, number> = {};
-    runs.forEach((r) => r.events.forEach((e) => (m[e.cls.cat] = (m[e.cls.cat] || 0) + 1)));
-    return Object.entries(m)
-      .map(([k, v]) => ({ k, v }))
-      .sort((a, b) => b.v - a.v);
-  }, [runs]);
+  const events = useMemo(() => runs.flatMap((r) => r.events), [runs]);
+
+  const cats = useMemo(
+    () => effectMix(events).map(({ label, value }) => ({ k: label, v: value })),
+    [events],
+  );
+
+  const cov = useMemo(() => coverageStats(events), [events]);
 
   const candidates = useMemo(() => {
     const m: Record<string, { cat: string; min: number; n: number }> = {};
@@ -54,8 +56,6 @@ export function Coverage() {
     return g;
   }, [runs]);
 
-  const total = cats.reduce((a, c) => a + c.v, 0);
-
   if (isLoading) {
     return (
       <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
@@ -77,8 +77,15 @@ export function Coverage() {
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Classification spread</CardTitle>
-            <CardDescription>{total} events by canonical tool category.</CardDescription>
+            <Tip tip="Classification spread|Scored over CLASSIFIABLE events only — tool calls and permission requests, the events an effect (read_only / mutating / destructive) can apply to. Lifecycle and hook-wrapper events have no effect by nature, so they are excluded from the denominator rather than counted as failures.">
+              <CardTitle className="w-fit cursor-help text-base underline decoration-dotted underline-offset-4">
+                Classification spread
+              </CardTitle>
+            </Tip>
+            <CardDescription>
+              {cov.classified} of {cov.classifiable} classifiable events carry an effect ({cov.pct}
+              %).
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <CoverageDonut />
@@ -94,6 +101,13 @@ export function Coverage() {
                 </div>
               ))}
             </div>
+            {(cov.lifecycle > 0 || cov.hook > 0) && (
+              <p className="mt-3 border-t pt-3 text-[11px] leading-snug text-muted-foreground">
+                Excludes {cov.lifecycle.toLocaleString()} lifecycle
+                {cov.hook > 0 ? ` + ${cov.hook.toLocaleString()} hook-wrapper` : ""} events — no
+                effect by nature, so they are not scored here.
+              </p>
+            )}
           </CardContent>
         </Card>
 

--- a/dashboard/src/views/Fleet.tsx
+++ b/dashboard/src/views/Fleet.tsx
@@ -5,6 +5,7 @@ import { useRuns } from "@/lib/queries";
 import { useApp } from "@/store";
 import type { SortKey } from "@/store";
 import { agg, dmin, hhmm, money, tk } from "@/lib/format";
+import { coverageStats, effectMix, scopeSplit } from "@/lib/coverage";
 import { G } from "@/data/tips";
 import { KpiCard } from "@/components/KpiCard";
 import { Tip } from "@/components/Tip";
@@ -58,16 +59,23 @@ export function Fleet() {
       value: all.filter((e) => e.risk === l).length,
       color: RISK_FILL[l],
     }));
-    const cats: Record<string, number> = {};
-    all.forEach((e) => {
-      const c = e.cls?.cat || "unclassified";
-      cats[c] = (cats[c] || 0) + 1;
-    });
-    const coverage = Object.entries(cats)
-      .sort((a, b) => b[1] - a[1])
+    const cov = coverageStats(all);
+    const coverage = effectMix(all)
       .slice(0, 5)
-      .map(([label, value], i) => ({ label, value, color: CHART_FILL[i % CHART_FILL.length] }));
-    return { spendByPhase, risk, coverage };
+      .map(({ label, value }, i) => ({
+        label,
+        value,
+        color: CHART_FILL[i % CHART_FILL.length],
+      }));
+    // Lifecycle + hook-wrapper events have no effect by nature; keep them
+    // visible in their own breakdown so they never read as classification
+    // failures.
+    const scope = scopeSplit(cov, {
+      classifiable: CHART_FILL[2],
+      hook: "var(--muted-foreground)",
+      lifecycle: "var(--border)",
+    });
+    return { spendByPhase, risk, coverage, scope, cov };
   }, [runs]);
 
   const rows = useMemo(() => {
@@ -181,12 +189,35 @@ export function Fleet() {
           </Card>
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                Classification mix
-              </CardTitle>
+              <Tip tip="Classification coverage|cls.cat is an effect taxonomy (read_only / mutating / destructive) — a tool-action property. Coverage is scored over CLASSIFIABLE events only (tool calls + permissions); lifecycle and hook-wrapper events have no effect by nature and are tracked separately, not counted as failures.">
+                <CardTitle className="w-fit cursor-help text-[11px] font-medium uppercase tracking-wide text-muted-foreground underline decoration-dotted underline-offset-4">
+                  Classification mix
+                </CardTitle>
+              </Tip>
             </CardHeader>
-            <CardContent>
-              <DistBar segments={rail.coverage} />
+            <CardContent className="space-y-4">
+              <div>
+                <div className="mb-2 flex items-baseline justify-between">
+                  <span className="text-[11px] text-muted-foreground">effect coverage</span>
+                  <span className="text-sm font-semibold tabular-nums">{rail.cov.pct}%</span>
+                </div>
+                <DistBar segments={rail.coverage} />
+                <p className="mt-2 text-[11px] leading-snug text-muted-foreground">
+                  {rail.cov.classified} of {rail.cov.classifiable} classifiable events (tool calls +
+                  permissions) carry an effect.
+                </p>
+              </div>
+              {rail.scope.length > 0 && (
+                <div className="border-t pt-3">
+                  <span className="text-[11px] text-muted-foreground">event scope</span>
+                  <div className="mt-2">
+                    <DistBar segments={rail.scope} />
+                  </div>
+                  <p className="mt-1 text-[11px] leading-snug text-muted-foreground">
+                    Lifecycle and hook-wrapper events have no effect by nature — shown, not scored.
+                  </p>
+                </div>
+              )}
             </CardContent>
           </Card>
           <Card>


### PR DESCRIPTION
## Summary

The classification **Coverage** metric measured classified-vs-unclassified against **all** events. But `cls.cat` is an **effect** taxonomy (`read_only` / `mutating` / `destructive`) — an inherently tool-action property. Lifecycle events (session / turn / message / llm markers) and hook-wrapper events (`hook.*`, which duplicate the already-classified `tool.call.*` events) have **no effect by nature**, so counting them as "unclassified" made the classifier look ~82% broken on real Copilot data (74.9% on the local demo DB). This is a **framing bug**, not a classifier failure.

## Fix (frontend-only)

- New shared helper `dashboard/src/lib/coverage.ts` — single source of truth for bucketing: `classified` / `unclassified` (the two halves of the classifiable denominator) + `hook` / `lifecycle` (out of scope, kept visible).
- Denominator scoped to **classifiable** events: `tool.call.*` + `permission.*` (prefix-matched against canonical `EventKind`s).
- Lifecycle + hook events get their own labelled buckets — **shown, not scored** — so no data is hidden and they never masquerade as classification failures.
- `permission.*` events stay **in** the denominator as an honest gap now (a sibling PR adds governance classification to them; the metric stays honest before *and* after that lands).
- Classifiable events that still carry no effect (shell tools — `Bash` / `PowerShell` / `ToolSearch`, whose effect is statically indeterminate) remain a **real, visible** "unclassified" slice. The dashboard is a truth instrument: it must not paper over gaps in either direction.
- Applied consistently across the three surfaces that shared the bug: Fleet "Classification mix" rail, the `Coverage` view, and `CoverageDonut`.

## Before / after (verified end-to-end against the real `/api/runs` payload, local demo DB — 1997 events)

| | denominator | result |
|---|---|---|
| **Before** | all 1997 events | 1495 "unclassified" = **74.9%** (conflates 165 real gap + 1330 lifecycle) |
| **After** | 667 classifiable | 502 classified = **75% effect coverage**; 165 genuine shell-tool gap; 1330 lifecycle + 0 hooks surfaced in their own buckets |

The ~82% headline on the coordinator's larger Copilot DB comes from hook wrappers being ~40% of events there; this local DB has 0 hooks, so its before/after is 74.9%→75% with the honest shell-tool gap. Verification script replays `coverage.ts` bucketing over the actual backend payload; `effectMix` sums to `classifiable` and the four buckets partition all events (invariants asserted).

## Guardrails honored

- **Zero `.py` changes** (`git diff --stat`: only `coverage.ts`, `Fleet.tsx`, `Coverage.tsx`, `CoverageDonut.tsx`).
- Did **not** touch cost rendering (`format.ts` / cost cell / sort lines) — sibling PR owns that.
- Did **not** touch the conf-based "Classified %" KPI (separate metric).
- Hooks are scoped out of the denominator and collapsed in the coverage view, but **not deleted** — they remain in the raw timeline / Chapters.
- `pnpm build` clean; `pnpm lint` clean (only the pre-existing `only-export-components` warnings in badge/store/button/tabs).

Closes #177

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>