### PR TITLE
Add view render tests and fix classified-coverage denominator (#196)

### DIFF
--- a/dashboard/src/lib/coverage.test.ts
+++ b/dashboard/src/lib/coverage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  coverageBucket,
+  coverageStats,
+  effectMix,
+  isClassifiable,
+} from "@/lib/coverage";
+import { fullyClassifiedEvents, makeEvent, makeLifecycleEvent } from "@/test/fixtures";
+
+describe("coverage buckets", () => {
+  it("classifies a tool call with an effect as classified", () => {
+    const e = makeEvent({ kind: "tool.call.function", cls: { canon: "x", cat: "read_only", conf: 0.9 } });
+    expect(coverageBucket(e)).toBe("classified");
+    expect(isClassifiable(e)).toBe(true);
+  });
+
+  it("counts an effect-less tool/permission event as an honest unclassified gap", () => {
+    const perm = makeEvent({ kind: "permission.request", cls: { canon: "", cat: "", conf: 0.3 } });
+    expect(coverageBucket(perm)).toBe("unclassified");
+    expect(isClassifiable(perm)).toBe(true);
+  });
+
+  it("routes hook wrappers and lifecycle events out of the denominator", () => {
+    const hook = makeEvent({ kind: "hook.completed", cls: { canon: "", cat: "", conf: 0 } });
+    const lifecycle = makeLifecycleEvent();
+    expect(coverageBucket(hook)).toBe("hook");
+    expect(coverageBucket(lifecycle)).toBe("lifecycle");
+    expect(isClassifiable(hook)).toBe(false);
+    expect(isClassifiable(lifecycle)).toBe(false);
+  });
+});
+
+describe("coverageStats denominator", () => {
+  // Regression guard for the `unclassified-coverage-framing` diagnostic: the
+  // denominator must be classifiable (tool + permission) events only. Scoring
+  // against ALL events — the lifecycle turns/messages included below — made a
+  // fully-classified pipeline read ~50% instead of the true 100%.
+  it("scores a fully-classified tool fixture at 100%", () => {
+    const stats = coverageStats(fullyClassifiedEvents());
+    expect(stats.classified).toBe(3);
+    expect(stats.unclassified).toBe(0);
+    expect(stats.classifiable).toBe(3);
+    expect(stats.lifecycle).toBe(3);
+    expect(stats.total).toBe(6);
+    expect(stats.pct).toBe(100);
+  });
+
+  it("excludes lifecycle events from the denominator entirely", () => {
+    // 1 classified tool event among 4 lifecycle events: dividing by all events
+    // would give 20%; the honest denominator gives 100%.
+    const events = [
+      makeEvent({ cls: { canon: "read_file", cat: "read_only", conf: 0.99 } }),
+      makeLifecycleEvent(),
+      makeLifecycleEvent(),
+      makeLifecycleEvent(),
+      makeLifecycleEvent(),
+    ];
+    const stats = coverageStats(events);
+    expect(stats.classifiable).toBe(1);
+    expect(stats.pct).toBe(100);
+  });
+
+  it("keeps effect-less classifiable events as a real gap", () => {
+    const events = [
+      makeEvent({ cls: { canon: "read_file", cat: "read_only", conf: 0.99 } }),
+      makeEvent({ kind: "permission.request", cls: { canon: "", cat: "", conf: 0.2 } }),
+    ];
+    const stats = coverageStats(events);
+    expect(stats.classifiable).toBe(2);
+    expect(stats.unclassified).toBe(1);
+    expect(stats.pct).toBe(50);
+  });
+
+  it("reports 0% (not NaN) when nothing is classifiable", () => {
+    const stats = coverageStats([makeLifecycleEvent(), makeLifecycleEvent()]);
+    expect(stats.classifiable).toBe(0);
+    expect(stats.pct).toBe(0);
+  });
+});
+
+describe("effectMix", () => {
+  it("breaks down classified events by effect, ignoring lifecycle noise", () => {
+    const mix = effectMix(fullyClassifiedEvents());
+    const labels = mix.map((m) => m.label).sort();
+    expect(labels).toEqual(["destructive", "mutating", "read_only"]);
+    expect(mix.every((m) => m.value === 1)).toBe(true);
+  });
+});

--- a/dashboard/src/test/fixtures.ts
+++ b/dashboard/src/test/fixtures.ts
@@ -1,0 +1,265 @@
+// Seeded, in-memory fixtures for view/selector tests.
+//
+// These build the same domain shapes (@/lib/types) the real API returns, so views
+// and selectors can be exercised without a live server. Every builder takes an
+// overrides bag so a test can pin exactly the field under test and let the rest
+// default to a realistic value.
+
+import type {
+  ModelUsage,
+  Run,
+  Seg,
+  TEvent,
+  Transcript,
+  TranscriptTurn,
+} from "@/lib/types";
+
+let eventSeq = 0;
+let runSeq = 0;
+
+export function makeEvent(o: Partial<TEvent> = {}): TEvent {
+  const id = o.id ?? `ev-${eventSeq++}`;
+  return {
+    id,
+    t: o.t ?? new Date("2026-07-10T09:00:00Z"),
+    tool: o.tool ?? { n: "read_file", cat: "read_only", canon: "read_file", w: 1 },
+    kind: o.kind ?? "tool.call.function",
+    summary: o.summary ?? "read a source file",
+    risk: o.risk ?? 0,
+    score: o.score ?? 0.12,
+    action: o.action ?? "allow",
+    cost: o.cost ?? null,
+    tokens: o.tokens ?? 120,
+    dur: o.dur ?? 14,
+    phase: o.phase ?? "explore",
+    seg: o.seg ?? "step-1",
+    file: o.file ?? "src/app.ts",
+    turn: o.turn ?? "turn-1",
+    retry: o.retry ?? false,
+    cls: o.cls ?? { canon: "read_file", cat: "read_only", conf: 0.99 },
+    ev: o.ev ?? null,
+    reco: o.reco ?? { action: "allow", why: "read-only access to a tracked file" },
+    gap: o.gap ?? null,
+    payload: o.payload ?? { path: "src/app.ts" },
+  };
+}
+
+// A lifecycle event (session / turn / message / llm marker): carries no effect by
+// nature, so its `cls.cat` is empty and it lands in the coverage "lifecycle"
+// bucket — never the classifiable denominator.
+export function makeLifecycleEvent(o: Partial<TEvent> = {}): TEvent {
+  return makeEvent({
+    kind: "turn.completed",
+    tool: { n: "turn", cat: "", canon: "", w: 0 },
+    summary: "assistant turn completed",
+    cls: { canon: "", cat: "", conf: 0 },
+    seg: "",
+    ...o,
+  });
+}
+
+export function makeModelUsage(o: Partial<ModelUsage> = {}): ModelUsage {
+  // Spread overrides LAST so an explicit `null` (unknown signal) is honored
+  // rather than coalesced back to a default — the "unknown → —" path Cost tests.
+  return {
+    model: "gpt-5",
+    aiuNano: 40_000_000_000,
+    premiumRequests: 2,
+    requests: 10,
+    inputUncached: 5_000,
+    cacheRead: 2_000,
+    cacheCreation: 500,
+    input: 7_500,
+    output: 3_000,
+    ...o,
+  };
+}
+
+const defaultSegs = (): Seg[] => [
+  { id: "act-1", kind: "activity", parent: null, title: "Explore the repository", risk: 1 },
+  { id: "step-1", kind: "step", parent: "act-1", title: "Read the source files", risk: 1 },
+];
+
+export function makeRun(o: Partial<Run> = {}): Run {
+  const id = o.id ?? `run-${runSeq++}`;
+  return {
+    id,
+    repo: o.repo ?? "acme/api",
+    agent: o.agent ?? "copilot",
+    model: o.model ?? "gpt-5",
+    title: o.title ?? `Run ${id}`,
+    live: o.live ?? false,
+    segs: o.segs ?? defaultSegs(),
+    events: o.events ?? [makeEvent()],
+    // A supplied `usage` is taken verbatim so explicit nulls (unknown signals)
+    // survive — a per-field `?? default` merge would coalesce them back and mask
+    // the "unknown → —" rendering the Cost fixtures rely on.
+    usage: o.usage ?? {
+      in: 7_500,
+      out: 3_000,
+      cost: null,
+      aiuNano: 40_000_000_000,
+      premiumRequests: 2,
+      inputUncached: 5_000,
+      cacheRead: 2_000,
+      cacheCreation: 500,
+      requestsTotal: 10,
+      models: [makeModelUsage()],
+    },
+    started: o.started ?? new Date("2026-07-10T09:00:00Z"),
+    durMs: o.durMs ?? 8 * 60_000 + 30_000,
+    drift: o.drift ?? null,
+    peak: o.peak ?? 1,
+    taint: o.taint ?? [],
+    trust: o.trust ?? [],
+    mcp: o.mcp ?? [],
+    gaps: o.gaps ?? [],
+  };
+}
+
+// A realistic two-run fleet exercising every view: classified tool events, a
+// permission escalation (risk 2) and a destructive call (risk 3) for Triage,
+// lifecycle events for the coverage scope split, per-model usage (including an
+// unattributed "" model with unknown counts) for Cost, and a recorded gap +
+// taint row for Coverage / Triage governance memory.
+export function seedRuns(): Run[] {
+  const runA = makeRun({
+    id: "run-a",
+    title: "Refactor the auth module",
+    repo: "acme/api",
+    live: true,
+    peak: 3,
+    drift: 0.31,
+    events: [
+      makeEvent({ id: "a-1", tool: { n: "read_file", cat: "read_only", canon: "read_file", w: 1 } }),
+      makeEvent({
+        id: "a-2",
+        tool: { n: "edit_file", cat: "mutating", canon: "edit_file", w: 2 },
+        kind: "tool.call.function",
+        summary: "edit the token verifier",
+        risk: 1,
+        phase: "edit",
+        cls: { canon: "edit_file", cat: "mutating", conf: 0.95 },
+      }),
+      makeEvent({
+        id: "a-3",
+        tool: { n: "http_post", cat: "network", canon: "http_post", w: 3 },
+        kind: "permission.request",
+        summary: "outbound POST to an unrecognized host",
+        risk: 2,
+        score: 0.71,
+        action: "escalate",
+        phase: "act",
+        // Permission events are classifiable but carry no effect yet → the honest
+        // "unclassified" gap slice.
+        cls: { canon: "http_post", cat: "", conf: 0.4 },
+      }),
+      makeEvent({
+        id: "a-4",
+        tool: { n: "run_shell", cat: "destructive", canon: "run_shell", w: 4 },
+        kind: "tool.call.shell",
+        summary: "delete the build directory",
+        risk: 3,
+        score: 0.93,
+        action: "deny",
+        phase: "act",
+        cls: { canon: "run_shell", cat: "destructive", conf: 0.88 },
+      }),
+      makeLifecycleEvent({ id: "a-5", summary: "user message received", kind: "message.user" }),
+      makeLifecycleEvent({ id: "a-6" }),
+    ],
+    taint: [{ flow: "web content → shell arg", det: "tainted argument reached run_shell", lvl: 2 }],
+    trust: [{ who: "github.com", ttl: "30m remaining", lvl: 1 }],
+    mcp: [{ srv: "filesystem", msg: "tool surface changed since last run", lvl: 1 }],
+    gaps: [{ t: "2026-07-10T09:04:00Z", dropped: 12, reason: "output sink restarted mid-run" }],
+  });
+
+  const runB = makeRun({
+    id: "run-b",
+    title: "Fix the flaky title test",
+    repo: "acme/web",
+    live: false,
+    peak: 0,
+    events: [
+      makeEvent({ id: "b-1", summary: "read the failing spec" }),
+      makeLifecycleEvent({ id: "b-2", kind: "session.started", summary: "session started" }),
+    ],
+    usage: {
+      in: 1_000,
+      out: 500,
+      cost: null,
+      // AIU present but from a single blank-model row → surfaces "unknown model"
+      // with unknown ("—") premium / request counts in the Cost table.
+      aiuNano: 26_596_400_000,
+      premiumRequests: null,
+      inputUncached: null,
+      cacheRead: null,
+      cacheCreation: null,
+      requestsTotal: null,
+      models: [
+        makeModelUsage({
+          model: "",
+          aiuNano: 26_596_400_000,
+          premiumRequests: null,
+          requests: null,
+          inputUncached: null,
+          cacheRead: null,
+          cacheCreation: null,
+          input: 1_000,
+          output: 500,
+        }),
+      ],
+    },
+  });
+
+  return [runA, runB];
+}
+
+// A fully-classified tool-event fixture for the coverage-denominator regression:
+// every classifiable (tool) event carries an effect, plus lifecycle events that
+// must be excluded from the denominator. Honest coverage here is 100%.
+export function fullyClassifiedEvents(): TEvent[] {
+  return [
+    makeEvent({ id: "fc-1", cls: { canon: "read_file", cat: "read_only", conf: 0.99 } }),
+    makeEvent({
+      id: "fc-2",
+      tool: { n: "edit_file", cat: "mutating", canon: "edit_file", w: 2 },
+      cls: { canon: "edit_file", cat: "mutating", conf: 0.97 },
+    }),
+    makeEvent({
+      id: "fc-3",
+      tool: { n: "run_shell", cat: "destructive", canon: "run_shell", w: 4 },
+      kind: "tool.call.shell",
+      cls: { canon: "run_shell", cat: "destructive", conf: 0.95 },
+    }),
+    // Lifecycle events: no effect by nature, excluded from the denominator. If they
+    // leaked into it the metric would read well below 100%.
+    makeLifecycleEvent({ id: "fc-4", kind: "session.started" }),
+    makeLifecycleEvent({ id: "fc-5", kind: "turn.completed" }),
+    makeLifecycleEvent({ id: "fc-6", kind: "message.assistant" }),
+  ];
+}
+
+export function makeTranscript(runId: string, turns?: TranscriptTurn[]): Transcript {
+  return {
+    id: runId,
+    turns: turns ?? [
+      {
+        id: "a-1",
+        t: "2026-07-10T09:00:00Z",
+        role: "user",
+        label: "User",
+        kind: "message.user",
+        text: "Please refactor the auth module for clarity.",
+      },
+      {
+        id: "a-2",
+        t: "2026-07-10T09:01:00Z",
+        role: "assistant",
+        label: "Assistant",
+        kind: "message.assistant",
+        text: "Starting by reading the token verifier.",
+      },
+    ],
+  };
+}

--- a/dashboard/src/test/harness.tsx
+++ b/dashboard/src/test/harness.tsx
@@ -1,0 +1,48 @@
+// Shared render helper for view/component tests.
+//
+// jsdom provides neither `ResizeObserver` (recharts' ResponsiveContainer measures
+// with it), `matchMedia`, nor `Element.scrollIntoView` (RunView's transcript
+// scrolls the selected turn into view); without stubs the chart-bearing views and
+// the transcript throw on mount. The views also assume the app-level
+// <TooltipProvider> ancestor (App.tsx), so `renderView` supplies one — matching
+// production wiring without pulling in the full <App> shell.
+
+import type { ReactElement } from "react";
+import { render } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+const g = globalThis as unknown as {
+  ResizeObserver?: unknown;
+  matchMedia?: unknown;
+};
+
+g.ResizeObserver ??= ResizeObserverStub;
+
+if (typeof g.matchMedia !== "function") {
+  g.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return false;
+    },
+  });
+}
+
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function scrollIntoView() {};
+}
+
+export function renderView(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}

--- a/dashboard/src/test/views.test.tsx
+++ b/dashboard/src/test/views.test.tsx
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderView } from "@/test/harness";
+import { fullyClassifiedEvents, makeRun, makeTranscript, seedRuns } from "@/test/fixtures";
+import { useRuns, useTranscript } from "@/lib/queries";
+import { Fleet } from "@/views/Fleet";
+import { RunView } from "@/views/RunView";
+import { Cost } from "@/views/Cost";
+import { Coverage } from "@/views/Coverage";
+import { Triage } from "@/views/Triage";
+import type { Run, Transcript } from "@/lib/types";
+
+// The views read their data through `useRuns()` / `useTranscript()` and their
+// navigation state through `useApp()`. Mock both so each view renders against an
+// in-memory seed with no live server, React Query cache, or fetch.
+const store = vi.hoisted(() => {
+  const noop = () => {};
+  return {
+    app: {
+      view: "fleet",
+      runId: null as string | null,
+      sel: 0,
+      filt: "",
+      sort: "recent",
+      setView: noop,
+      openRun: noop,
+      openEvent: noop,
+      back: noop,
+      setSel: noop,
+      setFilt: noop,
+      setSort: noop,
+    },
+  };
+});
+
+vi.mock("@/store", () => ({ useApp: () => store.app }));
+vi.mock("@/lib/queries", () => ({
+  useRuns: vi.fn(),
+  useTranscript: vi.fn(),
+  useHealth: vi.fn(),
+}));
+
+const mockedUseRuns = vi.mocked(useRuns);
+const mockedUseTranscript = vi.mocked(useTranscript);
+
+function setRuns(runs: Run[], isLoading = false) {
+  mockedUseRuns.mockReturnValue({
+    data: runs,
+    isLoading,
+    isError: false,
+    error: null,
+    refetch: () => {},
+  } as unknown as ReturnType<typeof useRuns>);
+}
+
+function setTranscript(transcript: Transcript, isLoading = false) {
+  mockedUseTranscript.mockReturnValue({
+    data: transcript,
+    isLoading,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useTranscript>);
+}
+
+beforeEach(() => {
+  store.app.view = "fleet";
+  store.app.runId = null;
+  store.app.sel = 0;
+  store.app.filt = "";
+  store.app.sort = "recent";
+  setRuns(seedRuns());
+  setTranscript(makeTranscript("run-a"));
+});
+
+describe("Fleet", () => {
+  it("mounts on seed data and lists a row per run", () => {
+    renderView(<Fleet />);
+
+    expect(screen.getByRole("heading", { name: "Fleet" })).toBeInTheDocument();
+    expect(screen.getByText("Refactor the auth module")).toBeInTheDocument();
+    expect(screen.getByText("Fix the flaky title test")).toBeInTheDocument();
+    // "2 of 2 shown" run count.
+    expect(screen.getByText(/2 of 2 shown/)).toBeInTheDocument();
+  });
+
+  it("scores the Classified KPI over classifiable events, not all events", () => {
+    // 3 fully-classified tool events (conf >= 0.9) + 3 lifecycle events. Dividing
+    // by ALL events would read 50%; the honest classifiable denominator reads 100%.
+    const run = makeRun({ id: "fc", title: "Fully classified", events: fullyClassifiedEvents() });
+    setRuns([run]);
+
+    const { container } = renderView(<Fleet />);
+
+    const label = screen.getByText("Classified");
+    const card = label.closest("[data-slot='card']");
+    expect(card).toHaveTextContent("100%");
+    // The buggy all-events framing would have surfaced 50% for this fixture.
+    expect(container.textContent).not.toMatch(/50\s*%/);
+  });
+});
+
+describe("RunView", () => {
+  beforeEach(() => {
+    store.app.runId = "run-a";
+    store.app.sel = 0;
+  });
+
+  it("mounts the opened run with its chapters, timeline and inspector", () => {
+    renderView(<RunView />);
+
+    expect(screen.getByRole("heading", { name: "Refactor the auth module" })).toBeInTheDocument();
+    expect(screen.getByText("Chapters")).toBeInTheDocument();
+    // Titler tree: activity + step titles from the seed.
+    expect(screen.getByText("Explore the repository")).toBeInTheDocument();
+    expect(screen.getByText("Read the source files")).toBeInTheDocument();
+    expect(screen.getByText("Timeline")).toBeInTheDocument();
+    expect(screen.getByText(/6 enriched events/)).toBeInTheDocument();
+  });
+
+  it("reveals the full-text transcript when expanded", () => {
+    renderView(<RunView />);
+
+    expect(screen.getByText("Transcript")).toBeInTheDocument();
+    // Transcript is lazy — its turns render only once shown.
+    expect(
+      screen.queryByText("Please refactor the auth module for clarity."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /show/i }));
+
+    expect(
+      screen.getByText("Please refactor the auth module for clarity."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Cost", () => {
+  it("shows AIU as the primary signal and the premium-request count as secondary", () => {
+    const { container } = renderView(<Cost />);
+
+    const aiuKpi = screen.getAllByText("AI credits")[0];
+    const premiumKpi = screen.getByText("Premium requests");
+    expect(aiuKpi).toBeInTheDocument();
+    expect(premiumKpi).toBeInTheDocument();
+    // Primary before secondary in document order.
+    expect(
+      aiuKpi.compareDocumentPosition(premiumKpi) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // Primary AIU total (40 + 26.5964 AIU) and secondary premium count.
+    expect(container.textContent).toMatch(/66\.6 AIU/);
+    expect(premiumKpi.closest("[data-slot='card']")).toHaveTextContent("2");
+  });
+
+  it("renders unknown per-model counts as an em dash, never a fabricated 0", () => {
+    renderView(<Cost />);
+
+    // The blank-model run surfaces as an "unknown model" row with unknown counts.
+    expect(screen.getByText("unknown model")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});
+
+describe("Coverage", () => {
+  it("mounts on seed data and scores over the classifiable denominator", () => {
+    const { container } = renderView(<Coverage />);
+
+    expect(screen.getByRole("heading", { name: "Coverage" })).toBeInTheDocument();
+    expect(screen.getByText("Classification spread")).toBeInTheDocument();
+    // 5 classifiable events across the seed (4 tool + 1 permission), NOT the 8
+    // total events — the honest denominator surfaced in the view.
+    expect(container.textContent).toMatch(/of 5 classifiable events/);
+    // Recorded context gap from the seed.
+    expect(screen.getByText("output sink restarted mid-run")).toBeInTheDocument();
+  });
+
+  it("shows 100% coverage for a fully-classified tool fixture (denominator regression)", () => {
+    const run = makeRun({ id: "fc", title: "Fully classified", events: fullyClassifiedEvents() });
+    setRuns([run]);
+
+    const { container } = renderView(<Coverage />);
+
+    expect(screen.getByText("Classification spread")).toBeInTheDocument();
+    expect(container.textContent).toMatch(/100\s*%/);
+    // If lifecycle events had leaked into the denominator this would read 50%.
+    expect(container.textContent).not.toMatch(/50\s*%/);
+  });
+});
+
+describe("Triage", () => {
+  it("lists danger- and critical-risk events worst first", () => {
+    renderView(<Triage />);
+
+    expect(screen.getByRole("heading", { name: "Triage" })).toBeInTheDocument();
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("Danger")).toBeInTheDocument();
+    // The critical (risk 3) and danger (risk 2) events from the seed.
+    expect(screen.getByText("delete the build directory")).toBeInTheDocument();
+    expect(screen.getByText("outbound POST to an unrecognized host")).toBeInTheDocument();
+    // Governance memory surfaced from the run's taint ledger.
+    expect(screen.getByText(/web content → shell arg/)).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/views/Fleet.tsx
+++ b/dashboard/src/views/Fleet.tsx
@@ -5,7 +5,7 @@ import { useRuns } from "@/lib/queries";
 import { useApp } from "@/store";
 import type { SortKey } from "@/store";
 import { dmin, fmtAiu, fmtCost, hhmm, nsum, pct, premiumReq, tk } from "@/lib/format";
-import { coverageStats, effectMix, scopeSplit } from "@/lib/coverage";
+import { coverageStats, effectMix, isClassifiable, scopeSplit } from "@/lib/coverage";
 import { G } from "@/data/tips";
 import { KpiCard } from "@/components/KpiCard";
 import { Tip } from "@/components/Tip";
@@ -38,7 +38,14 @@ export function Fleet() {
 
   const totals = useMemo(() => {
     const all = runs.flatMap((r) => r.events);
-    const classified = all.filter((e) => (e.cls?.conf ?? 0) >= 0.9).length;
+    // Classification confidence is an effect property of CLASSIFIABLE events
+    // (tool calls + permissions). Scoring high-confidence classifications against
+    // ALL events — lifecycle turns/messages/session markers that carry no effect
+    // by nature — deflates the denominator and makes the classifier read as broken
+    // when it is not (the `unclassified-coverage-framing` diagnostic). Scope both
+    // sides to classifiable events so the KPI reflects the real rate.
+    const classifiable = all.filter(isClassifiable);
+    const classified = classifiable.filter((e) => (e.cls?.conf ?? 0) >= 0.9).length;
     // GitHub Copilot bills in AI Units ("AIU", AI credits), not dollars — so the
     // PRIMARY fleet consumption signal is total AIU (nano-AIU summed null-aware,
     // divided to AIU only at render). It stays null (rendered "—") until some run
@@ -53,7 +60,7 @@ export function Fleet() {
       aiu,
       premium,
       tokens: runs.reduce((a, r) => a + r.usage.in + r.usage.out, 0),
-      classifiedPct: Math.round((classified / (all.length || 1)) * 100),
+      classifiedPct: Math.round((classified / (classifiable.length || 1)) * 100),
       triage: runs.filter((r) => r.peak >= 2).length,
     };
   }, [runs]);


### PR DESCRIPTION
Closes #196

Render-tests the five dashboard views against seeded in-memory fixtures (no live server) and fixes the surviving coverage-denominator framing bug.

## View render tests (AC a)
`dashboard/src/test/views.test.tsx` mounts each view on a seeded fixture and asserts its key elements:
- **Fleet** — a row per run + `2 of 2 shown`; a dedicated test proves the "Classified" KPI reads `100%` (not `50%`) for a fully-classified tool run.
- **Run** — run heading, Chapters/Timeline, the titler step, and the lazy transcript (revealed on "Show").
- **Cost** — AIU primary, premium-request count secondary, unknown → "—".
- **Coverage** — classification spread over the *classifiable* denominator, a recorded gap, and 100% for a fully-classified fixture.
- **Triage** — Critical/Danger buckets, risky events worst-first, and governance memory.

Fixtures/harness: `dashboard/src/test/fixtures.ts` (pure domain builders) and `dashboard/src/test/harness.tsx` (`renderView` + jsdom stubs for `ResizeObserver`/`matchMedia`/`scrollIntoView`). The data layer (`@/lib/queries`) and store (`@/store`) are mocked — no live server, no React Query provider.

## Coverage denominator fix (AC b)
The honest selector (`lib/coverage.ts`, from #177) already scoped `coverageStats` to classifiable events, and the Coverage view + Fleet rail consumed it. The **surviving** framing bug was Fleet's header **"Classified %" KPI**, which still divided high-confidence classifications by **all** events (lifecycle turns/messages/session markers included) — deflating the rate and making the classifier look ~broken when it is ~100% on classifiable tool events.

`dashboard/src/views/Fleet.tsx` now scopes **both** the numerator and denominator of `classifiedPct` to `isClassifiable` events. Regression guards:
- `dashboard/src/lib/coverage.test.ts` — a fully-classified tool fixture (3 tool + 3 lifecycle) scores `pct === 100`, and lifecycle events are excluded from the denominator entirely.
- The Fleet render test asserts the KPI shows `100%` (and never `50%`) for that fixture.

## Cost framing (AC c)
`Cost.tsx` already surfaced AIU as primary and the premium-request count as secondary, with unknown per-model counts rendered "—". Covered by tests only — no production change (kept minimal to avoid conflicts with #195).

## Verification
- `corepack pnpm exec vitest run` → **18 passed**
- `corepack pnpm exec tsc -b` → clean
- `corepack pnpm build` → clean
- `corepack pnpm exec oxlint` → clean (only pre-existing `only-export-components` warnings)