### PR TITLE
Remove unreachable steering mapping from copilot_vscode (#172)

### DIFF
--- a/src/traceforge/mappings/copilot_vscode.yaml
+++ b/src/traceforge/mappings/copilot_vscode.yaml
@@ -125,10 +125,12 @@ events:
     payload:
       request_id: request_id
 
-  steering:
-    kind: input.received
-    payload:
-      request_id: request_id
+  # `steering` is intentionally NOT mapped: in microsoft/vscode it is a
+  # ChatRequestQueueKind (request-queue state), not a member of the IChatProgress
+  # response-part union, so it never appears as a part `kind`. The preprocessor's
+  # _emit_part derives event_type strictly from a progress part's `kind`
+  # (copilot_vscode.py), so a `steering` event can never be emitted — mapping it
+  # here would be dead config. See issue #172.
 
   command:
     kind: command.started


### PR DESCRIPTION
Closes #172

## Problem

`src/traceforge/mappings/copilot_vscode.yaml` mapped a `steering` event (→ `kind: input.received`) that the preprocessor can **never** emit, tripping the weekly YAML-drift audit.

## Root cause (verified against upstream)

- The preprocessor `_emit_part` (`src/traceforge/preprocessors/copilot_vscode.py:58`) derives `event_type = part.get("kind")` **strictly** from `IChatProgress` response parts.
- In `microsoft/vscode`, `steering` is **not** a member of the `IChatProgress` union (`chatService.ts`, 44 members enumerated — none is `steering`). It is `ChatRequestQueueKind.Steering = 'steering'` (`chatService.ts:1711–1715`), used only in the request-**queue** path (`setPendingRequests` / `addPendingRequest` / `dequeueAllSteeringRequests`).
- Therefore `steering` can never appear as a progress-part `kind`, so the mapping was unreachable dead config.

## Change

Removed the `steering` block and replaced it with a comment documenting why it's intentionally omitted (prevents re-adding).

## Scope

Resolves **only** the unreachable `steering` key. The "15 new `IChatProgress` kinds" mentioned in the issue are out of scope (tracked separately, #175).

## Verification (all via `uv run`)

- ✅ **YAML load audit** (`audit-yaml-mappings` loader): all 24 mappings load; `copilot_vscode` now 20 events (was 21).
- ✅ **Golden raw-trace** (`tests/e2e/test_raw_traces.py -k copilot_vscode`): 2 passed — snapshot **unchanged** (the fixture never produced `steering`, so no golden churn).
- ✅ **Integration** (`test_copilot_vscode_e2e.py` + `test_new_mappings.py` + `test_pipeline_e2e.py`): 142 passed.
- ✅ **ruff** `check` + `format --check` (0.15.20): clean.

`input.received` remains covered by `aider_markdown.yaml`, `copilot.yaml`, and `crewai.yaml`, so canonical-kind coverage does not regress.