### PR TITLE
Dashboard: per-run full-text Transcript panel in RunView

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -17,6 +17,7 @@
 // components (which call Date methods) keep working unchanged.
 
 import type { Run, TEvent } from "@/lib/types";
+import type { Transcript } from "@/lib/types";
 
 export const API_BASE = "/api";
 
@@ -90,4 +91,15 @@ export async function getRun(id: string, signal?: AbortSignal): Promise<Run> {
     signal,
   );
   return reviveRun(w);
+}
+
+// --- Transcript ------------------------------------------------------------
+
+// The transcript wire form needs no revival: `t` stays an ISO string (rendered as
+// a label, not a Date), so the parsed JSON already matches `Transcript`.
+export function getTranscript(
+  id: string,
+  signal?: AbortSignal,
+): Promise<Transcript> {
+  return getJson<Transcript>(`/runs/${encodeURIComponent(id)}/transcript`, signal);
 }

--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -11,9 +11,9 @@
 
 import { useQuery } from "@tanstack/react-query";
 import type { Query } from "@tanstack/react-query";
-import { getHealth, getRuns } from "@/lib/api";
+import { getHealth, getRuns, getTranscript } from "@/lib/api";
 import type { Health } from "@/lib/api";
-import type { Run } from "@/lib/types";
+import type { Run, Transcript } from "@/lib/types";
 
 // Poll while any run is still live (spec fork 4: interval poll for v1), otherwise
 // stay idle. Live runs tail the output DB, so their events/cost keep growing.
@@ -33,5 +33,18 @@ export function useHealth() {
     queryKey: ["health"],
     queryFn: ({ signal }) => getHealth(signal),
     staleTime: 60_000,
+  });
+}
+
+// Per-run full-text transcript, fetched lazily: `enabled` is driven by the
+// RunView panel's open state so the (potentially large) full bodies load only
+// when the reader actually opens the transcript. Keyed by run id so switching
+// runs refetches and each run caches independently.
+export function useTranscript(runId: string | null, enabled: boolean) {
+  return useQuery<Transcript>({
+    queryKey: ["transcript", runId],
+    queryFn: ({ signal }) => getTranscript(runId as string, signal),
+    enabled: enabled && runId != null,
+    staleTime: 30_000,
   });
 }

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -152,3 +152,26 @@ export interface Run {
 // Risk-level labels, index-aligned to RiskLevel (0..3). Display + data concern,
 // shared by badges, ribbons and formatters — so it lives with the types.
 export const RISK = ["safe", "caution", "danger", "critical"] as const;
+
+// --- Transcript (per-run full-text reading view) ---------------------------
+// A run's transcript is fetched on demand (GET /api/runs/{id}/transcript) rather
+// than riding on the bounded /api/runs list: one turn per event, carrying the
+// COMPLETE untruncated text (distinct from TEvent.summary's one-line preview).
+export type TranscriptRole = "user" | "assistant" | "system" | "tool";
+
+export interface TranscriptTurn {
+  id: string;
+  // ISO-8601 string — kept as-is (like RunGap.t), not revived to a Date.
+  t: string;
+  role: TranscriptRole;
+  // Tool name, or a readable role label ("User"/"Assistant"/"System") for messages.
+  label: string;
+  kind: string;
+  // Full, newline-preserving body text; "" when the event carried no free text.
+  text: string;
+}
+
+export interface Transcript {
+  id: string;
+  turns: TranscriptTurn[];
+}

--- a/dashboard/src/views/RunView.tsx
+++ b/dashboard/src/views/RunView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, ArrowLeft, ChevronRight, FileText, MessagesSquare } from "lucide-react";
 import { useRuns, useTranscript } from "@/lib/queries";
 import type { TEvent, TranscriptRole, TranscriptTurn } from "@/lib/types";
@@ -260,7 +260,7 @@ export function RunView() {
         <Inspector e={cur} idx={selIdx} />
       </div>
 
-      <TranscriptPanel runId={run.id} />
+      <TranscriptPanel runId={run.id} selectedId={cur?.id ?? null} />
     </div>
   );
 }
@@ -391,10 +391,21 @@ const ROLE_STYLES: Record<TranscriptRole, { rail: string; label: string }> = {
   tool: { rail: "border-l-muted-foreground/40", label: "text-muted-foreground" },
 };
 
-function TranscriptTurnRow({ turn }: { turn: TranscriptTurn }) {
+function TranscriptTurnRow({ turn, active }: { turn: TranscriptTurn; active: boolean }) {
   const style = ROLE_STYLES[turn.role];
+  const ref = useRef<HTMLDivElement>(null);
+  // Keep the selected event's turn in view as the reader clicks around the
+  // Chapters/Timeline (turn.id === the enriched event id they select).
+  useEffect(() => {
+    if (active) ref.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [active]);
   return (
-    <div className={`border-l-2 ${style.rail} pl-3`}>
+    <div
+      ref={ref}
+      className={`border-l-2 ${style.rail} rounded-r-md pl-3 transition-colors ${
+        active ? "bg-muted/60" : ""
+      }`}
+    >
       <div className="flex items-baseline gap-2">
         <span className={`text-[11px] font-medium uppercase tracking-wide ${style.label}`}>
           {turn.role}
@@ -417,8 +428,10 @@ function TranscriptTurnRow({ turn }: { turn: TranscriptTurn }) {
 
 // Collapsible full-width panel rendering the run's full-text transcript. The
 // transcript is fetched lazily (only once opened) via useTranscript so the
-// potentially large bodies never load for readers who stay on the timeline.
-function TranscriptPanel({ runId }: { runId: string }) {
+// potentially large bodies never load for readers who stay on the timeline. When
+// open, the turn matching the currently-selected event is highlighted and scrolled
+// into view, keeping the transcript in sync with the Chapters/Timeline selection.
+function TranscriptPanel({ runId, selectedId }: { runId: string; selectedId: string | null }) {
   const [open, setOpen] = useState(false);
   const { data, isLoading, isError } = useTranscript(runId, open);
   const turns = data?.turns ?? [];
@@ -454,7 +467,11 @@ function TranscriptPanel({ runId }: { runId: string }) {
             <ScrollArea className="h-[420px]">
               <div className="space-y-4 px-4 py-3">
                 {turns.map((turn) => (
-                  <TranscriptTurnRow key={turn.id} turn={turn} />
+                  <TranscriptTurnRow
+                    key={turn.id}
+                    turn={turn}
+                    active={turn.id === selectedId}
+                  />
                 ))}
               </div>
             </ScrollArea>

--- a/dashboard/src/views/RunView.tsx
+++ b/dashboard/src/views/RunView.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
-import { AlertTriangle, ArrowLeft, ChevronRight, FileText } from "lucide-react";
-import { useRuns } from "@/lib/queries";
-import type { TEvent } from "@/lib/types";
+import { AlertTriangle, ArrowLeft, ChevronRight, FileText, MessagesSquare } from "lucide-react";
+import { useRuns, useTranscript } from "@/lib/queries";
+import type { TEvent, TranscriptRole, TranscriptTurn } from "@/lib/types";
 import { useApp } from "@/store";
 import { dmin, hhmm, fmtCost, fmtVal, premiumReq } from "@/lib/format";
 import { buildChapters, locateEvent } from "@/lib/chapters";
@@ -259,6 +259,8 @@ export function RunView() {
 
         <Inspector e={cur} idx={selIdx} />
       </div>
+
+      <TranscriptPanel runId={run.id} />
     </div>
   );
 }
@@ -376,6 +378,89 @@ function Inspector({ e, idx }: { e: TEvent; idx: number }) {
           </Tip>
         )}
       </CardContent>
+    </Card>
+  );
+}
+
+// Per-role accent for the transcript's left rail + label, reusing the risk-soft
+// tokens the rest of the console uses so the palette stays consistent.
+const ROLE_STYLES: Record<TranscriptRole, { rail: string; label: string }> = {
+  user: { rail: "border-l-primary", label: "text-primary" },
+  assistant: { rail: "border-l-border", label: "text-foreground" },
+  system: { rail: "border-l-muted-foreground/40", label: "text-muted-foreground" },
+  tool: { rail: "border-l-muted-foreground/40", label: "text-muted-foreground" },
+};
+
+function TranscriptTurnRow({ turn }: { turn: TranscriptTurn }) {
+  const style = ROLE_STYLES[turn.role];
+  return (
+    <div className={`border-l-2 ${style.rail} pl-3`}>
+      <div className="flex items-baseline gap-2">
+        <span className={`text-[11px] font-medium uppercase tracking-wide ${style.label}`}>
+          {turn.role}
+        </span>
+        <span className="truncate font-mono text-[11px] text-muted-foreground">{turn.label}</span>
+        <span className="ml-auto shrink-0 text-[10.5px] tabular-nums text-muted-foreground">
+          {hhmm(new Date(turn.t))}
+        </span>
+      </div>
+      {turn.text ? (
+        <p className="mt-1 whitespace-pre-wrap break-words text-[12.5px] leading-relaxed">
+          {turn.text}
+        </p>
+      ) : (
+        <p className="mt-1 text-[12px] italic text-muted-foreground">No text captured.</p>
+      )}
+    </div>
+  );
+}
+
+// Collapsible full-width panel rendering the run's full-text transcript. The
+// transcript is fetched lazily (only once opened) via useTranscript so the
+// potentially large bodies never load for readers who stay on the timeline.
+function TranscriptPanel({ runId }: { runId: string }) {
+  const [open, setOpen] = useState(false);
+  const { data, isLoading, isError } = useTranscript(runId, open);
+  const turns = data?.turns ?? [];
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="flex-row items-center justify-between gap-3 space-y-0">
+        <div className="flex items-center gap-2">
+          <MessagesSquare className="size-4 text-muted-foreground" />
+          <div>
+            <CardTitle className="text-base">Transcript</CardTitle>
+            <CardDescription>The run’s full text — messages and tool calls, in order.</CardDescription>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setOpen((o) => !o)} className="shrink-0">
+          <ChevronRight className={`size-4 transition-transform ${open ? "rotate-90" : ""}`} />
+          {open ? "Hide" : "Show"}
+        </Button>
+      </CardHeader>
+      {open && (
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="px-4 py-6 text-sm text-muted-foreground">Loading transcript…</div>
+          ) : isError ? (
+            <div className="px-4 py-6 text-sm text-muted-foreground">
+              Could not load the transcript for this run.
+            </div>
+          ) : turns.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-muted-foreground">
+              No transcript recorded for this run.
+            </div>
+          ) : (
+            <ScrollArea className="h-[420px]">
+              <div className="space-y-4 px-4 py-3">
+                {turns.map((turn) => (
+                  <TranscriptTurnRow key={turn.id} turn={turn} />
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/src/traceforge/dashboard/api.py
+++ b/src/traceforge/dashboard/api.py
@@ -99,6 +99,20 @@ def get_run(
     return repo.build_run(match.group("id"))
 
 
+def get_transcript(
+    repo: DashboardRepository, match: re.Match[str], _query: _Query
+) -> dict[str, Any] | None:
+    """``GET /api/runs/{id}/transcript`` — the run's full-text transcript.
+
+    Returns ``{id, turns[]}`` with the complete, untruncated text per event (the
+    reading view), or ``None`` (-> 404) for an unknown run / no output DB. Kept off
+    the bounded ``/api/runs`` list so full bodies load only when a run is opened.
+    """
+    if not repo.has_output_db():
+        return None
+    return repo.build_transcript(match.group("id"))
+
+
 _REGISTERED = False
 
 
@@ -108,11 +122,13 @@ def register_api_routes() -> None:
     Registration mutates the module-global table in ``server``; the guard keeps
     repeated ``create_server`` calls (e.g. across tests) from stacking duplicate
     routes. The run-list pattern is registered before ``/{id}`` so a bare
-    ``/api/runs`` never gets captured as an id.
+    ``/api/runs`` never gets captured as an id, and ``/{id}/transcript`` before the
+    bare ``/{id}`` so the drill-in read never shadows the transcript read.
     """
     global _REGISTERED
     if _REGISTERED:
         return
     register_route(r"^/api/runs/?$", get_runs)
+    register_route(r"^/api/runs/(?P<id>[^/]+)/transcript/?$", get_transcript)
     register_route(r"^/api/runs/(?P<id>[^/]+)/?$", get_run)
     _REGISTERED = True

--- a/src/traceforge/dashboard/repository.py
+++ b/src/traceforge/dashboard/repository.py
@@ -359,6 +359,38 @@ class DashboardRepository:
             "eventCount": int(agg["n"]),
         }
 
+    def build_transcript(
+        self, session_id: str, *, out_conn: sqlite3.Connection | None = None
+    ) -> dict[str, Any] | None:
+        """Assemble the full-text transcript for one session, or ``None`` if unknown.
+
+        One turn per ``enriched_events`` row in chronological order, each carrying
+        its ``role`` (user / assistant / system / tool), a display ``label``, its
+        ``kind``, and the **complete, untruncated** free text from the payload.
+
+        This is the reading view. It is deliberately separate from
+        ``/api/runs/{id}`` (whose per-event ``summary`` is a one-line, truncated
+        preview) and from the bounded ``GET /api/runs`` list projection — the
+        transcript is fetched on demand for a single run so its full bodies never
+        inflate the fleet payload.
+        """
+        own = out_conn is None
+        conn = _connect_ro(self._paths.output_db) if own else out_conn
+        try:
+            rows = conn.execute(
+                """SELECT id, kind, timestamp, tool_name, tool_display, payload_json
+                     FROM enriched_events
+                    WHERE session_id = ?
+                    ORDER BY timestamp ASC, created_at ASC""",
+                (session_id,),
+            ).fetchall()
+        finally:
+            if own:
+                conn.close()
+        if not rows:
+            return None
+        return {"id": session_id, "turns": [_map_transcript_turn(r) for r in rows]}
+
     # -- system.db (governance memory) — optional -----------------------------
 
     def _identity(
@@ -595,6 +627,72 @@ def _summarize(tool_name: str, payload: dict[str, Any]) -> str:
         if isinstance(val, str) and val.strip():
             return _snippet(val)
     return tool_name
+
+
+# kind -> transcript role. Prefix-based so unlisted kinds still resolve sensibly
+# (e.g. every ``session.*`` lifecycle event -> system). Tool/command/file/mcp and
+# anything unrecognized falls through to "tool" — the actor is the agent's tools.
+def _transcript_role(kind: str | None) -> str:
+    key = (kind or "").strip()
+    if key.startswith("message.user") or key.startswith("input."):
+        return "user"
+    if (
+        key.startswith("message.assistant")
+        or key.startswith("llm.")
+        or key.startswith("reasoning.")
+        or key.startswith("planning.")
+    ):
+        return "assistant"
+    if key.startswith("message.system") or key.startswith("session."):
+        return "system"
+    return "tool"
+
+
+# Payload keys carrying an invocation (the "what ran") and a body (the message or
+# output), in priority order. A turn shows the first of each it finds, so a tool
+# call with both a ``command`` and its ``output`` renders both, in that order.
+_TRANSCRIPT_INVOCATION_KEYS: tuple[str, ...] = ("command", "arguments", "url", "query")
+_TRANSCRIPT_BODY_KEYS: tuple[str, ...] = (
+    "content",
+    "text",
+    "message",
+    "output",
+    "result",
+    "stdout",
+    "body",
+)
+
+
+def _transcript_text(payload: dict[str, Any]) -> str:
+    """Full (untruncated) free text for a transcript turn.
+
+    Unlike :func:`_summarize` (a one-line, whitespace-collapsed, truncated preview
+    for the timeline), this returns the complete text — newlines preserved — so the
+    Transcript panel can render the run's actual content top-to-bottom.
+    """
+    parts: list[str] = []
+    for keys in (_TRANSCRIPT_INVOCATION_KEYS, _TRANSCRIPT_BODY_KEYS):
+        for key in keys:
+            val = payload.get(key)
+            if isinstance(val, str) and val.strip():
+                parts.append(val.strip())
+                break
+    return "\n\n".join(parts)
+
+
+def _map_transcript_turn(row: sqlite3.Row) -> dict[str, Any]:
+    """Reshape one ``enriched_events`` row into a transcript turn (full text)."""
+    payload = _loads(row["payload_json"])
+    kind = row["kind"]
+    label = row["tool_name"] or row["tool_display"] or _label_from_kind(kind)
+    return {
+        "id": row["id"],
+        "t": row["timestamp"],
+        "role": _transcript_role(kind),
+        "label": label,
+        "kind": kind,
+        "text": _transcript_text(payload),
+    }
 
 
 def _segment_risk(events: list[dict[str, Any]]) -> dict[str, int]:

--- a/tests/e2e/test_dashboard_api.py
+++ b/tests/e2e/test_dashboard_api.py
@@ -112,6 +112,23 @@ def test_run_detail_endpoint_returns_single_run(client: _Client) -> None:
     assert len(run["events"]) == 2
 
 
+def test_transcript_endpoint_returns_full_text_turns(client: _Client) -> None:
+    status, body = client.get("/api/runs/sess-alpha/transcript")
+    assert status == 200
+    transcript = json.loads(body)
+    assert transcript["id"] == "sess-alpha"
+    turns = transcript["turns"]
+    assert len(turns) == 3  # sess-alpha was seeded with 3 events
+    for turn in turns:
+        assert {"id", "t", "role", "label", "kind", "text"} <= turn.keys()
+
+
+def test_transcript_unknown_run_is_404(client: _Client) -> None:
+    status, body = client.get("/api/runs/does-not-exist/transcript")
+    assert status == 404
+    assert json.loads(body)["error"] == "not found"
+
+
 def test_unknown_run_is_404(client: _Client) -> None:
     status, body = client.get("/api/runs/does-not-exist")
     assert status == 404

--- a/tests/e2e/test_dashboard_repository.py
+++ b/tests/e2e/test_dashboard_repository.py
@@ -770,3 +770,99 @@ async def test_get_runs_opens_constant_connections_regardless_of_run_count(
     # O(1) opens: list_run_ids (1) + has_system_memory (1) + shared output (1) +
     # shared system (1) = 4. The pre-fix fan-out would be in the hundreds.
     assert opens <= 6, f"expected a small constant number of opens, got {opens} for {len(ids)} runs"
+
+
+# ─── transcript (per-run full-text reading view) ─────────────────────────────
+
+TID = "sess-transcript"
+# Deliberately longer than _snippet's 140-char cap: proves the transcript keeps the
+# full body where the timeline summary would truncate + collapse newlines.
+_LONG_ASSISTANT = (
+    "I looked at the login handler and found the bug: the session token is compared "
+    "with == instead of a constant-time check, and the expiry is read in seconds but "
+    "compared against milliseconds.\n\nHere is the plan:\n1. Use hmac.compare_digest\n"
+    "2. Normalise the expiry units\n3. Add a regression test for an expired token."
+)
+
+
+async def _seed_transcript(db: Path) -> None:
+    """A run mixing user / assistant / system messages and a tool call with output."""
+    sink = SqliteOutputSink(path=str(db))
+    await sink.on_event(
+        SessionEvent(
+            kind=EventKind.MESSAGE_USER,
+            session_id=TID,
+            timestamp=_T0,
+            payload={"content": "Please fix the login bug"},
+        )
+    )
+    await sink.on_event(
+        SessionEvent(
+            kind=EventKind.MESSAGE_ASSISTANT,
+            session_id=TID,
+            timestamp=_T0 + timedelta(seconds=1),
+            payload={"text": _LONG_ASSISTANT},
+        )
+    )
+    await sink.on_event(
+        SessionEvent(
+            kind=EventKind.MESSAGE_SYSTEM,
+            session_id=TID,
+            timestamp=_T0 + timedelta(seconds=2),
+            payload={"message": "context window trimmed"},
+        )
+    )
+    await sink.on_event(
+        SessionEvent(
+            kind=EventKind.TOOL_CALL_STARTED,
+            session_id=TID,
+            timestamp=_T0 + timedelta(seconds=3),
+            payload={"tool_name": "bash", "command": "rm -rf /tmp/x", "output": "removed"},
+        )
+    )
+    await sink.close()
+
+
+async def test_build_transcript_maps_roles_labels_and_order(tmp_path: Path) -> None:
+    out = tmp_path / "traceforge.db"
+    await _seed_transcript(out)
+    repo = DashboardRepository(DashboardPaths(output_db=out, system_db=tmp_path / "absent.db"))
+
+    transcript = repo.build_transcript(TID)
+    assert transcript is not None
+    assert transcript["id"] == TID
+    turns = transcript["turns"]
+    # One turn per event, in chronological order.
+    assert [t["role"] for t in turns] == ["user", "assistant", "system", "tool"]
+    assert [t["kind"] for t in turns] == [
+        "message.user",
+        "message.assistant",
+        "message.system",
+        "tool.call.started",
+    ]
+    # Message turns fall back to a readable role label (no tool name); the tool turn
+    # carries its tool name.
+    assert [t["label"] for t in turns] == ["User", "Assistant", "System", "bash"]
+    assert all("id" in t and "t" in t for t in turns)
+
+
+async def test_build_transcript_keeps_full_untruncated_text(tmp_path: Path) -> None:
+    out = tmp_path / "traceforge.db"
+    await _seed_transcript(out)
+    repo = DashboardRepository(DashboardPaths(output_db=out, system_db=tmp_path / "absent.db"))
+
+    turns = repo.build_transcript(TID)["turns"]  # type: ignore[index]
+    # The assistant body is returned in full, newlines preserved — not the 140-char
+    # collapsed preview the timeline uses.
+    assert turns[1]["text"] == _LONG_ASSISTANT
+    assert len(turns[1]["text"]) > 140
+    assert "\n" in turns[1]["text"]
+    # A tool call renders its invocation then its output, in that order.
+    assert turns[3]["text"] == "rm -rf /tmp/x\n\nremoved"
+
+
+async def test_build_transcript_unknown_session_returns_none(tmp_path: Path) -> None:
+    out = tmp_path / "traceforge.db"
+    await _seed_transcript(out)
+    repo = DashboardRepository(DashboardPaths(output_db=out, system_db=tmp_path / "absent.db"))
+    assert repo.build_transcript("does-not-exist") is None


### PR DESCRIPTION
## What & why

`RunView` could show a run's risk timeline and per-event inspector, but every event's free text was truncated to a one-line `summary` — there was no way to read a run's actual content top-to-bottom. This adds a per-run **full-text transcript**: user/assistant/system messages and tool commands + output, in order.

The full text gets its own dedicated endpoint rather than riding on `GET /api/runs` — which #150 is moving toward an event-body-free list projection — so full bodies never inflate the bounded fleet payload and load only when a reader opens the panel.

## Backend (`src/traceforge/dashboard`)
- `DashboardRepository.build_transcript(session_id)` → `{id, turns[]}`; one turn per `enriched_events` row in chronological order, each `{id, t, role, label, kind, text}`. `role` is derived from `kind` (user/assistant/system/tool); `text` is the **complete, untruncated** payload text (newlines preserved) — distinct from `_summarize`'s one-line, 140-char preview.
- New route `GET /api/runs/{id}/transcript`, registered before the bare `/{id}` route so the drill-in read never shadows it. Unknown run / no output DB → 404, consistent with the other read-only endpoints.

## Frontend (`dashboard/src`)
- `Transcript` / `TranscriptTurn` / `TranscriptRole` types, a `getTranscript(id)` client (no Date revival — `t` stays an ISO string), and a lazy `useTranscript(runId, enabled)` hook keyed by run id.
- A collapsible full-width **Transcript** panel in `RunView` that fetches on open and renders each turn with a per-role accent rail, label, timestamp, and `whitespace-pre-wrap` full text; loading / error / empty states handled.

## Tests & checks
- `tests/e2e/test_dashboard_repository.py`: role/label/order mapping, full untruncated text (asserts a >140-char assistant body survives and a tool turn renders invocation + output), unknown-session → `None`.
- `tests/e2e/test_dashboard_api.py`: `/transcript` 200 shape + 404 paths.
- Full Python suite: **3577 passed, 8 skipped**. `ruff check` + `ruff format --check` clean (pinned 0.15.20).
- Frontend: `tsc -b` + `pnpm build` pass; `oxlint` clean (only pre-existing warnings).

Closes #184