### PR TITLE
Titler honesty: strip system-prompt contamination and abstain on anchorless spans

### DIFF
--- a/src/traceforge/title/context.py
+++ b/src/traceforge/title/context.py
@@ -266,6 +266,39 @@ def salient_symbols(
 
 
 # ------------------------------------------------------------------- assemble
+#: Slot keys that carry a concrete *subject* the span acted on, as opposed to the
+#: verb-side ``actions`` / free-text ``notes`` which name no entity. When none of
+#: these is present the span model has nothing to anchor on and tends to
+#: hallucinate a subject, so the caller abstains from trusting it.
+_ANCHOR_SLOTS = frozenset({"intent", "files", "symbols"})
+
+
+def _drop_system(rows: list[dict]) -> list[dict]:
+    """Filter out ``message.system`` events before mining.
+
+    System prompts embed tool-doc examples, boilerplate file names and code
+    identifiers that are not part of what the agent actually *did* this span;
+    mining them contaminates the ``files``/``symbols``/``notes`` slots with
+    prompt scaffolding. They carry no signal about the segment's real subject, so
+    they are dropped source-agnostically here.
+    """
+    return [r for r in rows if not str(r.get("kind", "")).startswith("message.system")]
+
+
+def has_anchor(ctx: str) -> bool:
+    """Whether a distilled context names a concrete subject.
+
+    ``True`` iff the context carries an ``intent``, ``files`` or ``symbols``
+    slot -- a real entity to title. A context of only ``actions``/``notes`` has
+    no subject anchor, so a model title over it is a guess; callers fall back to
+    an extractive heuristic (or abstain) in that case.
+    """
+    for part in ctx.split(" | "):
+        if part.split(":", 1)[0].strip() in _ANCHOR_SLOTS:
+            return True
+    return False
+
+
 def distilled_context(rows: list[dict]) -> str:
     """The golden platter: the few highest-signal facts about a span.
 
@@ -273,6 +306,7 @@ def distilled_context(rows: list[dict]) -> str:
     in sequence order. Returns the slot string the titler was trained on, or
     ``"(no signal)"`` when nothing useful is extractable.
     """
+    rows = _drop_system(rows)
     parts: list[str] = []
     intent = next((extract_intent(r) for r in rows if extract_intent(r)), None)
     if intent:
@@ -292,4 +326,4 @@ def distilled_context(rows: list[dict]) -> str:
     return " | ".join(parts) if parts else "(no signal)"
 
 
-__all__ = ["STOP", "distilled_context"]
+__all__ = ["STOP", "distilled_context", "has_anchor"]

--- a/src/traceforge/title/inferencer.py
+++ b/src/traceforge/title/inferencer.py
@@ -53,7 +53,8 @@ from dataclasses import dataclass, field
 from traceforge.phase.event_rows import event_to_feature_row
 from traceforge.types import EventKind, SessionEvent, TitleUpdate
 
-from .context import distilled_context, narration, payload_text
+from .context import distilled_context, has_anchor, narration, payload_text
+from .heuristics import heuristic_title
 from .hygiene import best_of, norm_key, pick_distinct
 
 _ACTIVITY = "activity-boundary"
@@ -226,16 +227,37 @@ class TitleInferencer:
             refinements.append(TitleRefinement(step_id, "step", step_title, closed.activity_id))
         return refinements
 
+    def _heuristic_fallback(self, rows: list[dict]) -> str:
+        """An extractive title over the span's own narration, or ``""``.
+
+        Used when the distilled context has no subject anchor (:func:`has_anchor`
+        is ``False``): the span model would hallucinate a subject, so instead we
+        title from the words actually spoken this span. Absent any narration this
+        yields ``""`` -- an honest abstention beats an invented title.
+        """
+        return heuristic_title(" ".join(narration(rows)))
+
     def _title(self, rows: list[dict]) -> str:
         ctx = distilled_context(rows)
         if ctx == "(no signal)":
             return ""
+        if not has_anchor(ctx):
+            return self._heuristic_fallback(rows)
         return best_of(self.model.candidates(ctx))
 
     def _title_distinct(self, rows: list[dict], used: set) -> str:
         ctx = distilled_context(rows)
         if ctx == "(no signal)":
             return ""
+        if not has_anchor(ctx):
+            title = self._heuristic_fallback(rows)
+            if not title:
+                return ""
+            key = norm_key(title)
+            if not key or key in used:
+                return ""  # collides with parent/sibling -> abstain, don't guess
+            used.add(key)
+            return title
         return pick_distinct(used, self.model.candidates(ctx))
 
     def new_stream(self, session_id: str, source: str = "") -> "SessionTitleStream":

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -193,7 +193,7 @@ class TestPipelineSessionEviction:
                 kind="tool.call",
                 session_id=session_id,
                 timestamp=datetime.now(timezone.utc),
-                payload={"tool_name": "edit"},
+                payload={"tool_name": "edit", "arguments": {"path": "client.py"}},
                 metadata=EventMetadata(source_framework="copilot"),
             )
 
@@ -662,7 +662,7 @@ class TestPipelineActivityTitleRefinement:
                 kind="tool.call",
                 session_id=session_id,
                 timestamp=datetime.now(timezone.utc),
-                payload={"tool_name": "edit"},
+                payload={"tool_name": "edit", "arguments": {"path": "client.py"}},
                 metadata=EventMetadata(source_framework="copilot", boundary=boundary),
             )
 

--- a/tests/unit/test_title_context.py
+++ b/tests/unit/test_title_context.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 
-from traceforge.title.context import distilled_context
+from traceforge.title.context import distilled_context, has_anchor
 
 
 def _row(kind="tool.call", tool_name=None, payload=None, binaries=(), structure=()):
@@ -82,3 +82,51 @@ def test_notes_slot_from_assistant_narration():
     ctx = distilled_context(rows)
     assert "notes:" in ctx
     assert "refactored the parser" in ctx
+
+
+def test_system_events_are_stripped_before_mining():
+    # A message.system event carries tool-doc / prompt scaffolding (example file
+    # names and identifiers) that is NOT what the agent did this span; it must be
+    # dropped so it can't contaminate the files/symbols slots, while the real
+    # assistant work is kept.
+    rows = [
+        _row(
+            kind="message.system",
+            payload={"content": "Use `example_helper` in config.py per the tool docs"},
+            binaries=["config.py"],
+        ),
+        _row(
+            kind="message.assistant",
+            payload={"content": "Updated `validate_token` to reject expired tokens"},
+        ),
+    ]
+    ctx = distilled_context(rows)
+    assert "validate_token" in ctx  # real work kept
+    assert "example_helper" not in ctx  # system-prompt contamination dropped
+    assert "config.py" not in ctx
+
+
+def test_system_only_span_has_no_signal():
+    # If the ONLY events are system prompts, there is nothing the agent did ->
+    # no signal, rather than a title mined from prompt boilerplate.
+    rows = [
+        _row(
+            kind="message.system",
+            tool_name="edit",
+            payload={"arguments": {"path": "client.py"}},
+            binaries=["client.py"],
+        )
+    ]
+    assert distilled_context(rows) == "(no signal)"
+
+
+def test_has_anchor_true_for_subject_slots():
+    assert has_anchor("intent: Adding retry logic to the client")
+    assert has_anchor("actions: edit | files: client.py")
+    assert has_anchor("symbols: validate_token")
+
+
+def test_has_anchor_false_without_subject_slots():
+    assert not has_anchor("actions: edit, shell")
+    assert not has_anchor("actions: edit | notes: we tried a few things")
+    assert not has_anchor("(no signal)")

--- a/tests/unit/test_title_inferencer.py
+++ b/tests/unit/test_title_inferencer.py
@@ -19,6 +19,7 @@ Two layers, mirroring the boundary-stream tests:
 from __future__ import annotations
 
 import importlib.util
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -30,12 +31,20 @@ from traceforge.types import EventMetadata, SessionEvent
 
 def _event(i, tool="edit", boundary=None, payload=None, kind="tool.call", metadata=True):
     md = EventMetadata(source_framework="copilot", boundary=boundary) if metadata else None
+    body = {"tool_name": tool}
+    if payload is None:
+        # A realistic tool call acts on a file, giving the span a concrete
+        # subject anchor so the span model (not the anchorless heuristic
+        # fallback) titles it. Signal-less fixtures pass payload={} to opt out.
+        body["arguments"] = {"path": "client.py"}
+    else:
+        body.update(payload)
     return SessionEvent(
         id=f"e{i}",
         kind=kind,
         session_id="S",
         timestamp=datetime.now(timezone.utc),
-        payload={"tool_name": tool, **(payload or {})},
+        payload=body,
         metadata=md,
     )
 
@@ -416,6 +425,74 @@ def test_refine_activity_without_refiner_returns_empty():
     from traceforge.title.inferencer import _ClosedActivity
 
     assert inf.refine_activity(_ClosedActivity("e0", "Title 0", [("e0", [])])) == []
+
+
+# ─── honest abstention: no subject anchor -> heuristic, never a model guess ───
+
+
+def _frow(kind="tool.call", tool_name=None, payload=None):
+    """A minimal event feature-row (the shape ``distilled_context`` consumes)."""
+    return {
+        "kind": kind,
+        "tool_name": tool_name,
+        "payload_json": json.dumps(payload) if payload is not None else None,
+        "binaries": [],
+        "structure": [],
+    }
+
+
+def test_anchored_span_still_uses_the_model():
+    # A span with a real subject anchor (a stated intent) is titled by the span
+    # model exactly as before.
+    fake = _FakeTitle()
+    inf = TitleInferencer(model=fake)
+    rows = [
+        _frow(
+            tool_name="report_intent",
+            payload={
+                "tool_name": "report_intent",
+                "arguments": {"intent": "Adding retry logic to the client"},
+            },
+        )
+    ]
+    title = inf._title(rows)
+    assert fake.contexts  # the model was consulted
+    assert title == "Title 0"
+
+
+def test_anchorless_span_falls_back_to_heuristic_not_model():
+    # Only narration, no intent/files/symbols: the model would hallucinate a
+    # subject, so we title extractively from the words actually spoken and never
+    # invoke the model.
+    fake = _FakeTitle()
+    inf = TitleInferencer(model=fake)
+    rows = [_frow(kind="message.user", payload={"content": "Please fix the flaky retry behavior"})]
+    title = inf._title(rows)
+    assert fake.contexts == []  # model NOT consulted (no anchor)
+    assert title and "retry" in title.lower()  # grounded in the real words
+
+
+def test_anchorless_span_without_narration_abstains():
+    # Actions only, nothing spoken: no honest title exists, so abstain (return
+    # "") rather than let the model invent one.
+    fake = _FakeTitle()
+    inf = TitleInferencer(model=fake)
+    rows = [_frow(tool_name="edit"), _frow(tool_name="shell")]
+    assert inf._title(rows) == ""
+    assert fake.contexts == []  # the model never guessed
+
+
+def test_title_distinct_heuristic_fallback_respects_used():
+    # The anchorless heuristic fallback still honors parent/sibling distinctness:
+    # a second span with identical words abstains instead of repeating the title.
+    fake = _FakeTitle()
+    inf = TitleInferencer(model=fake)
+    rows = [_frow(kind="message.user", payload={"content": "Please fix the flaky retry behavior"})]
+    used: set = set()
+    first = inf._title_distinct(rows, used)
+    assert first and fake.contexts == []
+    second = inf._title_distinct(rows, used)
+    assert second == ""  # collides with the sibling -> abstain, don't guess
 
 
 # ─── real packaged model ─────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #186

Two serve-side fixes to stop the live activity/step titler emitting dishonest titles. No retraining.

## F1 — system-prompt contamination (`title/context.py`)
`distilled_context()` mined its slots from **all** span rows, including `message.system` events, so tool-doc example file names and identifiers embedded in system prompts leaked into the `files`/`symbols`/`notes` slots and tainted the title. Now `message.system` events are dropped before mining (source-agnostic), and a system-only span distils to `(no signal)`.

## F2 — hallucinated titles for anchorless spans (`title/inferencer.py`)
`_title()`/`_title_distinct()` previously only abstained when the context was literally `(no signal)`. A context of just `actions:`/`notes:` (no `intent`, `files`, or `symbols`) names no subject, yet the span model was still asked to title it and invented one. The gate is now widened via a new `has_anchor()` helper:

- **anchored** (real intent/file/symbol) → span model, unchanged.
- **anchorless with narration** → extractive `heuristic_title` over the span's own words (grounded, never invented).
- **anchorless with no narration** → abstain (emit no title). The distinct path still respects parent/sibling de-dup on the fallback.

## Tests
Targeted unit tests added to `tests/unit/test_title_context.py` (system stripping, `has_anchor`) and `tests/unit/test_title_inferencer.py` (anchored→model, anchorless→heuristic, no-narration→abstain, distinctness). Tool-call fixtures shared by the title/pipeline tests were anchored with a realistic file path (a real edit touches a file) so the model path stays covered under the new gate.

`pytest -k title` → 122 passed. Ruff check + format (0.15.20) clean on changed files. Full suite not run locally (per coordinator time budget); CI Test workflow will confirm.