### PR TITLE
Cost honesty: render unknown cost as "—" and surface Copilot premium-request count (#176)

### DIFF
--- a/dashboard/src/components/charts/CostScatter.tsx
+++ b/dashboard/src/components/charts/CostScatter.tsx
@@ -41,7 +41,7 @@ export function CostScatter({ onPick }: { onPick: (id: string) => void }) {
     id: r.id,
     title: r.title,
     x: +(r.durMs / 60000).toFixed(1),
-    y: +r.usage.cost.toFixed(2),
+    y: +(r.usage.cost ?? 0).toFixed(2),
     z: r.events.length,
     peak: r.peak,
   }));

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -5,6 +5,20 @@ export type Dim = "phase" | "tool" | "file" | "segment" | "turn" | "retry";
 
 export const money = (n: number) => "$" + n.toFixed(2);
 export const money3 = (n: number) => "$" + n.toFixed(3);
+
+/** Render a run's dollar cost, or "—" when it is unknown. Cost is null when the
+ * wire carries no dollars (e.g. GitHub Copilot CLI emits none) — that is *unknown*,
+ * not free, so it must never render as "$0.00". A real 0 dollars (should any
+ * source ever report it) still shows "$0.00"; only null/undefined becomes "—". */
+export const fmtCost = (n: number | null | undefined) =>
+  n == null ? "—" : money(n);
+
+/** Render a run's Copilot premium-request count as "N premium request(s)", or ""
+ * when unknown (null/undefined — every non-Copilot source). A true 0 is a real
+ * "0 premium requests", distinct from unknown. */
+export const premiumReq = (n: number | null | undefined) =>
+  n == null ? "" : `${n} premium request${n === 1 ? "" : "s"}`;
+
 export const tk = (n: number) => (n >= 1000 ? (n / 1000).toFixed(1) + "k" : String(n));
 export const hhmm = (d: Date) => d.toTimeString().slice(0, 8);
 export const dmin = (ms: number) =>

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -98,7 +98,12 @@ export interface Run {
   live: boolean;
   segs: Seg[];
   events: TEvent[];
-  usage: { in: number; out: number; cost: number };
+  // `cost` is null when the run carries no dollar cost on the wire (e.g. GitHub
+  // Copilot CLI, which emits no dollars at all) — rendered as "—" (unknown), never
+  // a fake "$0.00". `premiumRequests` is Copilot's only real billing signal: the
+  // per-run premium-request count (summed across models); null when unknown, a
+  // true 0 when the run genuinely made none.
+  usage: { in: number; out: number; cost: number | null; premiumRequests: number | null };
   started: Date;
   durMs: number;
   // null when no cross-session drift baseline has been recorded for the run (it

--- a/dashboard/src/views/Cost.tsx
+++ b/dashboard/src/views/Cost.tsx
@@ -42,7 +42,9 @@ export function Cost() {
       const o = (m[r.model] ||= { calls: 0, tokens: 0, cost: 0 });
       o.calls += r.events.length;
       o.tokens += r.usage.in + r.usage.out;
-      o.cost += r.usage.cost;
+      // Unknown cost (null — e.g. Copilot carries no dollars) adds nothing to the
+      // per-model dollar total rather than NaN-poisoning it.
+      o.cost += r.usage.cost ?? 0;
     });
     return Object.entries(m).sort((a, b) => b[1].cost - a[1].cost);
   }, [runs]);

--- a/dashboard/src/views/Fleet.tsx
+++ b/dashboard/src/views/Fleet.tsx
@@ -4,7 +4,7 @@ import { RISK } from "@/lib/types";
 import { useRuns } from "@/lib/queries";
 import { useApp } from "@/store";
 import type { SortKey } from "@/store";
-import { agg, dmin, hhmm, money, tk } from "@/lib/format";
+import { agg, dmin, fmtCost, hhmm, money, premiumReq, tk } from "@/lib/format";
 import { coverageStats, effectMix, scopeSplit } from "@/lib/coverage";
 import { G } from "@/data/tips";
 import { KpiCard } from "@/components/KpiCard";
@@ -44,7 +44,10 @@ export function Fleet() {
     return {
       live: runs.filter((r) => r.live).length,
       runs: runs.length,
-      spend: runs.reduce((a, r) => a + r.usage.cost, 0),
+      // Fleet-wide dollar spend sums only the runs that carry real dollars; runs
+      // with unknown cost (null — e.g. Copilot) contribute nothing rather than
+      // poisoning the total with NaN. It stays an honest sum of what's known.
+      spend: runs.reduce((a, r) => a + (r.usage.cost ?? 0), 0),
       tokens: runs.reduce((a, r) => a + r.usage.in + r.usage.out, 0),
       classifiedPct: Math.round((classified / (all.length || 1)) * 100),
       triage: runs.filter((r) => r.peak >= 2).length,
@@ -88,8 +91,12 @@ export function Fleet() {
         r.agent.toLowerCase().includes(q)
     );
     list = [...list].sort((a, b) => {
-      if (sort === "risk") return b.peak - a.peak || b.usage.cost - a.usage.cost;
-      if (sort === "cost") return b.usage.cost - a.usage.cost;
+      // Unknown cost (null) sorts below any real dollar amount (which is always
+      // >= 0) instead of being treated as 0, so a Copilot run with no dollars
+      // doesn't masquerade as the cheapest — it sinks to the bottom.
+      const cost = (r: (typeof list)[number]) => r.usage.cost ?? -1;
+      if (sort === "risk") return b.peak - a.peak || cost(b) - cost(a);
+      if (sort === "cost") return cost(b) - cost(a);
       return b.started.getTime() - a.started.getTime();
     });
     return list;
@@ -332,7 +339,14 @@ export function Fleet() {
                     </div>
                   </TableCell>
                   <TableCell className="text-right tabular-nums">{r.events.length}</TableCell>
-                  <TableCell className="text-right tabular-nums">{money(r.usage.cost)}</TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    <div>{fmtCost(r.usage.cost)}</div>
+                    {r.usage.premiumRequests != null && (
+                      <div className="text-[11px] text-muted-foreground">
+                        {premiumReq(r.usage.premiumRequests)}
+                      </div>
+                    )}
+                  </TableCell>
                   <TableCell className="text-right tabular-nums text-muted-foreground">
                     {dmin(r.durMs)}
                   </TableCell>

--- a/dashboard/src/views/RunView.tsx
+++ b/dashboard/src/views/RunView.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, ArrowLeft, ChevronRight, FileText } from "lucide-react";
 import { useRuns } from "@/lib/queries";
 import type { TEvent } from "@/lib/types";
 import { useApp } from "@/store";
-import { dmin, hhmm, money, money3, fmtVal } from "@/lib/format";
+import { dmin, hhmm, money3, fmtCost, fmtVal, premiumReq } from "@/lib/format";
 import { buildChapters, locateEvent } from "@/lib/chapters";
 import { G, mtip } from "@/data/tips";
 import { Tip } from "@/components/Tip";
@@ -56,7 +56,13 @@ export function RunView() {
             <span>·</span>
             <span>{dmin(run.durMs)}</span>
             <span>·</span>
-            <span>{money(run.usage.cost)}</span>
+            <span>{fmtCost(run.usage.cost)}</span>
+            {run.usage.premiumRequests != null && (
+              <>
+                <span>·</span>
+                <span>{premiumReq(run.usage.premiumRequests)}</span>
+              </>
+            )}
           </div>
         </div>
         <Button variant="outline" size="sm" onClick={back} className="shrink-0">
@@ -89,7 +95,9 @@ export function RunView() {
           <div className="flex justify-between text-[10.5px] text-muted-foreground">
             <span>{hhmm(evs[0].t)}</span>
             <span>
-              {evs.length} events · {money(run.usage.cost)} total
+              {evs.length} events · {fmtCost(run.usage.cost)} total
+              {run.usage.premiumRequests != null &&
+                ` · ${premiumReq(run.usage.premiumRequests)}`}
             </span>
             <span>{hhmm(evs[evs.length - 1].t)}</span>
           </div>

--- a/src/traceforge/cli/watch.py
+++ b/src/traceforge/cli/watch.py
@@ -469,6 +469,24 @@ def _usage_record_from(event) -> "UsageRecord | None":
         return None
 
     cost = payload.get("cost_usd")
+    attributes: dict[str, int] = {
+        "input_uncached": input_uncached,
+        "cache_read_tokens": cache_read,
+        "cache_creation_tokens": cache_write,
+    }
+    # Copilot's per-model ``modelMetrics.requests`` counts (the only real billing
+    # signal on the wire — ``requests.cost`` is a premium-request *count*, not
+    # dollars) ride the synthetic usage payload. Preserve them losslessly so the
+    # dashboard can surface "N premium requests" where a fake "$0.00" once sat. A
+    # genuine ``0`` is a real zero and kept; absent keys (every non-Copilot source)
+    # add nothing, so ``attributes`` stays exactly the token split there.
+    premium_requests = payload.get("premium_requests")
+    if premium_requests is not None:
+        attributes["premium_requests"] = int(premium_requests)
+    requests_total = payload.get("requests_total")
+    if requests_total is not None:
+        attributes["requests_total"] = int(requests_total)
+
     return UsageRecord(
         session_id=event.session_id,
         timestamp=event.timestamp,
@@ -476,11 +494,7 @@ def _usage_record_from(event) -> "UsageRecord | None":
         input_tokens=total_input,
         output_tokens=output_tokens,
         cost_usd=float(cost) if cost is not None else None,
-        attributes={
-            "input_uncached": input_uncached,
-            "cache_read_tokens": cache_read,
-            "cache_creation_tokens": cache_write,
-        },
+        attributes=attributes,
     )
 
 

--- a/src/traceforge/dashboard/repository.py
+++ b/src/traceforge/dashboard/repository.py
@@ -257,7 +257,7 @@ class DashboardRepository:
             usage = conn.execute(
                 """SELECT COALESCE(SUM(input_tokens), 0)  AS in_tok,
                           COALESCE(SUM(output_tokens), 0) AS out_tok,
-                          COALESCE(SUM(cost_usd), 0.0)    AS cost
+                          SUM(cost_usd)                   AS cost
                      FROM usage_records
                     WHERE session_id = ?""",
                 (session_id,),
@@ -294,7 +294,14 @@ class DashboardRepository:
                 "usage": {
                     "in": int(usage["in_tok"]),
                     "out": int(usage["out_tok"]),
-                    "cost": float(usage["cost"]),
+                    # Copilot carries no dollar cost on the wire; ``SUM(cost_usd)``
+                    # is NULL only when NO usage row for the run has real dollars.
+                    # Pass that through as null (not 0.0) so the frontend renders
+                    # "—" (unknown), never a fake "$0.00" that reads as free.
+                    "cost": float(usage["cost"]) if usage["cost"] is not None else None,
+                    # The one real Copilot billing signal: premium-request count
+                    # summed across models (null when unknown, a true 0 otherwise).
+                    "premiumRequests": _premium_requests(conn, session_id),
                 },
                 "started": event_rows[0]["timestamp"],
                 "durMs": dur_ms,
@@ -334,7 +341,7 @@ class DashboardRepository:
             usage = conn.execute(
                 """SELECT COALESCE(SUM(input_tokens), 0)  AS in_tok,
                           COALESCE(SUM(output_tokens), 0) AS out_tok,
-                          COALESCE(SUM(cost_usd), 0.0)    AS cost
+                          SUM(cost_usd)                   AS cost
                      FROM usage_records
                     WHERE session_id = ?""",
                 (session_id,),
@@ -350,6 +357,7 @@ class DashboardRepository:
                 (session_id,),
             ).fetchone()
             dominant_model = _dominant_model(conn, session_id)
+            premium_requests = _premium_requests(conn, session_id)
         finally:
             conn.close()
 
@@ -369,7 +377,8 @@ class DashboardRepository:
             "usage": {
                 "in": int(usage["in_tok"]),
                 "out": int(usage["out_tok"]),
-                "cost": float(usage["cost"]),
+                "cost": float(usage["cost"]) if usage["cost"] is not None else None,
+                "premiumRequests": premium_requests,
             },
             "started": agg["first_ts"],
             "durMs": dur_ms,
@@ -715,6 +724,39 @@ def _dominant_model(conn: sqlite3.Connection, session_id: str) -> str:
         (session_id,),
     ).fetchone()
     return row["model"] if row else ""
+
+
+def _premium_requests(conn: sqlite3.Connection, session_id: str) -> int | None:
+    """Sum the run's Copilot premium-request count, or ``None`` when unknown.
+
+    GitHub Copilot's per-model ``modelMetrics.requests.cost`` is a
+    premium-request *count* (not dollars); the copilot preprocessor stashes it in
+    each ``usage_records`` row's ``attributes_json`` under ``premium_requests``.
+    This sums it across the run's models. The unknown/zero distinction is real and
+    preserved: a run whose usage rows never carry the key (every non-Copilot
+    source) returns ``None`` (surfaced as "—", not "0 premium requests"), while a
+    Copilot run that genuinely made zero premium requests returns ``0`` (a true
+    zero). ``cost_usd`` stays null throughout — no dollars are ever derived from
+    the count.
+    """
+    rows = conn.execute(
+        """SELECT attributes_json FROM usage_records
+            WHERE session_id = ? AND attributes_json IS NOT NULL""",
+        (session_id,),
+    ).fetchall()
+    total: int | None = None
+    for row in rows:
+        try:
+            attrs = json.loads(row["attributes_json"])
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(attrs, dict) or "premium_requests" not in attrs:
+            continue
+        value = attrs["premium_requests"]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            continue
+        total = (total or 0) + int(value)
+    return total
 
 
 def _session_title(seg_rows: list[sqlite3.Row]) -> str | None:

--- a/src/traceforge/mappings/copilot.yaml
+++ b/src/traceforge/mappings/copilot.yaml
@@ -199,7 +199,11 @@ events:
   # ``UsageRecord.attributes``.
   # ``msg_id`` (``<shutdown-id>:<model>``) dedups a replayed shutdown. No dollar
   # cost exists in the wire, so ``cost_usd`` stays null. ``cost``/``duration`` remain
-  # mapped for back-compat with producers that carry them.
+  # mapped for back-compat with producers that carry them. ``premiumRequests`` /
+  # ``requestsTotal`` carry the one real billing signal Copilot emits — the
+  # per-model ``modelMetrics.requests`` counts (``cost`` is a premium-request
+  # *count*, not dollars) — which the bridge stashes in ``UsageRecord.attributes``
+  # so the dashboard can surface "N premium requests" instead of a fake "$0.00".
   assistant.usage:
     kind: telemetry.usage
     payload:
@@ -211,6 +215,8 @@ events:
       cost_usd: data.cost
       duration_ms: data.duration
       msg_id: data.messageId
+      premium_requests: data.premiumRequests
+      requests_total: data.requestsTotal
 
   # ── Hooks ──────────────────────────────────────────────────────────────────
   hook.start:

--- a/src/traceforge/preprocessors/copilot.py
+++ b/src/traceforge/preprocessors/copilot.py
@@ -52,7 +52,8 @@ def preprocess_copilot(obj: dict[str, Any]) -> list[dict[str, Any]]:
         usage = entry.get("usage")
         if not isinstance(usage, dict):
             continue
-        usage_blocks.append(_usage_block(str(model), usage, shutdown_id, timestamp))
+        requests = entry.get("requests")
+        usage_blocks.append(_usage_block(str(model), usage, requests, shutdown_id, timestamp))
 
     return [obj, *usage_blocks]
 
@@ -79,7 +80,7 @@ def _decode_model_metrics(raw: Any) -> dict[str, Any]:
 
 
 def _usage_block(
-    model: str, usage: dict[str, Any], shutdown_id: str, timestamp: Any
+    model: str, usage: dict[str, Any], requests: Any, shutdown_id: str, timestamp: Any
 ) -> dict[str, Any]:
     """Build one synthetic ``assistant.usage`` event for a single model.
 
@@ -99,8 +100,19 @@ def _usage_block(
     equal Copilot's own reported ``inputTokens`` and keeps the split faithful in
     ``UsageRecord.attributes``. ``reasoningTokens`` is not surfaced separately
     (Copilot reports it as ``0`` and the provider folds reasoning into output
-    accounting). No dollar cost exists in the wire (``requests.cost`` is a
-    premium-request count), so none is emitted and ``cost_usd`` stays null.
+    accounting).
+
+    No dollar cost exists in the wire, so none is emitted and ``cost_usd`` stays
+    null. The one real billing signal Copilot carries is the per-model
+    ``requests`` block: ``requests.cost`` is a **premium-request count** (not
+    dollars — included models like haiku/sonnet stay ``0`` even at high volume;
+    only premium models such as opus accrue) and ``requests.count`` is the total
+    request count. Both are captured here (as ``premiumRequests`` /
+    ``requestsTotal``) so the bridge can stash them in ``UsageRecord.attributes``
+    and the dashboard can surface "N premium requests" instead of a fake "$0.00".
+    A genuine ``0`` premium count is preserved (it is a real zero); a missing or
+    malformed ``requests`` block yields no keys at all (honest-blank, never
+    fabricated).
     """
     input_total = _as_int(usage.get("inputTokens"))
     cache_read = _as_int(usage.get("cacheReadTokens"))
@@ -110,18 +122,23 @@ def _usage_block(
         input_uncached = 0
 
     msg_id = f"{shutdown_id}:{model}"
-    block: dict[str, Any] = {
-        "type": "assistant.usage",
-        "id": msg_id,
-        "data": {
-            "model": model,
-            "inputTokens": input_uncached,
-            "outputTokens": _as_int(usage.get("outputTokens")),
-            "cacheReadTokens": cache_read,
-            "cacheWriteTokens": cache_write,
-            "messageId": msg_id,
-        },
+    data: dict[str, Any] = {
+        "model": model,
+        "inputTokens": input_uncached,
+        "outputTokens": _as_int(usage.get("outputTokens")),
+        "cacheReadTokens": cache_read,
+        "cacheWriteTokens": cache_write,
+        "messageId": msg_id,
     }
+    if isinstance(requests, dict):
+        premium = _as_int_opt(requests.get("cost"))
+        if premium is not None:
+            data["premiumRequests"] = premium
+        total = _as_int_opt(requests.get("count"))
+        if total is not None:
+            data["requestsTotal"] = total
+
+    block: dict[str, Any] = {"type": "assistant.usage", "id": msg_id, "data": data}
     if timestamp is not None:
         block["timestamp"] = timestamp
     return block
@@ -135,3 +152,18 @@ def _as_int(value: Any) -> int:
         return int(value)
     except (ValueError, TypeError):
         return 0
+
+
+def _as_int_opt(value: Any) -> int | None:
+    """Coerce to ``int``, or ``None`` for missing/malformed values.
+
+    Unlike :func:`_as_int`, a genuine ``0`` is preserved and an absent value stays
+    ``None`` — so the premium/total request counts are captured as real zeros
+    without a missing block being fabricated into ``0``.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None

--- a/tests/e2e/test_copilot_identity_cost_enrichment.py
+++ b/tests/e2e/test_copilot_identity_cost_enrichment.py
@@ -226,6 +226,10 @@ def test_usage_input_breakdown_is_preserved(tmp_path, monkeypatch) -> None:
         "input_uncached": 29824,
         "cache_read_tokens": 7058,
         "cache_creation_tokens": 0,
+        # The premium-request COUNT (the only real billing signal Copilot emits) is
+        # captured losslessly. requests.cost is a premium-request count, NOT dollars.
+        "premium_requests": 1,
+        "requests_total": 1,
     }
 
 
@@ -253,7 +257,7 @@ def test_usage_stays_off_the_enriched_timeline(tmp_path, monkeypatch) -> None:
 
 
 def test_build_run_surfaces_repo_model_and_usage(tmp_path, monkeypatch) -> None:
-    """build_run returns non-empty repo + model + usage per run, cost honestly 0.0."""
+    """build_run returns non-empty repo + model + usage per run; cost honestly None."""
     db_path = _run_once(tmp_path, monkeypatch)
 
     paths = resolve_paths(output_db=db_path, system_db=tmp_path / "system.db")
@@ -265,12 +269,15 @@ def test_build_run_surfaces_repo_model_and_usage(tmp_path, monkeypatch) -> None:
     assert run_a["model"] == "claude-sonnet-4.5"
     assert run_a["usage"]["in"] == 36882
     assert run_a["usage"]["out"] == 354
-    # No wire cost → COALESCE(SUM(NULL), 0.0) → 0.0 (no NaN, no crash).
-    assert run_a["usage"]["cost"] == 0.0
+    # No wire cost → SUM(NULL) → None (honest "unknown", NOT a fabricated $0.00).
+    assert run_a["usage"]["cost"] is None
+    # The premium-request count IS surfaced (1 per the seeded modelMetrics).
+    assert run_a["usage"]["premiumRequests"] == 1
 
     run_b = repo.build_run(_UUID_B)
     assert run_b is not None
     assert run_b["repo"] == "/home/user/project-b"
     assert run_b["model"] == "gpt-5"
     assert run_b["usage"]["in"] == 100
-    assert run_b["usage"]["cost"] == 0.0
+    assert run_b["usage"]["cost"] is None
+    assert run_b["usage"]["premiumRequests"] == 1

--- a/tests/e2e/test_dashboard_repository.py
+++ b/tests/e2e/test_dashboard_repository.py
@@ -262,7 +262,7 @@ async def test_list_runs_summarizes_identity_and_usage(full_repo: DashboardRepos
     assert run["model"] == "gpt-4o"
     assert run["title"] == "Refactor auth"
     assert run["live"] is True
-    assert run["usage"] == {"in": 1000, "out": 500, "cost": 0.9}
+    assert run["usage"] == {"in": 1000, "out": 500, "cost": 0.9, "premiumRequests": None}
     assert run["drift"] == 0.42
     assert run["peak"] == 3  # critical
     assert run["eventCount"] == 2
@@ -278,7 +278,7 @@ async def test_build_run_core_fields(full_repo: DashboardRepository) -> None:
     assert run["live"] is True
     assert run["drift"] == 0.42
     assert run["peak"] == 3
-    assert run["usage"] == {"in": 1000, "out": 500, "cost": 0.9}
+    assert run["usage"] == {"in": 1000, "out": 500, "cost": 0.9, "premiumRequests": None}
     assert len(run["events"]) == 2
 
 
@@ -332,6 +332,97 @@ async def test_build_run_segments_and_gaps(full_repo: DashboardRepository) -> No
 
 async def test_build_run_unknown_session_returns_none(full_repo: DashboardRepository) -> None:
     assert full_repo.build_run("does-not-exist") is None
+
+
+def _bare_event_for(session_id: str, ts: datetime) -> SessionEvent:
+    """A minimal low-risk event for an arbitrary session (build_run needs ≥1 event)."""
+    risk = RiskAssessment(
+        score=4, level="safe", confidence="low", factors=(), mitre=(), version="risk-v2"
+    )
+    gov = SessionMeta(classification=None, risk_assessment=risk)
+    return SessionEvent(
+        kind=EventKind.TOOL_CALL_STARTED,
+        session_id=session_id,
+        timestamp=ts,
+        payload={"tool_name": "git"},
+        metadata=EventMetadata(governance=gov),
+    )
+
+
+async def _seed_premium(db: Path) -> None:
+    """Seed Copilot-shaped runs: no dollars, premium-request COUNTS in attributes."""
+    sink = SqliteOutputSink(path=str(db))
+    # Run with premium activity across two models: counts 12 + 3 = 15, cost NULL.
+    for model, premium, total in (("claude-opus-4.6", 12, 22), ("claude-opus-4.6", 3, 34)):
+        await sink.on_event(_bare_event_for("cop-premium", _T0))
+        await sink.on_usage(
+            UsageRecord(
+                session_id="cop-premium",
+                timestamp=_T0,
+                model=model,
+                input_tokens=100,
+                output_tokens=20,
+                cost_usd=None,
+                attributes={
+                    "input_uncached": 100,
+                    "cache_read_tokens": 0,
+                    "cache_creation_tokens": 0,
+                    "premium_requests": premium,
+                    "requests_total": total,
+                },
+            )
+        )
+    # Run that genuinely made ZERO premium requests (included model) — a real 0.
+    await sink.on_event(_bare_event_for("cop-zero", _T0))
+    await sink.on_usage(
+        UsageRecord(
+            session_id="cop-zero",
+            timestamp=_T0,
+            model="claude-haiku-4.5",
+            input_tokens=100,
+            output_tokens=20,
+            cost_usd=None,
+            attributes={
+                "input_uncached": 100,
+                "cache_read_tokens": 0,
+                "cache_creation_tokens": 0,
+                "premium_requests": 0,
+                "requests_total": 38,
+            },
+        )
+    )
+    await sink.close()
+
+
+async def test_premium_requests_surface_with_null_cost_and_zero_distinct(tmp_path: Path) -> None:
+    """cost stays None (unknown), while the premium-request COUNT is surfaced.
+
+    Also guards the unknown-vs-real-0 distinction: a run that never carries the
+    premium key surfaces ``None`` (→ "—"), a run that genuinely made 0 premium
+    requests surfaces ``0`` (→ "0 premium requests").
+    """
+    out = tmp_path / "traceforge.db"
+    await _seed_premium(out)
+    repo = DashboardRepository(DashboardPaths(output_db=out, system_db=tmp_path / "absent.db"))
+
+    premium_run = repo.build_run("cop-premium")
+    assert premium_run is not None
+    # No dollars are ever fabricated from the premium count.
+    assert premium_run["usage"]["cost"] is None
+    # Premium counts sum across the run's models (12 + 3).
+    assert premium_run["usage"]["premiumRequests"] == 15
+
+    zero_run = repo.build_run("cop-zero")
+    assert zero_run is not None
+    assert zero_run["usage"]["cost"] is None
+    # A genuine zero — distinct from unknown.
+    assert zero_run["usage"]["premiumRequests"] == 0
+
+    # And via the list/summary path, the same honesty holds.
+    summaries = {r["id"]: r for r in repo.list_runs()}
+    assert summaries["cop-premium"]["usage"]["premiumRequests"] == 15
+    assert summaries["cop-premium"]["usage"]["cost"] is None
+    assert summaries["cop-zero"]["usage"]["premiumRequests"] == 0
 
 
 async def test_degraded_mode_without_system_db(tmp_path: Path) -> None:

--- a/tests/e2e/test_identity_cost_enrichment.py
+++ b/tests/e2e/test_identity_cost_enrichment.py
@@ -161,5 +161,5 @@ def test_build_run_surfaces_repo_model_and_usage(tmp_path, monkeypatch) -> None:
     assert run["model"] == _EXPECTED_MODEL
     assert run["usage"]["in"] == _EXPECTED_SUM_INPUT
     assert run["usage"]["out"] == _EXPECTED_SUM_OUTPUT
-    # No wire cost → COALESCE(SUM(NULL), 0.0) → 0.0 (no NaN, no crash).
-    assert run["usage"]["cost"] == 0.0
+    # No wire cost → SUM(NULL) → None (honest "unknown", NOT a fabricated $0.00).
+    assert run["usage"]["cost"] is None

--- a/tests/unit/test_copilot_identity_cost_enrichment.py
+++ b/tests/unit/test_copilot_identity_cost_enrichment.py
@@ -144,6 +144,43 @@ def test_preprocessor_skips_blank_model_and_missing_usage() -> None:
     assert [b["type"] for b in blocks] == ["session.shutdown"]
 
 
+def test_preprocessor_captures_premium_request_counts() -> None:
+    # ``requests.cost`` is a premium-request COUNT (not dollars) and ``requests.count``
+    # is the total request count. Both must ride the synthetic usage block so the
+    # bridge can stash them and the dashboard can show "N premium requests".
+    blocks = preprocess_copilot(
+        _shutdown({_MODEL: {"usage": dict(_USAGE), "requests": {"count": 40, "cost": 3}}})
+    )
+    usage = blocks[-1]
+    assert usage["data"]["premiumRequests"] == 3
+    assert usage["data"]["requestsTotal"] == 40
+
+
+def test_preprocessor_preserves_genuine_zero_premium_count() -> None:
+    # Included models (haiku/sonnet) stay at 0 premium even at high volume — a real
+    # zero, distinct from "unknown". It must be captured, not dropped.
+    blocks = preprocess_copilot(
+        _shutdown({_MODEL: {"usage": dict(_USAGE), "requests": {"count": 144, "cost": 0}}})
+    )
+    usage = blocks[-1]
+    assert usage["data"]["premiumRequests"] == 0
+    assert usage["data"]["requestsTotal"] == 144
+
+
+def test_preprocessor_omits_premium_keys_when_requests_absent_or_malformed() -> None:
+    # No ``requests`` block → no keys (honest-blank, never fabricated into 0).
+    no_req = preprocess_copilot(_shutdown({_MODEL: {"usage": dict(_USAGE)}}))[-1]["data"]
+    assert "premiumRequests" not in no_req
+    assert "requestsTotal" not in no_req
+
+    # A malformed ``requests`` block (non-dict, or non-numeric fields) adds nothing.
+    bad = preprocess_copilot(
+        _shutdown({_MODEL: {"usage": dict(_USAGE), "requests": {"count": "x", "cost": None}}})
+    )[-1]["data"]
+    assert "premiumRequests" not in bad
+    assert "requestsTotal" not in bad
+
+
 # ─── Adapter (repo_field → EventMetadata.repo) ───────────────────────────────
 
 
@@ -178,6 +215,23 @@ def test_adapter_maps_synthetic_usage_to_telemetry_usage() -> None:
 
     # The shutdown itself still maps to session.ended (rides the timeline).
     assert any(e.kind == EventKind.SESSION_ENDED for e in events)
+
+
+def test_adapter_maps_premium_requests_into_payload() -> None:
+    adapter = _copilot_adapter()
+    events = list(
+        adapter.parse_dict(
+            _shutdown({_MODEL: {"usage": dict(_USAGE), "requests": {"count": 40, "cost": 3}}})
+        )
+    )
+    usage_events = [e for e in events if e.kind == EventKind.USAGE]
+    assert len(usage_events) == 1
+    payload = usage_events[0].payload
+    # The premium-request count + total ride the payload for the watch bridge.
+    assert payload["premium_requests"] == 3
+    assert payload["requests_total"] == 40
+    # Still no dollar cost synthesized.
+    assert "cost_usd" not in payload
 
 
 # ─── _feed_line (copilot-shaped: aggregate + dedup + off-timeline) ────────────
@@ -226,3 +280,27 @@ def test_feed_line_builds_aggregated_usage_off_timeline_and_dedups() -> None:
     # Off-timeline: session.ended rides the timeline; the usage event never does.
     assert all(e.kind != EventKind.USAGE for e in pipeline.pushed)
     assert any(e.kind == EventKind.SESSION_ENDED for e in pipeline.pushed)
+
+
+def test_feed_line_stashes_premium_request_counts_in_attributes() -> None:
+    adapter = _copilot_adapter("cp-sess")
+    pipeline = _RecordingPipeline()
+    seen: set[str] = set()
+
+    line = json.dumps(
+        _shutdown({_MODEL: {"usage": dict(_USAGE), "requests": {"count": 40, "cost": 3}}})
+    )
+    asyncio.run(watch_mod._feed_line(line, adapter, pipeline, seen))
+
+    assert len(pipeline.usage) == 1
+    record = pipeline.usage[0]
+    # cost_usd is still honestly None — the premium COUNT is not dollars.
+    assert record.cost_usd is None
+    # The token split is preserved AND the premium/total counts are stashed alongside.
+    assert record.attributes == {
+        "input_uncached": _UNCACHED,
+        "cache_read_tokens": _CACHE_READ,
+        "cache_creation_tokens": 0,
+        "premium_requests": 3,
+        "requests_total": 40,
+    }


### PR DESCRIPTION
## Why

The dashboard rendered run cost as **"$0.00" everywhere**, which reads as *"this run was free."* It wasn't — GitHub Copilot CLI simply carries **no dollar cost on the wire**. The only cost-ish field is `session.shutdown.data.modelMetrics.<model>.requests.cost`, which is a **premium-request COUNT, not dollars** (verified: included models like haiku/sonnet stay `0` even at 120k+ requests; only premium models like opus accrue). So `cost_usd = None` is the honest, correct value — and it was being papered over into `0.0`.

## What changed (cost honesty only)

**Defect 1 — dashboard papering (null cost rendered as $0.00)**
- `repository.py`: `build_run` + `_run_summary` now pass run cost through as **null** (dropped `COALESCE(SUM(cost_usd), 0.0)`). `SUM(cost_usd)` is NULL only when *no* usage row carries real dollars, so unknown-dollars stays distinct from a real `$0`.
- `types.ts`: `usage.cost` is now `number | null`.
- `format.ts`: new pure `fmtCost(n)` → `"—"` when null (the regression guard — no JS test harness in `dashboard/`), plus `premiumReq(n)`.
- Rendered `"—"` for unknown cost everywhere it shows: Fleet cost cell **and** the cost **sort** (nulls sort to the bottom via `?? -1`, never as 0), RunView header + rewind footer, and null-safe aggregates in `Cost.tsx` / `CostScatter.tsx` and the Fleet spend KPI (`?? 0`).

**Defect 2 — discarded billing signal (premium-request count)**
- `preprocessors/copilot.py`: capture the per-model `modelMetrics.requests` — `cost` (premium-request count) and `count` (total) — into the synthetic usage block as `premiumRequests` / `requestsTotal`. A genuine `0` is preserved (real zero); a missing/malformed `requests` block yields **no** keys (honest-blank, never fabricated).
- `mappings/copilot.yaml` + `cli/watch.py`: flow those through to `usage_records.attributes_json` as `premium_requests` / `requests_total`.
- `repository.py`: new `_premium_requests()` sums the count across a run's models → `usage.premiumRequests`. Unknown (no Copilot key on any row) → `null` → "—"; a Copilot run that genuinely made 0 premium requests → `0` → "0 premium requests" (distinct from unknown).
- Surfaced as **"N premium requests"** where the fake `$0.00` sat (Fleet cost cell, RunView).

**Design decision (settled by coordinator, not re-litigated):** surface the premium-request count; `cost_usd` stays `None`; **no price table, no dollars derived from the count.**

## Verification

**Isolated real-data re-ingest** — 60 real `~/.copilot/session-state/<uuid>/events.jsonl` sessions re-ingested through the production pipeline into a **TEMP `SqliteOutputSink`** (live `~/.traceforge` untouched):
- `usage_records` rows: **528**, rows with non-null `cost_usd`: **0** → cost stays NULL, no fabricated dollars.
- Premium capture matched raw ground truth on **60/60 sessions, 0 mismatches** (summed `premium_requests` == Σ `modelMetrics.<m>.requests.cost`; `requests_total` == Σ `requests.count`).
- Real-world accrual pattern reproduced faithfully, e.g. `claude-opus-4.8` premium=122805 while `claude-sonnet-4.6`/`claude-haiku-4.5` premium=**0** at 81k+ total requests — only premium models accrue.

**Suite / lint (all green):**
- `pytest`: **3549 passed, 8 skipped** (added unit tests for the preprocessor capture, adapter mapping, watch-bridge attributes, and the repository null-vs-real-0 distinction; updated the Copilot/Claude e2e cost assertions from `0.0` → `None`).
- `ruff check .` clean; `ruff format --check .` clean (461 files, ruff 0.15.20).
- Frontend `pnpm build` (tsc -b + vite) + `pnpm lint` (oxlint) clean — no new warnings beyond the pre-existing `only-export-components` ones.

## Scope notes
- **Cost honesty only.** Did not touch the classification/coverage metric or permission-event classification (sibling PRs). Rebased onto current `main` (which now includes the coverage PR #178); the one Fleet.tsx merge conflict was an import line — resolved keeping both.
- Left **event-level** `TEvent.cost` (and the Spend KPI / SpendArea / AttributionBars that aggregate it) unchanged to avoid a broad ripple; only run-level `usage.cost` was made nullable.

Closes #176

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>