### PR TITLE
Capture AI Units (AIU) as the primary consumption signal; demote premium requests (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI Units (AIU / "AI credits") are now the primary Copilot consumption signal**,
+  captured end-to-end. The `copilot` preprocessor carries each model's
+  `session.shutdown.data.modelMetrics.<model>.totalNanoAiu` (nano-AIU) onto its
+  synthetic `assistant.usage` record; the watch bridge stashes it in
+  `usage_records.attributes.nano_aiu`; and the dashboard read layer sums it per run
+  and per model (`usage.aiuNano`). Because per-model AIU sums exactly to the
+  session's top-level `totalNanoAiu`, no separate top-level record is synthesized.
+  nano-AIU is kept as an integer through the pipeline and divided by 1e9 (→ AIU) only
+  at render (`fmtAiu`). The Fleet, Cost, and Run views now headline **AI credits**
+  and demote the premium-request count to a secondary/legacy stat. Null-until-seen
+  throughout: an unknown AIU renders `—` (non-Copilot runs carry none), a genuine `0`
+  is kept, and no dollars are ever derived (`cost_usd` stays `None`).
 - `copilot` (GitHub Copilot CLI) recognized by ingest auto-detection, reading the
   per-session `~/.copilot/session-state/<uuid>/events.jsonl` streams (override the
   root with `COPILOT_SESSION_STATE_DIR`).

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -17,6 +17,20 @@ export const fmtCost = (n: number | null | undefined) =>
 export const premiumReq = (n: number | null | undefined) =>
   n == null ? "" : `${n} premium request${n === 1 ? "" : "s"}`;
 
+/** Render a run's AI-Unit (AIU) consumption from integer nano-AIU, or "—" when
+ * unknown. AIU ("AI credits") is Copilot's PRIMARY billing signal; it rides the
+ * whole pipeline as integer nano-AIU and is divided by 1e9 ONLY here (no float
+ * precision loss upstream). Null (every non-Copilot source) renders "—"; a genuine
+ * 0 renders "0.0 AIU" (distinct from unknown). Formatted to one decimal with
+ * thousands separators, e.g. "66,596.4 AIU". */
+export const fmtAiu = (nano: number | null | undefined) =>
+  nano == null
+    ? "—"
+    : (nano / 1e9).toLocaleString("en-US", {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }) + " AIU";
+
 export const tk = (n: number) => (n >= 1000 ? (n / 1000).toFixed(1) + "k" : String(n));
 
 /** Whole-percent share of `n` over `total`, or null when either is unknown (null)

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -95,10 +95,12 @@ export interface RunGap {
 // rows (one entry per distinct model string; a blank model "" is kept as its own
 // entry — labelled "unknown model" — because its tokens are real). The count
 // fields are null when unknown (the source never reported them, e.g. non-Copilot)
-// and a real number — including a genuine 0 — once any row carries them. `input`
-// and `output` are token grand totals and always numeric.
+// and a real number — including a genuine 0 — once any row carries them. `aiuNano`
+// is per-model AI-Unit consumption in nano-AIU (Copilot's primary billing signal);
+// `input` and `output` are token grand totals and always numeric.
 export interface ModelUsage {
   model: string;
+  aiuNano: number | null;
   premiumRequests: number | null;
   requests: number | null;
   inputUncached: number | null;
@@ -119,16 +121,20 @@ export interface Run {
   events: TEvent[];
   // `cost` is null when the run carries no dollar cost on the wire (e.g. GitHub
   // Copilot CLI, which emits no dollars at all) — rendered as "—" (unknown), never
-  // a fake "$0.00". `premiumRequests` is Copilot's only real billing signal: the
-  // per-run premium-request count (summed across models); null when unknown, a
-  // true 0 when the run genuinely made none. `inputUncached`/`cacheRead`/
-  // `cacheCreation` are cache-aware token classes and `requestsTotal` the request
-  // count — each null until some usage row reports it (unknown vs a real 0).
-  // `models` carries the per-model attribution (empty when no usage rows).
+  // a fake "$0.00". `aiuNano` is Copilot's PRIMARY billing signal: per-run AI-Unit
+  // consumption in nano-AIU (summed across models; divide by 1e9 for AIU) — null
+  // when unknown, a true 0 when the run genuinely consumed none. `premiumRequests`
+  // is a secondary/legacy signal: the per-run premium-request count (summed across
+  // models); null when unknown, a true 0 when the run genuinely made none.
+  // `inputUncached`/`cacheRead`/`cacheCreation` are cache-aware token classes and
+  // `requestsTotal` the request count — each null until some usage row reports it
+  // (unknown vs a real 0). `models` carries the per-model attribution (empty when
+  // no usage rows).
   usage: {
     in: number;
     out: number;
     cost: number | null;
+    aiuNano: number | null;
     premiumRequests: number | null;
     inputUncached: number | null;
     cacheRead: number | null;

--- a/dashboard/src/views/Cost.tsx
+++ b/dashboard/src/views/Cost.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useRuns } from "@/lib/queries";
-import { nsum, pct, tk } from "@/lib/format";
+import { fmtAiu, nsum, pct, tk } from "@/lib/format";
 import { G } from "@/data/tips";
 import { KpiCard } from "@/components/KpiCard";
 import { DistBar } from "@/components/DistBar";
@@ -15,16 +15,19 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
-// GitHub Copilot bills in premium REQUESTS, not dollars — the wire carries no
-// per-event cost. This view is built entirely from the real signals persisted on
-// usage_records: the premium-request count and cache-aware token attribution.
-// Every aggregate is null-aware: unknown stays null (rendered "—"), never a
-// fabricated 0, so a genuine zero (e.g. a model that ran no premium requests)
-// stays distinct from "we don't know".
+// GitHub Copilot bills in AI Units ("AIU", AI credits), not dollars — the wire
+// carries no per-event cost. AIU is now the PRIMARY billing signal; the
+// premium-request count is a secondary/legacy count. This view is built entirely
+// from the real signals persisted on usage_records: total AIU, the premium-request
+// count, and cache-aware token attribution. Every aggregate is null-aware: unknown
+// stays null (rendered "—"), never a fabricated 0, so a genuine zero (e.g. a model
+// that ran no premium requests) stays distinct from "we don't know". No dollars are
+// ever derived from AIU.
 export function Cost() {
   const { data: runs = [], isLoading } = useRuns();
 
   const totals = useMemo(() => {
+    const aiu = runs.reduce<number | null>((a, r) => nsum(a, r.usage.aiuNano), null);
     const premium = runs.reduce<number | null>((a, r) => nsum(a, r.usage.premiumRequests), null);
     const billedInput = runs.reduce<number | null>((a, r) => nsum(a, r.usage.inputUncached), null);
     const cacheRead = runs.reduce<number | null>((a, r) => nsum(a, r.usage.cacheRead), null);
@@ -37,6 +40,7 @@ export function Cost() {
     const cacheHeadline =
       inputTotal && cacheRead != null ? ((cacheRead / inputTotal) * 100).toFixed(1) + "%" : "—";
     return {
+      aiu,
       premium,
       billedInput,
       cacheRead,
@@ -64,6 +68,7 @@ export function Cost() {
       string,
       {
         model: string;
+        aiuNano: number | null;
         premiumRequests: number | null;
         requests: number | null;
         inputUncached: number | null;
@@ -76,12 +81,14 @@ export function Cost() {
       .forEach((mu) => {
         const o = m.get(mu.model) ?? {
           model: mu.model,
+          aiuNano: null,
           premiumRequests: null,
           requests: null,
           inputUncached: null,
           cacheRead: null,
           output: 0,
         };
+        o.aiuNano = nsum(o.aiuNano, mu.aiuNano);
         o.premiumRequests = nsum(o.premiumRequests, mu.premiumRequests);
         o.requests = nsum(o.requests, mu.requests);
         o.inputUncached = nsum(o.inputUncached, mu.inputUncached);
@@ -89,10 +96,12 @@ export function Cost() {
         o.output += mu.output;
         m.set(mu.model, o);
       });
-    // Sort premium desc, then requests desc. `?? -1` sinks unknown below a real 0
-    // so the honest "we don't know" rows never outrank a measured zero.
+    // Sort AIU desc (the primary signal), then premium desc, then requests desc.
+    // `?? -1` sinks unknown below a real 0 so the honest "we don't know" rows never
+    // outrank a measured zero.
     return [...m.values()].sort(
       (a, b) =>
+        (b.aiuNano ?? -1) - (a.aiuNano ?? -1) ||
         (b.premiumRequests ?? -1) - (a.premiumRequests ?? -1) ||
         (b.requests ?? -1) - (a.requests ?? -1)
     );
@@ -111,16 +120,22 @@ export function Cost() {
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Cost</h1>
         <p className="text-sm text-muted-foreground">
-          GitHub Copilot bills in premium requests; the wire carries no dollar cost (—). Tokens are
-          attributed per model.
+          GitHub Copilot bills in AI credits (AIU); premium requests are a secondary/legacy count.
+          The wire carries no dollar cost (—). Tokens are attributed per model.
         </p>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+        <KpiCard
+          label="AI credits"
+          value={fmtAiu(totals.aiu)}
+          sub="the billed signal"
+          tip={G.usage_records}
+        />
         <KpiCard
           label="Premium requests"
           value={totals.premium == null ? "—" : totals.premium}
-          sub="the billed signal"
+          sub="secondary / legacy count"
           tip={G.usage_records}
         />
         <KpiCard
@@ -167,8 +182,8 @@ export function Cost() {
         <CardHeader>
           <CardTitle className="text-base">By model</CardTitle>
           <CardDescription>
-            Premium requests and cache-aware token volume per model — the honest per-model
-            attribution.
+            AI credits, premium requests, and cache-aware token volume per model — the honest
+            per-model attribution.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -176,6 +191,7 @@ export function Cost() {
             <TableHeader>
               <TableRow className="hover:bg-transparent">
                 <TableHead>Model</TableHead>
+                <TableHead className="text-right">AI credits</TableHead>
                 <TableHead className="text-right">Premium reqs</TableHead>
                 <TableHead className="text-right">Requests</TableHead>
                 <TableHead className="text-right">Billed input</TableHead>
@@ -186,7 +202,7 @@ export function Cost() {
             <TableBody>
               {models.length === 0 ? (
                 <TableRow className="hover:bg-transparent">
-                  <TableCell colSpan={6} className="text-center text-muted-foreground">
+                  <TableCell colSpan={7} className="text-center text-muted-foreground">
                     No usage records.
                   </TableCell>
                 </TableRow>
@@ -196,6 +212,7 @@ export function Cost() {
                     <TableCell className="font-mono text-[12.5px]">
                       {o.model || "unknown model"}
                     </TableCell>
+                    <TableCell className="text-right tabular-nums">{fmtAiu(o.aiuNano)}</TableCell>
                     <TableCell className="text-right tabular-nums">
                       {o.premiumRequests == null ? "—" : o.premiumRequests}
                     </TableCell>

--- a/dashboard/src/views/Fleet.tsx
+++ b/dashboard/src/views/Fleet.tsx
@@ -4,7 +4,7 @@ import { RISK } from "@/lib/types";
 import { useRuns } from "@/lib/queries";
 import { useApp } from "@/store";
 import type { SortKey } from "@/store";
-import { dmin, fmtCost, hhmm, nsum, pct, premiumReq, tk } from "@/lib/format";
+import { dmin, fmtAiu, fmtCost, hhmm, nsum, pct, premiumReq, tk } from "@/lib/format";
 import { coverageStats, effectMix, scopeSplit } from "@/lib/coverage";
 import { G } from "@/data/tips";
 import { KpiCard } from "@/components/KpiCard";
@@ -39,14 +39,18 @@ export function Fleet() {
   const totals = useMemo(() => {
     const all = runs.flatMap((r) => r.events);
     const classified = all.filter((e) => (e.cls?.conf ?? 0) >= 0.9).length;
-    // GitHub Copilot bills in premium requests, not dollars — so the fleet-level
-    // billing signal is the premium-request COUNT, summed null-aware: it stays
-    // null (rendered "—") until some run reports a count, and never fabricates a 0.
-    // There is no fleet "$" because the wire carries no dollars.
+    // GitHub Copilot bills in AI Units ("AIU", AI credits), not dollars — so the
+    // PRIMARY fleet consumption signal is total AIU (nano-AIU summed null-aware,
+    // divided to AIU only at render). It stays null (rendered "—") until some run
+    // reports it, and never fabricates a 0. The premium-request COUNT is now a
+    // secondary/legacy signal, summed the same null-aware way. There is no fleet
+    // "$" because the wire carries no dollars.
+    const aiu = runs.reduce<number | null>((a, r) => nsum(a, r.usage.aiuNano), null);
     const premium = runs.reduce<number | null>((a, r) => nsum(a, r.usage.premiumRequests), null);
     return {
       live: runs.filter((r) => r.live).length,
       runs: runs.length,
+      aiu,
       premium,
       tokens: runs.reduce((a, r) => a + r.usage.in + r.usage.out, 0),
       classifiedPct: Math.round((classified / (all.length || 1)) * 100),
@@ -161,9 +165,13 @@ export function Fleet() {
         />
         <KpiCard label="Runs" value={totals.runs} sub="last 24h" tip={G.session_id} />
         <KpiCard
-          label="Premium reqs"
-          value={totals.premium == null ? "—" : totals.premium}
-          sub="all runs"
+          label="AI credits"
+          value={fmtAiu(totals.aiu)}
+          sub={
+            totals.premium == null
+              ? "AIU · — premium reqs"
+              : `AIU · ${totals.premium} premium req${totals.premium === 1 ? "" : "s"}`
+          }
           tip={G.usage_records}
         />
         <KpiCard label="Tokens" value={tk(totals.tokens)} sub="in + out" tip={G.usage_records} />
@@ -201,20 +209,30 @@ export function Fleet() {
               </Tip>
             </CardHeader>
             <CardContent>
-              {rail.consumption.hasData ? (
-                <div className="space-y-3">
-                  <DistBar segments={rail.consumption.segments} />
-                  <p className="text-[11px] leading-snug text-muted-foreground">
-                    {rail.consumption.cachePct != null &&
-                      `${rail.consumption.cachePct}% of input served from cache · `}
-                    {totals.premium == null
-                      ? "— premium requests"
-                      : `${totals.premium} premium request${totals.premium === 1 ? "" : "s"}`}
-                  </p>
+              <div className="space-y-3">
+                <div className="flex items-baseline justify-between">
+                  <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    AI credits
+                  </span>
+                  <span className="text-lg font-semibold tabular-nums">{fmtAiu(totals.aiu)}</span>
                 </div>
-              ) : (
-                <p className="text-[11px] leading-snug text-muted-foreground">No token breakdown</p>
-              )}
+                {rail.consumption.hasData ? (
+                  <>
+                    <DistBar segments={rail.consumption.segments} />
+                    <p className="text-[11px] leading-snug text-muted-foreground">
+                      {rail.consumption.cachePct != null &&
+                        `${rail.consumption.cachePct}% of input served from cache · `}
+                      {totals.premium == null
+                        ? "— premium requests"
+                        : `${totals.premium} premium request${totals.premium === 1 ? "" : "s"}`}
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-[11px] leading-snug text-muted-foreground">
+                    No token breakdown
+                  </p>
+                )}
+              </div>
             </CardContent>
           </Card>
           <Card>
@@ -305,6 +323,7 @@ export function Fleet() {
                 <TableHead>Identity</TableHead>
                 <TableHead>Risk</TableHead>
                 <TableHead className="text-right">Events</TableHead>
+                <TableHead className="text-right">AI credits</TableHead>
                 <TableHead className="text-right">Cost</TableHead>
                 <TableHead className="text-right">Duration</TableHead>
                 <TableHead className="text-right">Started</TableHead>
@@ -363,13 +382,14 @@ export function Fleet() {
                   </TableCell>
                   <TableCell className="text-right tabular-nums">{r.events.length}</TableCell>
                   <TableCell className="text-right tabular-nums">
-                    <div>{fmtCost(r.usage.cost)}</div>
+                    <div>{fmtAiu(r.usage.aiuNano)}</div>
                     {r.usage.premiumRequests != null && (
                       <div className="text-[11px] text-muted-foreground">
                         {premiumReq(r.usage.premiumRequests)}
                       </div>
                     )}
                   </TableCell>
+                  <TableCell className="text-right tabular-nums">{fmtCost(r.usage.cost)}</TableCell>
                   <TableCell className="text-right tabular-nums text-muted-foreground">
                     {dmin(r.durMs)}
                   </TableCell>

--- a/dashboard/src/views/RunView.tsx
+++ b/dashboard/src/views/RunView.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, ArrowLeft, ChevronRight, FileText, MessagesSquare } from
 import { useRuns, useTranscript } from "@/lib/queries";
 import type { TEvent, TranscriptRole, TranscriptTurn } from "@/lib/types";
 import { useApp } from "@/store";
-import { dmin, hhmm, fmtCost, fmtVal, premiumReq } from "@/lib/format";
+import { dmin, hhmm, fmtAiu, fmtCost, fmtVal, premiumReq } from "@/lib/format";
 import { buildChapters, locateEvent } from "@/lib/chapters";
 import { G, mtip } from "@/data/tips";
 import { Tip } from "@/components/Tip";
@@ -55,6 +55,8 @@ export function RunView() {
             <span>·</span>
             <span>{dmin(run.durMs)}</span>
             <span>·</span>
+            <span>{fmtAiu(run.usage.aiuNano)}</span>
+            <span>·</span>
             <span>{fmtCost(run.usage.cost)}</span>
             {run.usage.premiumRequests != null && (
               <>
@@ -93,7 +95,7 @@ export function RunView() {
           <div className="flex justify-between text-[10.5px] text-muted-foreground">
             <span>{hhmm(evs[0].t)}</span>
             <span>
-              {evs.length} events · {fmtCost(run.usage.cost)} total
+              {evs.length} events · {fmtAiu(run.usage.aiuNano)} total
               {run.usage.premiumRequests != null &&
                 ` · ${premiumReq(run.usage.premiumRequests)}`}
             </span>

--- a/docs/dashboard-spec.md
+++ b/docs/dashboard-spec.md
@@ -214,7 +214,7 @@ degraded modes + the data-source indicator.
 > **Usage token semantics (Copilot CLI shutdown-metrics path).** GitHub Copilot CLI
 > emits **no** per-turn usage event, so the authoritative whole-session token accounting
 > lives on the terminal `session.shutdown` event as `data.modelMetrics` — a per-model
-> map `{<model>: {requests: {count, cost}, usage: {inputTokens, outputTokens,
+> map `{<model>: {totalNanoAiu, requests: {count, cost}, usage: {inputTokens, outputTokens,
 > cacheReadTokens, cacheWriteTokens, reasoningTokens}}}` (`modelMetrics` may be a JSON
 > string or an object; both are decoded). The `copilot` preprocessor synthesizes one
 > `assistant.usage` block **per model** from it (stable dedup id `<shutdown-id>:<model>`),
@@ -230,9 +230,15 @@ degraded modes + the data-source indicator.
 > the lossless split kept in `usage_records.attributes` as
 > `{input_uncached, cache_read_tokens, cache_creation_tokens}`.
 > `reasoningTokens` is not surfaced separately (Copilot reports it as `0`; the provider
-> folds reasoning into output accounting). `cost_usd` is **`None`**: Copilot's
-> `requests.cost` is a **premium-request count**, not a dollar amount, so none is
-> derivable and none is synthesized (`build_run` degrades cost to `0.0` via `COALESCE`).
+> folds reasoning into output accounting). The **primary** billing signal is per-model
+> `totalNanoAiu` — AI Units ("AIU", AI credits) in *nano*-AIU — carried verbatim as an
+> integer onto each synthetic block (`nanoAiu`), stashed in
+> `usage_records.attributes.nano_aiu`, and summed per run and per model as `usage.aiuNano`
+> (per-model AIU sums exactly to the shutdown's top-level `totalNanoAiu`, so no separate
+> top-level record is synthesized; nano is divided by 1e9 → AIU only at render). `cost_usd`
+> is **`None`**: Copilot's `requests.cost` is a now-**secondary/legacy premium-request
+> count**, not a dollar amount, so none is derivable and none is synthesized (`build_run`
+> degrades cost to `0.0` via `COALESCE`).
 > `run.repo` comes from `session.start`'s `data.context.cwd` (surfaced as
 > `EventMetadata.repo` via the mapping's `repo_field`); `run.model` is the deduped
 > `usage_records` dominant model (e.g. `claude-sonnet-4.5`, `gpt-5`).

--- a/src/traceforge/cli/watch.py
+++ b/src/traceforge/cli/watch.py
@@ -474,12 +474,17 @@ def _usage_record_from(event) -> "UsageRecord | None":
         "cache_read_tokens": cache_read,
         "cache_creation_tokens": cache_write,
     }
-    # Copilot's per-model ``modelMetrics.requests`` counts (the only real billing
-    # signal on the wire — ``requests.cost`` is a premium-request *count*, not
-    # dollars) ride the synthetic usage payload. Preserve them losslessly so the
-    # dashboard can surface "N premium requests" where a fake "$0.00" once sat. A
-    # genuine ``0`` is a real zero and kept; absent keys (every non-Copilot source)
-    # add nothing, so ``attributes`` stays exactly the token split there.
+    # Copilot's per-model AI-Unit consumption (``modelMetrics.totalNanoAiu``, in
+    # nano-AIU) is now the **primary** billing signal on the wire; its per-model
+    # ``modelMetrics.requests`` counts are a **secondary/legacy** premium-request
+    # *count* (``requests.cost`` is a count, not dollars). Both ride the synthetic
+    # usage payload and are preserved losslessly here. Null-until-seen: a genuine
+    # ``0`` is a real zero and kept; absent keys (every non-Copilot source) add
+    # nothing, so ``attributes`` stays exactly the token split there. nano-AIU is
+    # kept as an integer end-to-end — only the frontend divides by 1e9.
+    nano_aiu = payload.get("nano_aiu")
+    if nano_aiu is not None:
+        attributes["nano_aiu"] = int(nano_aiu)
     premium_requests = payload.get("premium_requests")
     if premium_requests is not None:
         attributes["premium_requests"] = int(premium_requests)

--- a/src/traceforge/dashboard/repository.py
+++ b/src/traceforge/dashboard/repository.py
@@ -833,13 +833,17 @@ def _usage_breakdown(conn: sqlite3.Connection, session_id: str) -> dict[str, Any
     * ``cost`` — the summed ``cost_usd``, or ``None`` when no row carries dollars.
       GitHub Copilot emits none, so this stays ``None`` and renders "—" (unknown),
       never a fabricated "$0.00". No dollars are ever derived from the counts below.
-    * ``premiumRequests`` — Copilot's only real billing signal: the premium-request
+    * ``aiuNano`` — Copilot's **primary** billing signal: per-model AI-Unit
+      consumption in *nano*-AIU (``modelMetrics.<model>.totalNanoAiu``), summed
+      across models. Integer nano-AIU is kept verbatim; only the frontend divides
+      by 1e9 to AIU. ``None`` until some row carries it (unknown vs a genuine 0).
+    * ``premiumRequests`` — a **secondary/legacy** signal: the premium-request
       COUNT (``modelMetrics.<model>.requests.cost`` is a count, not dollars),
       summed across models.
     * ``inputUncached`` / ``cacheRead`` / ``cacheCreation`` — cache-aware token
       classes (billed/uncached vs cache read vs cache creation).
     * ``requestsTotal`` — total request count across models.
-    * ``models`` — per-model rows ``{model, premiumRequests, requests,
+    * ``models`` — per-model rows ``{model, aiuNano, premiumRequests, requests,
       inputUncached, cacheRead, cacheCreation, input, output}``.
 
     The unknown-vs-zero distinction is preserved throughout (see :func:`_nsum`):
@@ -865,6 +869,7 @@ def _usage_breakdown(conn: sqlite3.Connection, session_id: str) -> dict[str, Any
     in_tok = 0
     out_tok = 0
     cost: float | None = None
+    aiu: int | None = None
     premium: int | None = None
     uncached: int | None = None
     cache_read: int | None = None
@@ -881,12 +886,14 @@ def _usage_breakdown(conn: sqlite3.Connection, session_id: str) -> dict[str, Any
             cost = (cost or 0.0) + float(row["cost_usd"])
 
         attrs = _loads(row["attributes_json"])
+        a = _attr_count(attrs, "nano_aiu")
         p = _attr_count(attrs, "premium_requests")
         u = _attr_count(attrs, "input_uncached")
         cr = _attr_count(attrs, "cache_read_tokens")
         cc = _attr_count(attrs, "cache_creation_tokens")
         rt = _attr_count(attrs, "requests_total")
 
+        aiu = _nsum(aiu, a)
         premium = _nsum(premium, p)
         uncached = _nsum(uncached, u)
         cache_read = _nsum(cache_read, cr)
@@ -900,6 +907,7 @@ def _usage_breakdown(conn: sqlite3.Connection, session_id: str) -> dict[str, Any
         if agg is None:
             agg = {
                 "model": model,
+                "aiuNano": None,
                 "premiumRequests": None,
                 "requests": None,
                 "inputUncached": None,
@@ -911,6 +919,7 @@ def _usage_breakdown(conn: sqlite3.Connection, session_id: str) -> dict[str, Any
             models[model] = agg
         agg["input"] += row_in
         agg["output"] += row_out
+        agg["aiuNano"] = _nsum(agg["aiuNano"], a)
         agg["premiumRequests"] = _nsum(agg["premiumRequests"], p)
         agg["requests"] = _nsum(agg["requests"], rt)
         agg["inputUncached"] = _nsum(agg["inputUncached"], u)
@@ -921,6 +930,7 @@ def _usage_breakdown(conn: sqlite3.Connection, session_id: str) -> dict[str, Any
         "in": in_tok,
         "out": out_tok,
         "cost": cost,
+        "aiuNano": aiu,
         "premiumRequests": premium,
         "inputUncached": uncached,
         "cacheRead": cache_read,

--- a/src/traceforge/mappings/copilot.yaml
+++ b/src/traceforge/mappings/copilot.yaml
@@ -199,11 +199,13 @@ events:
   # ``UsageRecord.attributes``.
   # ``msg_id`` (``<shutdown-id>:<model>``) dedups a replayed shutdown. No dollar
   # cost exists in the wire, so ``cost_usd`` stays null. ``cost``/``duration`` remain
-  # mapped for back-compat with producers that carry them. ``premiumRequests`` /
-  # ``requestsTotal`` carry the one real billing signal Copilot emits — the
-  # per-model ``modelMetrics.requests`` counts (``cost`` is a premium-request
-  # *count*, not dollars) — which the bridge stashes in ``UsageRecord.attributes``
-  # so the dashboard can surface "N premium requests" instead of a fake "$0.00".
+  # mapped for back-compat with producers that carry them. ``nanoAiu`` carries the
+  # **primary** billing signal Copilot now emits — the per-model
+  # ``modelMetrics.totalNanoAiu`` (AI Units in nano-AIU; the read layer sums it and
+  # only the frontend divides by 1e9). ``premiumRequests`` / ``requestsTotal`` are
+  # the now-**secondary/legacy** per-model ``modelMetrics.requests`` counts
+  # (``cost`` is a premium-request *count*, not dollars). All three are stashed in
+  # ``UsageRecord.attributes`` (null-until-seen: absent keys add nothing).
   assistant.usage:
     kind: telemetry.usage
     payload:
@@ -215,6 +217,7 @@ events:
       cost_usd: data.cost
       duration_ms: data.duration
       msg_id: data.messageId
+      nano_aiu: data.nanoAiu
       premium_requests: data.premiumRequests
       requests_total: data.requestsTotal
 

--- a/src/traceforge/preprocessors/copilot.py
+++ b/src/traceforge/preprocessors/copilot.py
@@ -4,8 +4,9 @@ GitHub Copilot CLI never emits a per-turn ``assistant.usage`` event, so the Cost
 lens (``usage_records``) would stay empty. The authoritative token accounting for a
 whole session lives on the terminal ``session.shutdown`` event as
 ``data.modelMetrics`` — a per-model map of the complete input/output/cache token
-totals. This preprocessor decodes it and appends one synthetic ``assistant.usage``
-block per model so the existing YAML mapping can bridge each into ``usage_records``.
+totals **and per-model AI-Unit consumption** (``totalNanoAiu``). This preprocessor
+decodes it and appends one synthetic ``assistant.usage`` block per model so the
+existing YAML mapping can bridge each into ``usage_records``.
 
 Every original event is preserved verbatim (returned first), so the enriched-events
 timeline is unchanged. Only ``session.shutdown`` ever produces extra dicts.
@@ -53,7 +54,10 @@ def preprocess_copilot(obj: dict[str, Any]) -> list[dict[str, Any]]:
         if not isinstance(usage, dict):
             continue
         requests = entry.get("requests")
-        usage_blocks.append(_usage_block(str(model), usage, requests, shutdown_id, timestamp))
+        nano_aiu = entry.get("totalNanoAiu")
+        usage_blocks.append(
+            _usage_block(str(model), usage, requests, nano_aiu, shutdown_id, timestamp)
+        )
 
     return [obj, *usage_blocks]
 
@@ -80,7 +84,12 @@ def _decode_model_metrics(raw: Any) -> dict[str, Any]:
 
 
 def _usage_block(
-    model: str, usage: dict[str, Any], requests: Any, shutdown_id: str, timestamp: Any
+    model: str,
+    usage: dict[str, Any],
+    requests: Any,
+    nano_aiu: Any,
+    shutdown_id: str,
+    timestamp: Any,
 ) -> dict[str, Any]:
     """Build one synthetic ``assistant.usage`` event for a single model.
 
@@ -103,16 +112,25 @@ def _usage_block(
     accounting).
 
     No dollar cost exists in the wire, so none is emitted and ``cost_usd`` stays
-    null. The one real billing signal Copilot carries is the per-model
-    ``requests`` block: ``requests.cost`` is a **premium-request count** (not
-    dollars — included models like haiku/sonnet stay ``0`` even at high volume;
-    only premium models such as opus accrue) and ``requests.count`` is the total
-    request count. Both are captured here (as ``premiumRequests`` /
-    ``requestsTotal``) so the bridge can stash them in ``UsageRecord.attributes``
-    and the dashboard can surface "N premium requests" instead of a fake "$0.00".
-    A genuine ``0`` premium count is preserved (it is a real zero); a missing or
-    malformed ``requests`` block yields no keys at all (honest-blank, never
-    fabricated).
+    null. The **primary** billing signal Copilot now carries is the per-model
+    ``totalNanoAiu`` — AI Units ("AIU", AI credits) expressed in *nano*-AIU
+    (divide by 1e9 for AIU). It is captured verbatim as an integer ``nanoAiu``
+    (never converted here — the pipeline keeps nano precision end-to-end and only
+    the frontend divides). Because the per-model AIU sums exactly to the
+    shutdown's top-level ``totalNanoAiu`` (verified against real ``~/.copilot``
+    sessions), the read layer simply sums each block's ``nanoAiu`` — no separate
+    top-level event is synthesized.
+
+    The per-model ``requests`` block is now a **secondary/legacy** count, not the
+    headline: ``requests.cost`` is a **premium-request count** (not dollars —
+    included models like haiku/sonnet stay ``0`` even at high volume; only premium
+    models such as opus accrue) and ``requests.count`` is the total request count.
+    Both are still captured (as ``premiumRequests`` / ``requestsTotal``) so the
+    bridge can stash them in ``UsageRecord.attributes`` alongside ``nanoAiu``.
+
+    Every count uses honest-blank semantics via :func:`_as_int_opt`: a genuine
+    ``0`` (AIU or premium) is preserved (it is a real zero); a missing or
+    malformed value yields no key at all (never fabricated).
     """
     input_total = _as_int(usage.get("inputTokens"))
     cache_read = _as_int(usage.get("cacheReadTokens"))
@@ -130,6 +148,9 @@ def _usage_block(
         "cacheWriteTokens": cache_write,
         "messageId": msg_id,
     }
+    aiu = _as_int_opt(nano_aiu)
+    if aiu is not None:
+        data["nanoAiu"] = aiu
     if isinstance(requests, dict):
         premium = _as_int_opt(requests.get("cost"))
         if premium is not None:

--- a/tests/e2e/test_copilot_identity_cost_enrichment.py
+++ b/tests/e2e/test_copilot_identity_cost_enrichment.py
@@ -46,13 +46,21 @@ _UUID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 _UUID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
 
 
-def _session_lines(*, tag: str, model: str, cwd: str, usage: dict) -> list[str]:
+def _session_lines(
+    *, tag: str, model: str, cwd: str, usage: dict, nano_aiu: int | None = None
+) -> list[str]:
     """Real-shaped Copilot ``events.jsonl`` lines: start, exchange, tool, shutdown.
 
     ``session.shutdown`` carries ``modelMetrics`` (the whole-session token accounting)
-    — the only place Copilot records usage. ``requests.cost`` is a premium-request
-    *count*, not a dollar amount, so no cost is derivable.
+    — the only place Copilot records usage. ``modelMetrics.<model>.totalNanoAiu`` is
+    the PRIMARY billing signal (AI Units in nano-AIU); it is injected only when
+    ``nano_aiu`` is provided, so a session without it stays honestly unknown (aiuNano
+    → None). ``requests.cost`` is a now-secondary premium-request *count*, not a dollar
+    amount, so no cost is derivable.
     """
+    entry: dict = {"requests": {"count": 1, "cost": 1}, "usage": usage}
+    if nano_aiu is not None:
+        entry["totalNanoAiu"] = nano_aiu
     return [
         json.dumps(
             {
@@ -115,7 +123,7 @@ def _session_lines(*, tag: str, model: str, cwd: str, usage: dict) -> list[str]:
                 "data": {
                     "shutdownType": "routine",
                     "totalApiDurationMs": 3500,
-                    "modelMetrics": {model: {"requests": {"count": 1, "cost": 1}, "usage": usage}},
+                    "modelMetrics": {model: entry},
                 },
             }
         ),
@@ -137,6 +145,9 @@ def _seed_state(root: Path) -> None:
                 "cacheWriteTokens": 0,
                 "reasoningTokens": 0,
             },
+            # Session A reports AIU (10.52 AIU) — proves the primary signal flows
+            # raw JSONL → preprocessor → adapter → sink → repo.
+            10517580000,
         ),
         (
             _UUID_B,
@@ -150,12 +161,14 @@ def _seed_state(root: Path) -> None:
                 "cacheWriteTokens": 0,
                 "reasoningTokens": 0,
             },
+            # Session B reports NO totalNanoAiu → aiuNano stays unknown (None) end-to-end.
+            None,
         ),
     ]
-    for uuid, tag, model, cwd, usage in sessions:
+    for uuid, tag, model, cwd, usage, nano_aiu in sessions:
         session_dir = root / uuid
         session_dir.mkdir(parents=True, exist_ok=True)
-        lines = _session_lines(tag=tag, model=model, cwd=cwd, usage=usage)
+        lines = _session_lines(tag=tag, model=model, cwd=cwd, usage=usage, nano_aiu=nano_aiu)
         (session_dir / "events.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -226,8 +239,10 @@ def test_usage_input_breakdown_is_preserved(tmp_path, monkeypatch) -> None:
         "input_uncached": 29824,
         "cache_read_tokens": 7058,
         "cache_creation_tokens": 0,
-        # The premium-request COUNT (the only real billing signal Copilot emits) is
-        # captured losslessly. requests.cost is a premium-request count, NOT dollars.
+        # AIU (nano-AIU) is the PRIMARY billing signal Copilot emits, captured
+        # losslessly as an integer. The premium-request COUNT (requests.cost — a
+        # count, NOT dollars) is now a secondary/legacy signal, kept alongside.
+        "nano_aiu": 10517580000,
         "premium_requests": 1,
         "requests_total": 1,
     }
@@ -271,6 +286,8 @@ def test_build_run_surfaces_repo_model_and_usage(tmp_path, monkeypatch) -> None:
     assert run_a["usage"]["out"] == 354
     # No wire cost → SUM(NULL) → None (honest "unknown", NOT a fabricated $0.00).
     assert run_a["usage"]["cost"] is None
+    # AIU is the primary signal and flows end-to-end: 10517580000 nano (10.52 AIU).
+    assert run_a["usage"]["aiuNano"] == 10517580000
     # The premium-request count IS surfaced (1 per the seeded modelMetrics).
     assert run_a["usage"]["premiumRequests"] == 1
 
@@ -280,4 +297,6 @@ def test_build_run_surfaces_repo_model_and_usage(tmp_path, monkeypatch) -> None:
     assert run_b["model"] == "gpt-5"
     assert run_b["usage"]["in"] == 100
     assert run_b["usage"]["cost"] is None
+    # Session B carried no totalNanoAiu → aiuNano stays unknown (None), never a fake 0.
+    assert run_b["usage"]["aiuNano"] is None
     assert run_b["usage"]["premiumRequests"] == 1

--- a/tests/e2e/test_dashboard_repository.py
+++ b/tests/e2e/test_dashboard_repository.py
@@ -266,6 +266,7 @@ async def test_list_runs_summarizes_identity_and_usage(full_repo: DashboardRepos
         "in": 1000,
         "out": 500,
         "cost": 0.9,
+        "aiuNano": None,
         "premiumRequests": None,
         "inputUncached": None,
         "cacheRead": None,
@@ -274,6 +275,7 @@ async def test_list_runs_summarizes_identity_and_usage(full_repo: DashboardRepos
         "models": [
             {
                 "model": "gpt-4o",
+                "aiuNano": None,
                 "premiumRequests": None,
                 "requests": None,
                 "inputUncached": None,
@@ -303,6 +305,7 @@ async def test_build_run_core_fields(full_repo: DashboardRepository) -> None:
         "in": 1000,
         "out": 500,
         "cost": 0.9,
+        "aiuNano": None,
         "premiumRequests": None,
         "inputUncached": None,
         "cacheRead": None,
@@ -311,6 +314,7 @@ async def test_build_run_core_fields(full_repo: DashboardRepository) -> None:
         "models": [
             {
                 "model": "gpt-4o",
+                "aiuNano": None,
                 "premiumRequests": None,
                 "requests": None,
                 "inputUncached": None,
@@ -471,13 +475,19 @@ async def test_premium_requests_surface_with_null_cost_and_zero_distinct(tmp_pat
 
 
 async def _seed_mixed(db: Path) -> None:
-    """One run mixing every usage shape: multi-model Copilot rows with the five
-    attribute keys, a genuine-zero-premium model, a blank-model row (real tokens,
-    unattributable), and a non-Copilot row with no attributes at all."""
+    """One run mixing every usage shape: multi-model Copilot rows carrying AIU
+    (nano-AIU) plus the five token/premium attribute keys, a genuine-zero-premium
+    model, a blank-model row (real tokens, unattributable, and — critically — no
+    ``nano_aiu`` key so its AIU stays unknown even though its premium is a real 0),
+    and a non-Copilot row with no attributes at all. The three Copilot models carry
+    the real per-session ``totalNanoAiu`` values (66450771325000 + 77277060000 +
+    68365100000 = 66596413485000 → 66,596.4 AIU) so the run-level sum reconstructs a
+    real session total."""
     sink = SqliteOutputSink(path=str(db))
     await sink.on_event(_bare_event_for("mix", _T0))
     rows = [
-        # Two opus rows → premium 600+9=609, requests 800+10=810, cacheRead 800+180=980.
+        # Two opus rows → premium 600+9=609, requests 800+10=810, cacheRead 800+180=980,
+        # AIU 66450771325000+77277060000=66528048385000.
         (
             "claude-opus-4.6",
             1000,
@@ -486,6 +496,7 @@ async def _seed_mixed(db: Path) -> None:
                 "input_uncached": 30,
                 "cache_read_tokens": 800,
                 "cache_creation_tokens": 170,
+                "nano_aiu": 66450771325000,
                 "premium_requests": 600,
                 "requests_total": 800,
             },
@@ -498,11 +509,13 @@ async def _seed_mixed(db: Path) -> None:
                 "input_uncached": 9,
                 "cache_read_tokens": 180,
                 "cache_creation_tokens": 11,
+                "nano_aiu": 77277060000,
                 "premium_requests": 9,
                 "requests_total": 10,
             },
         ),
-        # A model that genuinely made ZERO premium requests — a real 0, not unknown.
+        # A model that genuinely made ZERO premium requests — a real 0, not unknown —
+        # but DID consume AIU (68365100000 nano).
         (
             "claude-haiku-4.5",
             100,
@@ -511,11 +524,14 @@ async def _seed_mixed(db: Path) -> None:
                 "input_uncached": 100,
                 "cache_read_tokens": 0,
                 "cache_creation_tokens": 0,
+                "nano_aiu": 68365100000,
                 "premium_requests": 0,
                 "requests_total": 38,
             },
         ),
         # Blank model: real tokens the wire couldn't attribute — kept, not dropped.
+        # It carries a genuine-0 premium but NO ``nano_aiu`` key, proving AIU stays
+        # unknown (None) per-key independently of the premium signal.
         (
             "",
             50,
@@ -556,9 +572,9 @@ async def _seed_mixed(db: Path) -> None:
 
 
 async def test_usage_breakdown_multi_model_cache_and_null_vs_zero(tmp_path: Path) -> None:
-    """The full null-aware usage breakdown: per-model attribution, run-level cache
-    and premium sums, blank-model retention, and unknown (None) staying distinct
-    from a genuine 0 within the same run."""
+    """The full null-aware usage breakdown: per-model attribution, run-level AIU,
+    cache and premium sums, blank-model retention, and unknown (None) staying
+    distinct from a genuine 0 within the same run — per key independently."""
     out = tmp_path / "traceforge.db"
     await _seed_mixed(out)
     repo = DashboardRepository(DashboardPaths(output_db=out, system_db=tmp_path / "absent.db"))
@@ -571,6 +587,12 @@ async def test_usage_breakdown_multi_model_cache_and_null_vs_zero(tmp_path: Path
     assert usage["in"] == 1650
     assert usage["out"] == 590
     assert usage["cost"] is None
+    # AIU is the PRIMARY billing signal: per-model nano-AIU summed null-until-seen.
+    # The blank-model row carries no nano_aiu key and the gpt-4o row no attributes,
+    # so both contribute nothing — the sum is exactly the three Copilot models, which
+    # reconstructs the real session total (÷1e9 → 66,596.4 AIU).
+    assert usage["aiuNano"] == 66596413485000
+    assert round(usage["aiuNano"] / 1e9, 1) == 66596.4
     # Run-level counts sum only rows that carry the key (the no-attrs gpt-4o row
     # contributes nothing rather than a fabricated 0).
     assert usage["premiumRequests"] == 609
@@ -584,6 +606,7 @@ async def test_usage_breakdown_multi_model_cache_and_null_vs_zero(tmp_path: Path
     assert set(by_model) == {"claude-opus-4.6", "claude-haiku-4.5", "", "gpt-4o"}
     assert by_model["claude-opus-4.6"] == {
         "model": "claude-opus-4.6",
+        "aiuNano": 66528048385000,
         "premiumRequests": 609,
         "requests": 810,
         "inputUncached": 39,
@@ -592,13 +615,19 @@ async def test_usage_breakdown_multi_model_cache_and_null_vs_zero(tmp_path: Path
         "input": 1200,
         "output": 500,
     }
-    # Genuine zero premium — a real 0, distinct from unknown.
+    # Genuine zero premium — a real 0, distinct from unknown — but real AIU consumed.
     assert by_model["claude-haiku-4.5"]["premiumRequests"] == 0
+    assert by_model["claude-haiku-4.5"]["aiuNano"] == 68365100000
     assert by_model[""]["inputUncached"] == 50
     assert by_model[""]["input"] == 50
+    # Blank model made a real 0 premium requests yet its AIU stays UNKNOWN (None):
+    # the two signals are tracked per-key, never conflated.
+    assert by_model[""]["premiumRequests"] == 0
+    assert by_model[""]["aiuNano"] is None
     # Non-Copilot model carries no attributes → every count is unknown (None),
     # never coerced to 0; its tokens are still real numbers.
     gpt = by_model["gpt-4o"]
+    assert gpt["aiuNano"] is None
     assert gpt["premiumRequests"] is None
     assert gpt["requests"] is None
     assert gpt["inputUncached"] is None
@@ -612,9 +641,16 @@ async def test_usage_breakdown_multi_model_cache_and_null_vs_zero(tmp_path: Path
 
     # The list/summary path builds the identical breakdown (parity of both sites).
     summary = {r["id"]: r for r in repo.list_runs()}["mix"]
+    assert summary["usage"]["aiuNano"] == 66596413485000
     assert summary["usage"]["premiumRequests"] == 609
     assert summary["usage"]["cacheRead"] == 980
     assert summary["usage"]["cost"] is None
+    assert {m["model"]: m["aiuNano"] for m in summary["usage"]["models"]} == {
+        "claude-opus-4.6": 66528048385000,
+        "claude-haiku-4.5": 68365100000,
+        "": None,
+        "gpt-4o": None,
+    }
     assert {m["model"]: m["premiumRequests"] for m in summary["usage"]["models"]} == {
         "claude-opus-4.6": 609,
         "claude-haiku-4.5": 0,

--- a/tests/unit/test_copilot_identity_cost_enrichment.py
+++ b/tests/unit/test_copilot_identity_cost_enrichment.py
@@ -44,6 +44,17 @@ _USAGE = {
     "reasoningTokens": 0,
 }
 
+# ── AI Units (AIU) ground truth, verified 3/3 against real ~/.copilot sessions ──
+# Each model's ``modelMetrics.<model>.totalNanoAiu`` (nano-AIU) sums EXACTLY to the
+# shutdown's top-level ``data.totalNanoAiu`` — so the read layer reconstructs the
+# session total by summing the per-model blocks (no separate top-level event).
+# nano ÷ 1e9 = AIU.
+_AIU_SINGLE = 10517580000  # single-model sample → 10.52 AIU
+_AIU_OPUS = 66450771325000
+_AIU_SONNET = 77277060000
+_AIU_HAIKU = 68365100000
+_AIU_SESSION_TOTAL = _AIU_OPUS + _AIU_SONNET + _AIU_HAIKU  # 66596413485000 → 66,596.4 AIU
+
 
 def _copilot_adapter(session_id: str = "test-session") -> MappedJsonAdapter:
     return MappedJsonAdapter.from_yaml(str(MAPPINGS_DIR / "copilot.yaml"), session_id=session_id)
@@ -181,6 +192,63 @@ def test_preprocessor_omits_premium_keys_when_requests_absent_or_malformed() -> 
     assert "requestsTotal" not in bad
 
 
+# ─── AI Units (AIU) — the primary billing signal ─────────────────────────────
+
+
+def test_preprocessor_captures_nano_aiu() -> None:
+    # ``modelMetrics.<model>.totalNanoAiu`` (nano-AIU) is Copilot's PRIMARY billing
+    # signal. It rides the synthetic usage block verbatim as an integer ``nanoAiu``
+    # (never divided here — the pipeline keeps nano precision end-to-end).
+    blocks = preprocess_copilot(
+        _shutdown({_MODEL: {"usage": dict(_USAGE), "totalNanoAiu": _AIU_SINGLE}})
+    )
+    assert blocks[-1]["data"]["nanoAiu"] == _AIU_SINGLE
+
+
+def test_preprocessor_preserves_genuine_zero_nano_aiu() -> None:
+    # A model that genuinely consumed zero AIU is a real 0, distinct from "unknown".
+    blocks = preprocess_copilot(_shutdown({_MODEL: {"usage": dict(_USAGE), "totalNanoAiu": 0}}))
+    assert blocks[-1]["data"]["nanoAiu"] == 0
+
+
+def test_preprocessor_omits_nano_aiu_when_absent_or_malformed() -> None:
+    # No ``totalNanoAiu`` → no key (honest-blank; non-Copilot sources add nothing).
+    absent = preprocess_copilot(_shutdown({_MODEL: {"usage": dict(_USAGE)}}))[-1]["data"]
+    assert "nanoAiu" not in absent
+    # A malformed (non-numeric) value adds nothing rather than fabricating a 0.
+    bad = preprocess_copilot(_shutdown({_MODEL: {"usage": dict(_USAGE), "totalNanoAiu": "x"}}))[-1][
+        "data"
+    ]
+    assert "nanoAiu" not in bad
+
+
+def test_preprocessor_per_model_nano_aiu_sums_to_session_total() -> None:
+    # KEY DESIGN INVARIANT (verified 3/3 on real sessions): the per-model
+    # ``totalNanoAiu`` values sum EXACTLY to the shutdown's top-level
+    # ``totalNanoAiu`` — so carrying per-model ``nanoAiu`` and summing it in the read
+    # layer reconstructs the session total, with no separate top-level event.
+    blocks = preprocess_copilot(
+        _shutdown(
+            {
+                "claude-opus-4.8": {"usage": dict(_USAGE), "totalNanoAiu": _AIU_OPUS},
+                "claude-sonnet-4.6": {"usage": dict(_USAGE), "totalNanoAiu": _AIU_SONNET},
+                "claude-haiku-4.5": {"usage": dict(_USAGE), "totalNanoAiu": _AIU_HAIKU},
+            }
+        )
+    )
+    usage_blocks = [b for b in blocks if b["type"] == "assistant.usage"]
+    per_model = {b["data"]["model"]: b["data"]["nanoAiu"] for b in usage_blocks}
+    assert per_model == {
+        "claude-opus-4.8": _AIU_OPUS,
+        "claude-sonnet-4.6": _AIU_SONNET,
+        "claude-haiku-4.5": _AIU_HAIKU,
+    }
+    # Integer nano precision preserved; the sum reconstructs the session total, and
+    # ÷1e9 yields the AIU the dashboard renders (66,596.4 AIU).
+    assert sum(per_model.values()) == _AIU_SESSION_TOTAL
+    assert round(_AIU_SESSION_TOTAL / 1e9, 1) == 66596.4
+
+
 # ─── Adapter (repo_field → EventMetadata.repo) ───────────────────────────────
 
 
@@ -212,9 +280,28 @@ def test_adapter_maps_synthetic_usage_to_telemetry_usage() -> None:
     assert payload["msg_id"] == "sh1:claude-sonnet-4.5"
     # No dollar cost in the wire → cost_usd never mapped (stays absent → None).
     assert "cost_usd" not in payload
+    # Null-until-seen at the adapter boundary: no ``totalNanoAiu`` on the wire → the
+    # mapped ``nano_aiu`` key is omitted entirely (never fabricated into 0).
+    assert "nano_aiu" not in payload
 
     # The shutdown itself still maps to session.ended (rides the timeline).
     assert any(e.kind == EventKind.SESSION_ENDED for e in events)
+
+
+def test_adapter_maps_nano_aiu_into_payload() -> None:
+    adapter = _copilot_adapter()
+    events = list(
+        adapter.parse_dict(
+            _shutdown({_MODEL: {"usage": dict(_USAGE), "totalNanoAiu": _AIU_SINGLE}})
+        )
+    )
+    usage_events = [e for e in events if e.kind == EventKind.USAGE]
+    assert len(usage_events) == 1
+    payload = usage_events[0].payload
+    # AIU (nano-AIU) rides the payload as ``nano_aiu`` for the watch bridge to stash.
+    assert payload["nano_aiu"] == _AIU_SINGLE
+    # Still no dollar cost synthesized.
+    assert "cost_usd" not in payload
 
 
 def test_adapter_maps_premium_requests_into_payload() -> None:
@@ -301,6 +388,40 @@ def test_feed_line_stashes_premium_request_counts_in_attributes() -> None:
         "input_uncached": _UNCACHED,
         "cache_read_tokens": _CACHE_READ,
         "cache_creation_tokens": 0,
+        "premium_requests": 3,
+        "requests_total": 40,
+    }
+
+
+def test_feed_line_stashes_nano_aiu_in_attributes() -> None:
+    adapter = _copilot_adapter("cp-sess")
+    pipeline = _RecordingPipeline()
+    seen: set[str] = set()
+
+    line = json.dumps(
+        _shutdown(
+            {
+                _MODEL: {
+                    "usage": dict(_USAGE),
+                    "totalNanoAiu": _AIU_SINGLE,
+                    "requests": {"count": 40, "cost": 3},
+                }
+            }
+        )
+    )
+    asyncio.run(watch_mod._feed_line(line, adapter, pipeline, seen))
+
+    assert len(pipeline.usage) == 1
+    record = pipeline.usage[0]
+    # cost_usd stays honestly None — AIU is Copilot's billing signal, not dollars.
+    assert record.cost_usd is None
+    # nano-AIU is stashed as an INTEGER (no float division) alongside the token split
+    # and the now-secondary premium/total counts.
+    assert record.attributes == {
+        "input_uncached": _UNCACHED,
+        "cache_read_tokens": _CACHE_READ,
+        "cache_creation_tokens": 0,
+        "nano_aiu": _AIU_SINGLE,
         "premium_requests": 3,
         "requests_total": 40,
     }


### PR DESCRIPTION
Closes #188

## Summary

GitHub Copilot CLI has migrated billing/consumption accounting to **AI Units** ("AIU", AI credits). The authoritative signal is on the wire (`session.shutdown.data.modelMetrics.<model>.totalNanoAiu`, in nano-AIU) but TraceForge captured **none** of it, and several comments falsely called the premium-request *count* "the one real billing signal Copilot emits."

This PR captures AIU end-to-end, makes **AI credits (AIU)** the **primary** consumption signal in the dashboard, and **demotes premium requests to a secondary/legacy stat** (premium is still emitted and still real — just no longer the headline). Stale comments are corrected.

Approach mirrors the proven premium_requests seam (#160/#179/#183): carry per-model `totalNanoAiu` on each synthetic per-model `assistant.usage` block and **sum it in the read layer**. Per-model AIU sums **exactly** to the session total (verified 3/3 real sessions), so there is **no separate top-level synthetic event**.

## Changes

**Ingestion**
- `preprocessors/copilot.py` — `_usage_block` carries per-model `data["nanoAiu"]` via `_as_int_opt` (honest-blank: a genuine `0` is kept, a missing value stays absent). Docstring corrected (AIU primary, premium secondary/legacy).
- `mappings/copilot.yaml` — `assistant.usage` payload adds `nano_aiu: data.nanoAiu`; stale comment fixed.
- `cli/watch.py` — `_usage_record_from` stashes `nano_aiu` (int, null-safe) into `attributes`; stale comment fixed.

**Read layer**
- `dashboard/repository.py` — `_usage_breakdown` adds a run-level `aiuNano` total and a per-model `aiuNano` field, summed **null-until-seen** (unknown `None` ≠ genuine `0`). Stays O(1) connections (reuses the open ro conn; parses `attributes_json` once per row). Docstring corrected.

**Frontend**
- `lib/types.ts` — `aiuNano: number | null` on the run `usage` shape and per-model `ModelUsage`.
- `lib/format.ts` — `fmtAiu(nano)` → `—` when null, else `(nano / 1e9)` at one decimal + ` AIU` (e.g. `66,596.4 AIU`). Nano stays integer everywhere upstream; the ÷1e9 conversion happens **only** here.
- `views/Fleet.tsx` — AI credits is the primary consumption KPI + rail headline; premium demoted to a secondary line; new "AI credits" runs-table column (unknown → `—`).
- `views/Cost.tsx` — AI credits headline KPI + by-model column + AIU-first sort; premium kept but secondary/legacy. No `$` / SpendArea / CostScatter reintroduced.
- `views/RunView.tsx` — surfaces the run's AIU (header meta + Rewind footer) via `fmtAiu`; premium secondary.

**Docs**
- `CHANGELOG.md` — `[Unreleased] Added` entry for AIU capture + premium demotion.
- `docs/dashboard-spec.md` — `modelMetrics` shape gains `totalNanoAiu`; the `cost_usd`-None note now names AIU primary / premium secondary.

## Honesty invariants
- **Null-until-seen** everywhere: unknown AIU is `None` → renders `—`; a genuine `0` is kept; non-Copilot runs (Claude, etc.) carry no `nanoAiu` key and stay `—` (proven in a test).
- `cost_usd` stays `None` — no dollars exist on the Copilot wire, and none are derived from AIU.
- nano-AIU stays integer through ingestion + read layer; divided by 1e9 to AIU **only** in `format.ts` (no float precision loss in the pipeline).

## By-model AIU aggregation proof
- Single-model fixture: `claude-sonnet-4.6` `totalNanoAiu=10517580000` → run `aiuNano=10517580000` → ÷1e9 = **10.52 AIU**.
- Multi-model fixture: opus `66450771325000` + sonnet `77277060000` + haiku `68365100000` = **`66596413485000`** → ÷1e9 = **66,596.4 AIU**; per-model rows preserved; premium (`requests.cost`) `2655+0+0 = 2655` stays as the secondary stat.

## Verification
- `pytest -k "copilot or usage or dashboard or watch"` + unit/e2e subset: green.
- Golden `test_raw_traces.py`: unchanged (count+histogram fixtures are field-agnostic) — no regen.
- `ruff check` + `ruff format --check`: clean.
- `pnpm -C dashboard build` (tsc + vite) + `pnpm -C dashboard lint` (oxlint): green (only pre-existing warnings in untouched UI files).

Left **unmerged** for the coordinator to verify + squash-merge.