### PR TITLE
Classify Copilot permission gates instead of dropping them (#180)

### DIFF
--- a/src/traceforge/classify/__init__.py
+++ b/src/traceforge/classify/__init__.py
@@ -35,6 +35,7 @@ from traceforge.classify.mcp import (
     classify_mcp_tool,
     extract_mcp_namespace,
 )
+from traceforge.classify.permission import classify_permission
 from traceforge.classify.powershell import classify_powershell_command
 from traceforge.classify.registry import DimensionRegistry, get_default_registry
 from traceforge.classify.risk import Confidence, RiskAssessment, assess_risk, assess_tool_risk
@@ -84,6 +85,7 @@ __all__ = [
     "classify_powershell_command",
     "classify_tool",
     "classify_mcp_tool",
+    "classify_permission",
     "extract_mcp_namespace",
     "McpServerProfile",
     "McpToolOverride",

--- a/src/traceforge/classify/permission.py
+++ b/src/traceforge/classify/permission.py
@@ -1,0 +1,89 @@
+"""Classification of permission-gate events by requested capability kind.
+
+Coding agents such as GitHub Copilot CLI emit a *permission gate* immediately
+before a privileged action, carrying the requested capability ``kind`` (read /
+write / shell / …) plus the intention and target of the action it protects.
+These gates are exactly the read/write/execute actions the governance layer
+exists to score, yet — unlike the tool call they precede — they historically
+landed unclassified.
+
+:func:`classify_permission` derives a :class:`Classification` from that ``kind``
+alone, mirroring the shape :func:`traceforge.classify.tools.classify_tool`
+produces for the equivalent tool. It is framework-agnostic: any adapter that
+maps a permission event's requested kind onto the canonical ``permission_kind``
+payload key benefits.
+
+Honesty rules (no fabrication):
+  * ``shell`` gates get ``effect=None`` — a shell command's read/write/destroy
+    effect depends on the specific command and its arguments, which a bare
+    permission gate does not statically determine. Mechanism/role/action/
+    capability still mark it as a classified subprocess-execution gate.
+  * ``write`` is ``mutating``, never ``destructive`` — a file edit is reversible
+    (e.g. via version control); ``destructive`` is reserved for irreversible
+    deletes. We do NOT inspect the diff to guess destructiveness, as that is not
+    reliably derivable from the gate.
+  * Absent or unrecognized kinds (including ``extension-permission-access``,
+    which carries no comparable read/write/execute semantics) return ``None`` so
+    the gate stays honestly unclassified rather than being assigned a made-up
+    effect.
+"""
+
+from __future__ import annotations
+
+from traceforge.classify.coding import CodingAction, CodingMechanism, CodingRole, CodingScope
+from traceforge.classify.core import Capability, Classification, Effect, Mechanism
+from traceforge.classify.phases import with_phase_map as _with_phase_map
+
+# Canonical Copilot permission kinds → base Classification (before phase_map /
+# path-based scope refinement, which the caller applies). ``None`` entries mark
+# kinds that are recognized but intentionally left effect-blank at build time.
+_PERMISSION_CLASSIFICATIONS: dict[str, Classification] = {
+    "read": Classification(
+        mechanism=Mechanism.FILESYSTEM,
+        effect=Effect.READ_ONLY,
+        scope=frozenset({CodingScope.SOURCE_CODE}),
+        role=frozenset({CodingRole.FILE_BROWSER}),
+        action=frozenset({CodingAction.READ}),
+        capability=frozenset({Capability.FILESYSTEM_READ}),
+    ),
+    "write": Classification(
+        mechanism=Mechanism.FILESYSTEM,
+        effect=Effect.MUTATING,
+        scope=frozenset({CodingScope.SOURCE_CODE}),
+        role=frozenset({CodingRole.FILE_EDITOR}),
+        action=frozenset({CodingAction.WRITE}),
+        capability=frozenset({Capability.FILESYSTEM_WRITE}),
+    ),
+    # Shell effect is deliberately None: the gate authorizes running *a* command
+    # but does not statically reveal whether it reads, writes, or destroys.
+    "shell": Classification(
+        mechanism=CodingMechanism.PROCESS_SHELL,
+        effect=None,
+        role=frozenset({CodingRole.SCRIPT_RUNNER}),
+        action=frozenset({CodingAction.RUN_COMMAND}),
+        capability=frozenset({Capability.SUBPROCESS}),
+    ),
+}
+
+
+def classify_permission(permission_kind: str | None) -> Classification | None:
+    """Derive a :class:`Classification` for a permission gate from its kind.
+
+    Args:
+        permission_kind: The requested capability kind from the gate's payload
+            (e.g. ``"read"``, ``"write"``, ``"shell"``). ``None``/empty when the
+            source carried no kind.
+
+    Returns:
+        A :class:`Classification` carrying a single-segment ``phase_map`` (as
+        :func:`classify_tool` does), or ``None`` when the kind is absent or not
+        recognized — leaving the gate honestly unclassified.
+    """
+    if not permission_kind:
+        return None
+
+    base = _PERMISSION_CLASSIFICATIONS.get(permission_kind.strip().lower())
+    if base is None:
+        return None
+
+    return _with_phase_map(base)

--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -12,6 +12,7 @@ from traceforge.classify.cmd import classify_cmd_command
 from traceforge.classify.config import ClassificationEngine, ClassifyConfig, load_config
 from traceforge.classify.core import Classification, PhaseSegment
 from traceforge.classify.coding import CodingMechanism, CodingScope
+from traceforge.classify.permission import classify_permission
 from traceforge.classify.powershell import classify_powershell_command
 from traceforge.classify.risk import assess_risk, assess_tool_risk
 from traceforge.classify.tool_display import ToolDisplayProvider, ToolDisplayResolver
@@ -201,6 +202,16 @@ class Enricher:
             event = self._set_phase(event)
             result = [*orphans, event] if orphans else event
 
+        elif event.kind == EventKind.PERMISSION_REQUESTED:
+            # Permission gates carry the requested capability kind (read/write/
+            # shell/…). Classify them from that kind so they surface with an
+            # effect + risk just like the tool call they gate, rather than
+            # landing unclassified. Unknown/absent kinds stay honest-blank.
+            event = self._classify_permission(event)
+            event = self._set_visibility(event)
+            event = self._set_phase(event)
+            result = event
+
         else:
             # Non-tool events: set visibility and phase, pass through
             event = self._set_visibility(event)
@@ -329,6 +340,36 @@ class Enricher:
                 event = self._assess_risk(event, cls)
             else:
                 event = self._assess_tool_risk(event, cls)
+
+        return event
+
+    def _classify_permission(self, event: SessionEvent) -> SessionEvent:
+        """Set metadata.classification for a permission-gate event from its kind.
+
+        Mirrors :meth:`_classify` for tool events: derives a Classification from
+        the requested ``permission_kind`` (read/write/shell/…), refines its scope
+        from the target path, and — when a risk config is loaded — stashes a risk
+        assessment in ``payload._enrichment.risk``. The gate's intention, target,
+        and diff ride the payload untouched, preserving the security signal.
+
+        Unknown or absent kinds leave the event unclassified (honest-blank): no
+        effect is invented for a gate whose semantics are not on the wire.
+        """
+        permission_kind = event.payload.get("permission_kind")
+        cls = classify_permission(permission_kind)
+        if cls is None:
+            return event
+
+        # Refine scope from the gated file path (test/docs/config/… vs generic
+        # source), same as tool events.
+        cls = _refine_scope_from_payload(cls, event.payload)
+
+        new_metadata = event.metadata.model_copy(update={"classification": cls})
+        event = event.model_copy(update={"metadata": new_metadata})
+
+        # Risk scoring — mirror native tools (targets from the payload path).
+        if self._engine.risk_config is not None:
+            event = self._assess_tool_risk(event, cls)
 
         return event
 

--- a/src/traceforge/mappings/copilot.yaml
+++ b/src/traceforge/mappings/copilot.yaml
@@ -269,13 +269,32 @@ events:
       skill_name: data.skillName
 
   # ── Permissions ────────────────────────────────────────────────────────────
+  # Copilot gates privileged actions behind a permission request that carries the
+  # requested capability ``kind`` (read / write / shell / …) plus the intention and
+  # target (fileName+diff for writes, path for reads, fullCommandText for shell).
+  # Surfacing that payload lets the Enricher classify the gate with an effect/risk,
+  # the same way it classifies the tool call the gate protects. Fields resolve to
+  # None when absent and are omitted by the adapter — honest-blank, never synthesized.
   permission.requested:
     kind: permission.requested
-    payload: {}
+    payload:
+      permission_kind: data.permissionRequest.kind
+      intention: data.permissionRequest.intention
+      path: data.permissionRequest.path
+      file: data.permissionRequest.fileName
+      diff: data.permissionRequest.diff
+      command: data.permissionRequest.fullCommandText
+      tool_call_id: data.permissionRequest.toolCallId
+      extension_name: data.permissionRequest.extensionName
 
+  # The completion carries only the approval result (approved / denied-*), not the
+  # request payload, so it is not independently classifiable — kept as-is.
   permission.completed:
     kind: permission.granted
-    payload: {}
+    payload:
+      result: data.result.kind
+      tool_call_id: data.toolCallId
+      request_id: data.requestId
 
   # ── User input ─────────────────────────────────────────────────────────────
   user_input.requested:

--- a/tests/e2e/test_copilot_permission_classification.py
+++ b/tests/e2e/test_copilot_permission_classification.py
@@ -1,0 +1,194 @@
+"""End-to-end: Copilot permission gates surface with an effect via the read side.
+
+Real GitHub Copilot CLI sessions emit ``permission.requested`` gates carrying the
+requested capability ``kind`` (read / write / shell / …) plus the intention,
+target, and (for writes) the diff. This proves that after ingestion those gates
+carry ``governance.classification`` — so :meth:`DashboardRepository.build_run`
+gives each one an effect + mechanism (``tool.cat`` / ``tool.canon``) exactly like
+the tool call they gate — while genuinely-absent effects (shell) and unknown
+kinds (extension) stay honestly blank, and the diff/intention ride through intact.
+
+Everything is verified against an **isolated** temp :class:`SqliteOutputSink`
+(seed dir-per-session state, ingest ``--once``, reopen read-only) — never the live
+``~/.traceforge/*.db`` and never the real ``~/.copilot`` files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from traceforge.cli.runner import ADAPTER_MAP, ResolvedPipeline
+from traceforge.dashboard.repository import DashboardRepository, resolve_paths
+from traceforge.sinks.sqlite_output import SqliteOutputSink
+
+pytestmark = pytest.mark.e2e
+
+watch_mod = importlib.import_module("traceforge.cli.watch")
+
+_UUID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+_WRITE_DIFF = "@@ -1 +1 @@\n-old = 1\n+new = 2\n"
+
+
+def _lines() -> list[str]:
+    """Real-shaped Copilot ``events.jsonl`` with all four permission kinds."""
+    ev: list[dict] = [
+        {
+            "type": "session.start",
+            "id": "evt-start",
+            "timestamp": "2024-06-01T10:00:00Z",
+            "data": {"selectedModel": "claude-sonnet-4.5", "context": {"cwd": "/proj"}},
+        },
+        {
+            "type": "permission.requested",
+            "id": "evt-write",
+            "timestamp": "2024-06-01T10:00:01Z",
+            "data": {
+                "requestId": "r-write",
+                "permissionRequest": {
+                    "kind": "write",
+                    "toolCallId": "tc-write",
+                    "intention": "Create file",
+                    "fileName": "src/app.py",
+                    "diff": _WRITE_DIFF,
+                    "newFileContents": "new = 2\n",
+                },
+            },
+        },
+        {
+            "type": "permission.requested",
+            "id": "evt-read",
+            "timestamp": "2024-06-01T10:00:02Z",
+            "data": {
+                "requestId": "r-read",
+                "permissionRequest": {
+                    "kind": "read",
+                    "toolCallId": "tc-read",
+                    "intention": "Read file: src/app.py",
+                    "path": "src/app.py",
+                },
+            },
+        },
+        {
+            "type": "permission.requested",
+            "id": "evt-shell",
+            "timestamp": "2024-06-01T10:00:03Z",
+            "data": {
+                "requestId": "r-shell",
+                "permissionRequest": {
+                    "kind": "shell",
+                    "toolCallId": "tc-shell",
+                    "intention": "run tests",
+                    "fullCommandText": "pytest -q",
+                },
+            },
+        },
+        {
+            "type": "permission.requested",
+            "id": "evt-ext",
+            "timestamp": "2024-06-01T10:00:04Z",
+            "data": {
+                "requestId": "r-ext",
+                "permissionRequest": {
+                    "kind": "extension-permission-access",
+                    "extensionName": "user:some-ext",
+                    "capabilities": ["register hooks"],
+                },
+            },
+        },
+        {
+            "type": "permission.completed",
+            "id": "evt-done",
+            "timestamp": "2024-06-01T10:00:05Z",
+            "data": {
+                "requestId": "r-write",
+                "toolCallId": "tc-write",
+                "result": {"kind": "approved"},
+            },
+        },
+        {
+            "type": "session.shutdown",
+            "id": "evt-shutdown",
+            "timestamp": "2024-06-01T10:00:06Z",
+            "data": {"shutdownType": "routine"},
+        },
+    ]
+    return [json.dumps(e) for e in ev]
+
+
+def _run_once(tmp_path: Path, monkeypatch) -> Path:
+    state = tmp_path / "session-state"
+    (state / _UUID).mkdir(parents=True)
+    (state / _UUID / "events.jsonl").write_text("\n".join(_lines()) + "\n", encoding="utf-8")
+
+    db_path = tmp_path / "out.db"
+    sink = SqliteOutputSink(path=str(db_path))
+    monkeypatch.setattr(watch_mod, "_build_sinks", lambda _p: [sink])
+
+    pipeline = ResolvedPipeline(
+        name="copilot",
+        source_path=state,
+        ingestion_mode="file_watch",
+        adapter=ADAPTER_MAP["copilot"],
+        sinks=[],
+    )
+    asyncio.run(watch_mod._process_pipeline_once(pipeline, governance=None, enable_title=False))
+    return db_path
+
+
+def _permission_events(db_path: Path, tmp_path: Path) -> dict[str, dict]:
+    """build_run the session and index permission.requested events by kind."""
+    paths = resolve_paths(output_db=db_path, system_db=tmp_path / "system.db")
+    repo = DashboardRepository(paths)
+    run = repo.build_run(_UUID)
+    assert run is not None, "session did not build a run"
+    by_kind: dict[str, dict] = {}
+    for ev in run["events"]:
+        if ev["kind"] == "permission.requested":
+            by_kind[ev["payload"].get("permission_kind", "<none>")] = ev
+    return by_kind
+
+
+def test_write_gate_surfaces_mutating_effect_with_diff(tmp_path, monkeypatch) -> None:
+    events = _permission_events(_run_once(tmp_path, monkeypatch), tmp_path)
+    write = events["write"]
+
+    # Read side gives the gate an effect + mechanism, no read-side change needed.
+    assert write["tool"]["cat"] == "mutating"
+    assert write["tool"]["canon"] == "filesystem"
+    assert write["cls"]["cat"] == "mutating"
+    # The security signal rides through intact.
+    assert write["payload"]["diff"] == _WRITE_DIFF
+    assert write["payload"]["intention"] == "Create file"
+    assert write["file"] == "src/app.py"
+
+
+def test_read_gate_surfaces_read_only_effect(tmp_path, monkeypatch) -> None:
+    events = _permission_events(_run_once(tmp_path, monkeypatch), tmp_path)
+    read = events["read"]
+    assert read["tool"]["cat"] == "read_only"
+    assert read["tool"]["canon"] == "filesystem"
+    assert read["file"] == "src/app.py"
+
+
+def test_shell_gate_is_classified_but_effect_is_honestly_blank(tmp_path, monkeypatch) -> None:
+    events = _permission_events(_run_once(tmp_path, monkeypatch), tmp_path)
+    shell = events["shell"]
+    # Classified as a subprocess-execution gate...
+    assert shell["tool"]["canon"] == "process.shell"
+    # ...but the effect is blank — it depends on the actual command (no fabrication).
+    assert shell["tool"]["cat"] == ""
+    assert shell["payload"]["command"] == "pytest -q"
+
+
+def test_unknown_extension_gate_stays_unclassified(tmp_path, monkeypatch) -> None:
+    events = _permission_events(_run_once(tmp_path, monkeypatch), tmp_path)
+    ext = events["extension-permission-access"]
+    # No comparable read/write/execute semantics on the wire → honestly blank.
+    assert ext["tool"]["cat"] == ""
+    assert ext["tool"]["canon"] == ""
+    assert ext["payload"].get("extension_name") == "user:some-ext"

--- a/tests/unit/test_classify_permission.py
+++ b/tests/unit/test_classify_permission.py
@@ -1,0 +1,85 @@
+"""Tests for traceforge.classify.permission — permission-gate classification.
+
+Copilot (and similar agents) emit a permission gate carrying the requested
+capability ``kind`` before a privileged action. These assert that the derived
+:class:`Classification` honestly reflects the kind on the wire, and that
+unknown/absent kinds stay unclassified rather than being assigned a made-up
+effect.
+"""
+
+from __future__ import annotations
+
+from traceforge.classify import classify_permission
+from traceforge.classify.core import Capability, Effect, Mechanism
+
+
+class TestClassifyPermissionRead:
+    def test_read_is_read_only_filesystem(self):
+        cls = classify_permission("read")
+        assert cls is not None
+        assert cls.mechanism == Mechanism.FILESYSTEM
+        assert cls.effect == Effect.READ_ONLY
+        assert Capability.FILESYSTEM_READ in cls.capability
+        assert cls.has_action("retrieve")
+        assert cls.has_role("retriever")
+
+    def test_read_carries_phase_map(self):
+        # Mirrors classify_tool: every derived classification carries a phase_map.
+        cls = classify_permission("read")
+        assert cls is not None
+        assert cls.phase_map
+
+
+class TestClassifyPermissionWrite:
+    def test_write_is_mutating_filesystem(self):
+        cls = classify_permission("write")
+        assert cls is not None
+        assert cls.mechanism == Mechanism.FILESYSTEM
+        assert cls.effect == Effect.MUTATING
+        assert Capability.FILESYSTEM_WRITE in cls.capability
+        assert cls.has_action("persist")
+        assert cls.has_role("modifier")
+
+    def test_write_is_not_destructive(self):
+        # Judgement: a file write/edit is reversible (e.g. via VCS). Destructive
+        # is reserved for irreversible deletes; we never infer it from a gate.
+        cls = classify_permission("write")
+        assert cls is not None
+        assert cls.effect != Effect.DESTRUCTIVE
+
+
+class TestClassifyPermissionShell:
+    def test_shell_is_subprocess_with_blank_effect(self):
+        # A shell gate authorizes running *a* command but the effect depends on
+        # the specific command + args — not statically determinable → honest None.
+        cls = classify_permission("shell")
+        assert cls is not None
+        assert cls.mechanism == "process.shell"
+        assert cls.effect is None
+        assert Capability.SUBPROCESS in cls.capability
+        assert cls.has_action("execute")
+        assert cls.has_role("executor")
+
+
+class TestClassifyPermissionHonestBlank:
+    def test_none_returns_none(self):
+        assert classify_permission(None) is None
+
+    def test_empty_returns_none(self):
+        assert classify_permission("") is None
+
+    def test_extension_permission_access_returns_none(self):
+        # Real Copilot kind with no comparable read/write/execute semantics and
+        # no target on the wire → stays unclassified (no fabrication).
+        assert classify_permission("extension-permission-access") is None
+
+    def test_unknown_kind_returns_none(self):
+        assert classify_permission("frobnicate") is None
+
+
+class TestClassifyPermissionNormalization:
+    def test_case_insensitive(self):
+        assert classify_permission("WRITE") == classify_permission("write")
+
+    def test_surrounding_whitespace_ignored(self):
+        assert classify_permission("  read  ") == classify_permission("read")

--- a/tests/unit/test_enricher_permission.py
+++ b/tests/unit/test_enricher_permission.py
@@ -1,0 +1,119 @@
+"""Enricher tests for permission-gate classification.
+
+The Enricher attaches ``metadata.classification`` to ``permission.requested``
+events from their ``permission_kind`` payload — the same shape it gives tool
+events — so permission gates surface with an effect + risk instead of landing
+unclassified. Absent/unknown kinds stay honestly blank.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from traceforge import Enricher, EventKind, SessionEvent
+
+
+def _permission_event(session_id: str = "sess-1", **payload) -> SessionEvent:
+    return SessionEvent(
+        kind=EventKind.PERMISSION_REQUESTED,
+        session_id=session_id,
+        timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        payload=payload,
+    )
+
+
+class TestPermissionWrite:
+    def test_write_gate_is_classified_mutating(self):
+        event = _permission_event(
+            permission_kind="write",
+            intention="Create file",
+            file="src/app.py",
+            diff="+ new line\n- old line",
+            tool_call_id="tc-1",
+        )
+        result = Enricher().process(event)
+
+        assert result is not None
+        assert result.metadata.classification is not None
+        assert result.metadata.classification.effect == "mutating"
+        assert result.metadata.classification.mechanism == "filesystem"
+
+    def test_write_gate_preserves_diff_and_intention(self):
+        diff = "+ added\n- removed"
+        event = _permission_event(
+            permission_kind="write",
+            intention="Edit config",
+            file="pyproject.toml",
+            diff=diff,
+            tool_call_id="tc-2",
+        )
+        result = Enricher().process(event)
+
+        # The security-relevant payload rides through untouched.
+        assert result.payload["diff"] == diff
+        assert result.payload["intention"] == "Edit config"
+        assert result.payload["file"] == "pyproject.toml"
+
+    def test_write_gate_gets_a_risk_assessment(self):
+        # Mirrors tool events: risk rides payload._enrichment.risk.
+        event = _permission_event(
+            permission_kind="write",
+            file="src/app.py",
+            diff="+ x",
+            tool_call_id="tc-3",
+        )
+        result = Enricher().process(event)
+
+        risk = result.payload.get("_enrichment", {}).get("risk")
+        assert risk is not None
+        assert "score" in risk and "level" in risk
+
+
+class TestPermissionRead:
+    def test_read_gate_is_classified_read_only(self):
+        event = _permission_event(
+            permission_kind="read",
+            intention="Read file: src/app.py",
+            path="src/app.py",
+            tool_call_id="tc-4",
+        )
+        result = Enricher().process(event)
+
+        assert result.metadata.classification is not None
+        assert result.metadata.classification.effect == "read_only"
+        assert result.metadata.classification.mechanism == "filesystem"
+        assert result.payload["path"] == "src/app.py"
+
+
+class TestPermissionShell:
+    def test_shell_gate_is_subprocess_with_blank_effect(self):
+        event = _permission_event(
+            permission_kind="shell",
+            intention="run tests",
+            command="pytest -q",
+            tool_call_id="tc-5",
+        )
+        result = Enricher().process(event)
+
+        cls = result.metadata.classification
+        assert cls is not None
+        # Classified as an execute/subprocess gate...
+        assert cls.mechanism == "process.shell"
+        # ...but the effect is honestly blank: it depends on the actual command.
+        assert cls.effect is None
+        assert result.payload["command"] == "pytest -q"
+
+
+class TestPermissionHonestBlank:
+    def test_unknown_kind_stays_unclassified(self):
+        event = _permission_event(
+            permission_kind="extension-permission-access",
+            extension_name="user:some-ext",
+        )
+        result = Enricher().process(event)
+        assert result.metadata.classification is None
+
+    def test_missing_kind_stays_unclassified(self):
+        event = _permission_event(intention="no kind on the wire")
+        result = Enricher().process(event)
+        assert result.metadata.classification is None


### PR DESCRIPTION
Closes #180

## What

GitHub Copilot CLI emits `permission.requested` / `permission.completed` gates before privileged actions, each carrying a rich, security-relevant payload (`permissionRequest: {kind, intention, fileName, diff, path, fullCommandText, toolCallId, ...}`). Today `mappings/copilot.yaml` maps them with `payload: {}` (drops the payload) and the Enricher routes them to the no-classification `else` branch — so every gate lands **UNCLASSIFIED** in the dashboard even though these are the write/execute actions governance exists to score.

This PR makes `permission.requested` events carry `governance.classification` (and a mirrored risk assessment), so each gate surfaces with an **effect + mechanism** exactly like the tool call it gates — with **no read-side change** (it uses the same `metadata.classification` shape `repository.py` `_map_event` already reads).

## How

1. **`mappings/copilot.yaml`** — preserve the permission payload via dot-paths (`permission_kind`, `intention`, `path`, `file`←`fileName`, `diff`, `command`←`fullCommandText`, `tool_call_id`, `extension_name`; `permission.completed` → `result`/`tool_call_id`/`request_id`). The adapter omits fields whose path resolves to `None`, so absent fields stay honestly blank.
2. **`classify/permission.py`** (new, framework-agnostic) — `classify_permission(permission_kind) -> Classification | None`:
   - `read` → filesystem / **read_only** / retriever.file_browser / retrieve.read
   - `write` → filesystem / **mutating** / modifier.file_editor / persist.write
   - `shell` → **process.shell** / **effect blank** / executor.script_runner / execute.run_script
   - unknown / absent (incl. `extension-permission-access`) → `None` (stays unclassified)

   Wrapped with `with_phase_map`, mirroring `classify_tool`.
3. **`classify/__init__.py`** — export `classify_permission`.
4. **`enricher.py`** — add a `PERMISSION_REQUESTED` branch that classifies from `permission_kind`, refines scope from the payload (test/docs/etc.), sets `metadata.classification`, and stashes a risk assessment in `payload._enrichment.risk` (same as tool events).

### Design choices (framework placement + honesty)

- **Framework-agnostic placement.** Permission gates are a cross-cutting concept (any agent with an approval layer can emit them), and the effect derivation is pure vocabulary — so it lives in `classify/permission.py`, benefiting any future source, with the Copilot-specific wire→field mapping staying in `copilot.yaml`.
- **`write` is `mutating`, not `destructive`.** A file write/edit is reversible (e.g. via VCS). Destructive is reserved for irreversible deletes; we never infer it from diff *content* (that would be fabrication).
- **`shell` effect is honestly blank.** A shell gate authorizes running *a* command, but the effect depends on the actual command + args — not statically determinable — so mechanism marks it as a subprocess-execution gate while the effect stays blank.
- **Only `permission.requested` is classified.** `permission.completed` carries only `result.kind` (approved/denied), no request payload → not independently classifiable → honest-blank.
- **Real wire kinds are `read`/`write`/`shell`/`extension-permission-access`** (the original directive assumed `write`/`execute`; classified from what is actually on the wire).

## Verification (isolated real-data re-ingest — never `~/.traceforge`)

Re-ingested real `~/.copilot/session-state` sessions into a temp `SqliteOutputSink` (copying only `events.jsonl` into a temp dir; the live DBs and `~/.copilot` files are never touched):

**Run A — 5 large sessions, 4472 permission events → 4470 classified / 2 unclassified**

| kind | count | effect | mechanism |
|------|------:|--------|-----------|
| write | 1175 | mutating | filesystem |
| read | 3295 | read_only | filesystem |
| extension-permission-access | 2 | *(blank)* | *(blank)* |

diff preserved 1168/1175 · **fabricated effects on unknown/absent kind: 0**
(the 7 diff deltas are `toolCallId`-reuse collisions in the spot-check harness — a gate re-requested after an edit — not data loss; the pipeline passes each event's own `diff` through byte-for-byte, as the e2e test proves.)

**Run B — 3 shell-heavy sessions, 151 permission events → 151 classified / 0 unclassified**

| kind | count | effect | mechanism |
|------|------:|--------|-----------|
| read | 127 | read_only | filesystem |
| shell | 24 | *(blank — honest)* | process.shell |

intention preserved 151/151 · target preserved 127/127 · **fabricated effects: 0**

## Tests

- `tests/unit/test_classify_permission.py` — read/write/shell effects + honest-blank for unknown/absent/extension kinds + case-insensitivity.
- `tests/unit/test_enricher_permission.py` — permission event → `metadata.classification` through `Enricher.process`, diff/intention preserved, risk stashed, unknown/missing kind stays blank.
- `tests/e2e/test_copilot_permission_classification.py` — full ingest → `DashboardRepository.build_run` surfaces write→mutating (+ diff), read→read_only, shell→process.shell/blank effect, extension→unclassified — proving the read side with **no `repository.py` change**.

Full suite: **3571 passed, 8 skipped**. `ruff check .` + `ruff format --check .` clean (ruff==0.15.20).

## Scope / follow-ups (not in this PR)

- Untouched: `preprocessors/copilot.py` usage/`modelMetrics`, the frontend coverage metric.
- **Latent bug (documented, not fixed here):** `permission.completed` is mapped to canonical kind `permission.granted` even when `result.kind == "denied"`. Out of scope for permission *classification*; flagged for a follow-up.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
