### PR TITLE
Real vendor-CLI PreToolUse hook smoke runbook + fake-vendor harness (#193)

### DIFF
--- a/docs/gate-real-cli-smoke.md
+++ b/docs/gate-real-cli-smoke.md
@@ -1,0 +1,306 @@
+# Smoke test: a real vendor CLI fires the `traceforge gate` PreToolUse hook
+
+> **⚠️ NON-CI — this runbook requires a real vendor CLI (Claude Code) and a human.**
+> It is deliberately **not** part of the automated test suite. CI already covers the
+> *synthetic* halves of this path (`tests/e2e/test_gate_init_e2e.py` proves the hook is
+> injected into `.claude/settings.json`; `tests/e2e/test_gate_stdin_e2e.py` drives the
+> real `traceforge gate --stdin` relay with live allow/deny verdicts). The one honest
+> blind spot they can't cover is a **real Claude Code process actually firing the
+> installed hook on a live tool call** — that is what you verify by hand here.
+>
+> A CI-friendly *fake-vendor-CLI* harness closes as much of this gap as possible
+> without a vendor binary: `tests/e2e/test_gate_real_cli_smoke_harness.py`. See
+> [Appendix B](#appendix-b--the-automated-fake-vendor-harness).
+
+## What this proves
+
+By the end you will have watched a **real Claude Code CLI**:
+
+1. **Allow baseline** — with no gate policy, run a tool call and watch it proceed
+   normally (the gate fires, sees allow-all, and steps aside).
+2. **Deny** — declare a deny policy, restart the pipeline, run the *same* tool call,
+   and watch Claude Code **block it** and surface the traceforge deny reason.
+
+The mechanical core — the exact command `init` injects, and the allow/deny verdict
+bytes it returns — is reproducible with a one-line `traceforge gate --stdin` sanity
+check (given below with its verified output), so you can confirm the wiring even
+before you open the vendor CLI.
+
+## How the pieces fit together
+
+```
+Claude Code (real CLI)
+  │  every tool call → PreToolUse hook
+  ▼
+<abs>/traceforge gate --stdin --agent claude-code        # injected into .claude/settings.json
+  │  reads {session_id, tool_name, tool_input} from stdin
+  ▼
+gate client  →  looks up session_id in the registry, falls back to "_default"
+  │            (~/.traceforge/system.db :: gate_endpoints)
+  ▼
+Gate IPC server  (running inside `traceforge watch`)
+  │  scores + runs the preflight policy chain
+  ▼
+Verdict  →  translated into Claude Code's hook dialect on stdout
+            allow → {}      deny → {"hookSpecificOutput": {... "permissionDecision":"deny" ...}}
+```
+
+Source of truth for each hop: hook injection `src/traceforge/cli/init_cmd.py`
+(`_init_claude_code`, ~L167–199); relay + fail-closed dialect
+`src/traceforge/gate/client.py` (`_gate_from_stdin_impl` L93–161, `_output_deny`/`_output_allow`
+L164–264); IPC server + registration `src/traceforge/gate/server.py` and
+`src/traceforge/cli/watch.py` (`gate_server.register_session("_default")`, ~L156);
+policy loading `src/traceforge/governance/shield.py` (`build_policy_from_config`, L37).
+
+---
+
+## Prerequisites
+
+- **traceforge installed** and on `PATH` (`traceforge --version` works). A `pip install
+  traceforge-toolkit` or an editable dev checkout both work.
+- **A real Claude Code CLI** installed and authenticated. (The same shape works for
+  Copilot CLI — swap `claude-code` for `copilot-cli` in step 1 and `--agent
+  copilot-cli` throughout; its hook lands in `.github/hooks/traceforge.json`.)
+- **A throwaway project directory** you don't mind an agent poking at. Everything below
+  assumes you `cd` into it first:
+
+  ```bash
+  mkdir /tmp/tf-smoke && cd /tmp/tf-smoke
+  ```
+
+> Paths in the captured output below are from the machine this runbook was verified on
+> (2026-07); substitute your own. See [Appendix A](#appendix-a--verified-on-this-machine).
+
+---
+
+## Step 1 — Install the hook
+
+```bash
+traceforge init claude-code --project .
+```
+
+Verified output (the middle line is your absolute `traceforge` path):
+
+```text
+✓ Wrote PreToolUse hook to /tmp/tf-smoke/.claude/settings.json
+  Command: /abs/path/to/traceforge gate --stdin --agent claude-code
+  Note: configure a gate policy (governance.gate_policy) and run `traceforge watch` — until then the gate allows every call.
+```
+
+This writes (or idempotently merges into) `.claude/settings.json`. The resulting shape —
+a `.*` matcher so **every** tool call is gated, plus the injected relay command:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/abs/path/to/traceforge gate --stdin --agent claude-code"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `command` is an absolute path so Claude Code can exec it regardless of its own
+working directory (`_find_traceforge_command`, `init_cmd.py` L59–67). Re-running `init`
+is a no-op once the traceforge hook is present.
+
+> **Note:** `init` only lays down the *wiring*. The hook relays every call to the gate,
+> which **allows everything until you declare a policy** (step 2). That is the whole
+> point of the loud warning you'll see in step 3.
+
+---
+
+## Step 2 — Declare a deny policy
+
+A preflight gate is a callable `(request, ctx) -> Verdict` referenced by a dotted import
+path under `governance.gate_policy.preflight` (`shield.py` L37–108; the request exposes
+`request.tool`, `request.input`, etc. — see `src/traceforge/sdk/gate_types.py`
+`ToolCallRequest`). Create a tiny policy module in the project:
+
+```python
+# smoke_policy.py
+from traceforge.sdk.verdict import Verdict
+
+
+def deny_all(request, ctx):
+    # Block every tool call so the smoke is unambiguous — the FIRST tool Claude
+    # Code tries is denied, with this reason surfaced back to the model.
+    return Verdict.deny(f"traceforge smoke: blocked {request.tool}")
+```
+
+…and a config that points at it:
+
+```yaml
+# traceforge-smoke.yaml
+governance:
+  gate_policy:
+    preflight:
+      - smoke_policy.deny_all
+```
+
+Because `smoke_policy.py` is imported by dotted path, its directory must be on
+`PYTHONPATH` when you start the daemon. From the project directory:
+
+```bash
+# bash / zsh
+export PYTHONPATH="$PWD"
+```
+
+```powershell
+# PowerShell
+$env:PYTHONPATH = (Resolve-Path .).Path
+```
+
+---
+
+## Step 3 — Start the gate / pipeline session
+
+`traceforge watch` builds the policy, starts the Gate IPC server, and registers a
+`_default` session that any CLI hook falls back to. Start it in **its own terminal**
+(keep `PYTHONPATH` set from step 2) and leave it running:
+
+```bash
+traceforge watch --config traceforge-smoke.yaml --frameworks claude
+```
+
+> `--frameworks claude` keeps detection deterministic (watch exits if it detects
+> nothing; it detects `claude` once `~/.claude/projects` exists, which it will after
+> you've run Claude Code at least once). Add `--no-score` if port 7331 is busy.
+
+**Enforcing** output looks like this (note: **no** allow-all warning):
+
+```text
+Detected 1 framework(s): claude
+Gate IPC server listening on tcp://127.0.0.1:50510
+Watching 1 pipeline(s). Press Ctrl+C to stop.
+```
+
+For contrast, start it **without** `--config` (or with a config that declares no
+`gate_policy`) and you get the allow-all baseline, which prints a loud banner:
+
+```text
+Gate IPC server listening on tcp://127.0.0.1:65188
+
+  ============================================================
+  WARNING: gating enforcement is INACTIVE (allow-all).
+  No gate policy is configured, so EVERY tool call is ALLOWED.
+  ...
+  ============================================================
+```
+
+That banner is your proof the two modes are distinct (`_warn_gating_inactive`,
+`watch.py` L38–65).
+
+### Sanity-check the wiring before touching the CLI
+
+The relay verdict is deterministic, so you can confirm the whole chain with one pipe —
+**run this while `watch` is up**, from the same shell environment (same `HOME`) so the
+registry lookup resolves. `session_id` is intentionally a value the daemon never saw;
+it falls back to `_default` (`client.py` L124–126), exactly like a real Claude Code
+session id:
+
+```bash
+echo '{"hook_event_name":"PreToolUse","session_id":"smoke","tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' \
+  | traceforge gate --stdin --agent claude-code
+```
+
+```powershell
+'{"hook_event_name":"PreToolUse","session_id":"smoke","tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' |
+  traceforge gate --stdin --agent claude-code
+```
+
+**Verified verdicts** (this is the evidence to capture):
+
+| Daemon policy | stdout | exit |
+| --- | --- | --- |
+| Deny (`smoke_policy.deny_all`) | `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "traceforge smoke: blocked Bash"}}` | 0 |
+| Allow-all (no policy) | `{}` | 0 |
+
+A fail-closed deny still exits **0** — the stdout JSON *is* the contract Claude Code
+reads (`client.py` L65–90, `_output_deny` L201–220). If the daemon is not running you'll
+still get a deny (`"... not registered with any pipeline"`), because the gate fails
+closed.
+
+---
+
+## Step 4 — Fire a real tool call in Claude Code
+
+In a **separate terminal**, from the same project directory (so Claude Code loads
+`.claude/settings.json`):
+
+```bash
+cd /tmp/tf-smoke
+claude          # start the real Claude Code CLI
+```
+
+Ask it to run a shell command, e.g.:
+
+> Run the shell command `echo hello` for me.
+
+### Expected evidence
+
+**Allow baseline (daemon started with no policy):** Claude Code runs the command
+normally. The `watch` terminal shows the allow-all warning from step 3; the gate fired
+(`{}` on stdout) and deferred to Claude Code's own permission flow — so from the user's
+seat the tool "just works", which is the correct allow behavior.
+
+**Deny (daemon started with `traceforge-smoke.yaml`):** Claude Code is **blocked before
+the tool executes** and surfaces the deny reason — `traceforge smoke: blocked Bash`
+(the exact `permissionDecisionReason` from the verdict). The command never runs.
+
+Capture the contrast — a screenshot or copy-paste of Claude Code refusing the tool
+with the traceforge reason, alongside the deterministic `gate --stdin` verdict from the
+sanity check — and the smoke is complete.
+
+> If Claude Code appears to ignore the hook: confirm `.claude/settings.json` exists in
+> the directory you launched `claude` from, that `traceforge watch` is still running,
+> and that the sanity-check pipe in step 3 returns the deny JSON. Those three isolate
+> which hop failed.
+
+---
+
+## Cleanup
+
+- `Ctrl+C` the `traceforge watch` terminal.
+- Delete the throwaway project (`rm -rf /tmp/tf-smoke`), which removes the injected
+  `.claude/settings.json`, `smoke_policy.py`, and the config.
+- The gate registry row self-heals once the daemon exits (`registry.lookup_endpoint`
+  drops rows whose owning PID is gone), so nothing persists in `~/.traceforge`.
+
+---
+
+## Appendix A — verified on this machine
+
+The command/verdict captures above were produced on 2026-07 (Windows, Python 3.12) by
+driving a **real `traceforge watch`** daemon and execing the exact command string from
+`.claude/settings.json` with a Claude-Code-shaped PreToolUse event — i.e. everything in
+this runbook except the literal keypress inside the Claude Code UI. The only
+platform-specific detail is the IPC transport: a `tcp://127.0.0.1:<port>` loopback
+socket on Windows vs. a unix-domain socket under `~/.traceforge/gates/` on POSIX
+(`server.py` `_default_sock_path` / `start`).
+
+## Appendix B — the automated fake-vendor harness
+
+`tests/e2e/test_gate_real_cli_smoke_harness.py` (marked `e2e` + `slow`) automates the
+mechanical core with **no vendor binary**: it runs `traceforge init claude-code`, reads
+the injected command **verbatim** out of `.claude/settings.json`, and execs it from a
+fake "vendor CLI" against a real in-process Gate IPC server registered as `_default`.
+Swapping the pipeline policy flips the result between allow (`{}`, tool runs) and deny
+(tool blocked with the policy reason) — the same contrast this runbook captures by hand.
+Run it with:
+
+```bash
+uv run python -m pytest tests/e2e/test_gate_real_cli_smoke_harness.py -v
+```
+
+What it deliberately does **not** cover — and why this manual runbook still exists — is
+a genuine vendor process reading `settings.json` and firing the hook through its own
+tool-call machinery. That last mile needs a real CLI and a human.

--- a/tests/e2e/test_gate_real_cli_smoke_harness.py
+++ b/tests/e2e/test_gate_real_cli_smoke_harness.py
@@ -1,0 +1,211 @@
+"""Fake-vendor-CLI harness for the real PreToolUse hook-firing smoke (issue #193).
+
+The manual runbook (``docs/gate-real-cli-smoke.md``) proves a *real* Claude Code
+CLI fires the injected ``traceforge gate --stdin`` PreToolUse hook and that a deny
+policy blocks a live tool call. That last step needs a human at a real vendor
+binary, so it is inherently non-CI. This harness closes as much of that gap as CI
+can without a vendor binary: a **fake vendor CLI** drives the *exact* command
+``traceforge init claude-code`` wrote into ``.claude/settings.json``.
+
+What is real here vs. faked:
+
+* **Real** — the injected hook command (read verbatim from ``settings.json``, never
+  reconstructed), the ``python -m traceforge gate --stdin`` relay subprocess, the
+  in-process :class:`GateServer` + :class:`GovernancePipeline` answering it over the
+  actual IPC socket, and the ``_default`` registration fallback that routes a vendor
+  ``session_id`` the daemon never saw to the running policy.
+* **Faked** — only the vendor binary. :class:`_FakeVendorCLI` stands in for Claude
+  Code's PreToolUse hook runner: it reads ``settings.json``, execs the command with a
+  Claude-Code-shaped tool-call event on stdin, and interprets the verdict per Claude
+  Code's public hook contract (stdout ``permissionDecision`` / neutral ``{}``). It
+  never imports traceforge, so it can only "see" what a real CLI would.
+
+Swapping the pipeline's policy flips the fake CLI between "tool ran" (allow) and
+"tool blocked" (deny) — the same allow-vs-deny contrast the runbook captures by
+hand. Marked ``slow`` because constructing the pipeline may load ML models on first
+use (same headroom as ``test_gate_stdin_e2e``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import shlex
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from traceforge.gate.server import GateServer
+from traceforge.governance.persistence import SystemStore
+from traceforge.governance.pipeline import GovernancePipeline
+from traceforge.sdk.gate_policy import GatePolicy
+from traceforge.sdk.verdict import Verdict
+
+from tests.e2e._cli import run_cli
+
+# A generous ceiling for the server-backed relay: the child connects to a loopback
+# socket and returns immediately, but the pipeline scorer may load ML models on
+# first construction — same headroom as the live gate-relay e2e tests.
+_LIVE_TIMEOUT = 90.0
+
+_DENY_REASON = "blocked by traceforge smoke policy"
+
+
+# ─── Policies (dotted-import stand-ins for a real deny/allow gate) ─────────────
+
+
+def _deny_all(request, ctx) -> Verdict:
+    return Verdict.deny(_DENY_REASON)
+
+
+def _allow_all(request, ctx) -> Verdict:
+    return Verdict.allow()
+
+
+@contextlib.contextmanager
+def _live_gate(*session_ids: str, policy: GatePolicy | None = None) -> Iterator[GateServer]:
+    """Start an in-process gate IPC server registered under ``session_ids``.
+
+    Mirrors ``test_gate_stdin_e2e._live_gate``: bootstraps the sandboxed
+    ``system.db`` (the Alembic migration that creates ``gate_endpoints`` the
+    registry writes to), starts a :class:`GateServer` over a real socket, and
+    registers the given session ids. The fake vendor CLI's ``gate --stdin`` child
+    reaches it through the registry.
+    """
+    system_db = Path.home() / ".traceforge" / "system.db"
+    SystemStore(str(system_db)).connection.close()
+
+    pipeline = GovernancePipeline.create()
+    pipeline.policy = policy
+    server = GateServer(pipeline)
+    server.start()
+    try:
+        for sid in session_ids:
+            server.register_session(sid)
+        yield server
+    finally:
+        server.stop()
+
+
+# ─── Fake vendor CLI (stands in for Claude Code's PreToolUse hook runner) ──────
+
+
+def _injected_pretooluse_command(settings_file: Path) -> str:
+    """Return the exact PreToolUse command string ``init`` wrote to ``settings.json``.
+
+    This is the command a real vendor CLI would exec on every tool call. We read it
+    verbatim (never reconstruct it) so the harness proves the *injected* wiring, not
+    a hand-built approximation of it.
+    """
+    data = json.loads(settings_file.read_text(encoding="utf-8"))
+    for entry in data.get("hooks", {}).get("PreToolUse", []):
+        if not isinstance(entry, dict):
+            continue
+        for hook in entry.get("hooks", []):
+            command = hook.get("command", "") if isinstance(hook, dict) else ""
+            if "traceforge" in command and "gate --stdin" in command:
+                return command
+    raise AssertionError(f"no traceforge gate hook found in {settings_file}: {data}")
+
+
+class _FakeVendorCLI:
+    """A stand-in for a real CLI's PreToolUse hook runner (Claude Code dialect).
+
+    Knows only the public hook contract — it reads ``.claude/settings.json``, execs
+    the injected command with a tool-call event on stdin, and blocks the tool iff
+    the verdict says ``permissionDecision == "deny"``. It never imports traceforge.
+    """
+
+    def __init__(self, settings_file: Path) -> None:
+        self._command = _injected_pretooluse_command(settings_file)
+
+    @property
+    def command(self) -> str:
+        return self._command
+
+    def run_tool(self, tool_name: str, tool_input: dict, *, session_id: str) -> tuple[bool, str]:
+        """Fire the PreToolUse hook for one tool call.
+
+        Returns ``(allowed, reason)``: ``allowed`` is False when the gate denied the
+        call (the vendor would block it), and ``reason`` carries the deny message the
+        CLI would surface to the model.
+        """
+        event = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "session_id": session_id,
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+            }
+        )
+        # A real vendor runs the hook command through a shell; an argv split keeps the
+        # test off the shell's quoting rules while still execing the injected string.
+        argv = shlex.split(self._command, posix=(sys.platform != "win32"))
+        proc = subprocess.run(
+            argv,
+            input=event,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_LIVE_TIMEOUT,
+        )
+        # Claude Code reads the decision from stdout at exit 0 (a fail-closed deny is
+        # still exit 0 — the JSON is the contract); a non-zero exit is a hook crash.
+        assert proc.returncode == 0, f"hook exited {proc.returncode}: {proc.stderr or proc.stdout}"
+        verdict = json.loads(proc.stdout.strip() or "{}")
+
+        hook_output = verdict.get("hookSpecificOutput", {})
+        if hook_output.get("permissionDecision") == "deny":
+            return False, hook_output.get("permissionDecisionReason", "")
+        # An empty object == "no decision" == defer to the CLI's normal permission flow.
+        assert verdict == {}, f"unexpected non-allow verdict: {verdict}"
+        return True, ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# init → settings.json → fake-vendor exec → allow/deny round trip
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_fake_vendor_cli_deny_blocks_tool(tmp_traceforge_home: Path) -> None:
+    """A deny policy blocks the tool the fake CLI fired straight from settings.json."""
+    project = tmp_traceforge_home / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+
+    run_cli("init", "claude-code", "--project", str(project))
+    vendor = _FakeVendorCLI(project / ".claude" / "settings.json")
+
+    # The vendor's session_id is unknown to the daemon → routes to the `_default`
+    # policy exactly as `traceforge watch`'s fallback does.
+    with _live_gate("_default", policy=GatePolicy().preflight(_deny_all)):
+        allowed, reason = vendor.run_tool(
+            "Bash", {"command": "rm -rf /"}, session_id="vendor-session-never-registered"
+        )
+
+    assert allowed is False, "deny policy must block the tool call"
+    assert _DENY_REASON in reason, reason
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_fake_vendor_cli_allow_permits_tool(tmp_traceforge_home: Path) -> None:
+    """The same injected command allows the tool when the policy allows — allow baseline."""
+    project = tmp_traceforge_home / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+
+    run_cli("init", "claude-code", "--project", str(project))
+    vendor = _FakeVendorCLI(project / ".claude" / "settings.json")
+
+    with _live_gate("_default", policy=GatePolicy().preflight(_allow_all)):
+        allowed, reason = vendor.run_tool(
+            "Read", {"path": "notes.txt"}, session_id="vendor-session-never-registered"
+        )
+
+    assert allowed is True, "allow policy must permit the tool call"
+    assert reason == ""


### PR DESCRIPTION
## What & why

Issue #193's honest blind spot: the gate hooks are thoroughly e2e-tested via a *synthetic* subprocess + IPC, but nothing drives a **real Claude Code / Copilot CLI actually firing the installed `traceforge gate --stdin` PreToolUse hook** on a live tool call. That real-CLI path is inherently hard to automate.

This PR delivers both scoped items:

### D1 (required) — manual smoke runbook
`docs/gate-real-cli-smoke.md`, clearly labelled **NON-CI**. Step-by-step:
1. `traceforge init claude-code --project .` → the injected `.claude/settings.json` (`.*` matcher + the absolute `gate --stdin --agent claude-code` relay command).
2. Declare a deny policy (`smoke_policy.deny_all` dotted preflight gate + `traceforge-smoke.yaml`).
3. Start the gate/pipeline session with `traceforge watch --config …` (enforcing vs. the loud allow-all baseline).
4. Fire a real tool call in Claude Code and capture the allow-vs-deny evidence.

The mechanical core (exact injected command + the allow `{}` / deny `hookSpecificOutput` verdict bytes) was **verified against a real `traceforge watch` daemon** — everything except the literal keypress inside the vendor UI — and those real outputs are pasted into the doc. Each hop is cited to `file:line` in the source.

### D2 (stretch) — automated fake-vendor harness
`tests/e2e/test_gate_real_cli_smoke_harness.py` (`e2e` + `slow`): a fake vendor CLI reads the injected command **verbatim** from `.claude/settings.json` and execs it against a real in-process deny/allow `GateServer` registered as `_default` (the same fallback `watch` relies on). Swapping the policy flips it between "tool ran" (`{}`) and "tool blocked" (policy reason). No vendor binary.

## Verification
- `uv run python -m pytest tests/e2e/test_gate_real_cli_smoke_harness.py -v` → **2 passed**.
- `ruff check .` and `ruff format --check .` (pinned `0.15.20`) → clean, repo-wide.

Closes #193