### PR TITLE
Fix opencode.yaml event drift: drop dead keys, correct payload paths (#171)

### DIFF
--- a/src/traceforge/mappings/opencode.yaml
+++ b/src/traceforge/mappings/opencode.yaml
@@ -451,21 +451,13 @@ events:
     kind: session.info
     payload:
       session_id: properties.sessionID
-      directory: properties.directory
+      directory: properties.subdirectory
   session.next.prompt.admitted:
     kind: message.user
     payload:
       session_id: properties.sessionID
       delivery: properties.delivery
-      text: properties.text
-  session.next.prompt.promoted:
-    kind: session.info
-    payload:
-      session_id: properties.sessionID
-  session.next.interrupt.requested:
-    kind: session.info
-    payload:
-      session_id: properties.sessionID
+      text: properties.prompt.text
   session.next.context.updated:
     kind: session.info
     payload:


### PR DESCRIPTION
## Summary

Resolves the YAML drift audit in `src/traceforge/mappings/opencode.yaml`, aligning it with the canonical upstream schema `anomalyco/opencode` `packages/schema/src/session-event.ts` (the `Event.define` schemas cited in the file header).

### Dead event keys removed
- `session.next.prompt.promoted` — no such published bus event exists upstream.
- `session.next.interrupt.requested` — no such published bus event exists upstream.

### Payload path fixes
- `session.next.moved`: `directory: properties.directory` → `directory: properties.subdirectory`. The `Moved` schema exposes `location` (a `{directory, workspaceID}` struct) + `subdirectory` (an optional `RelativePath` string); there is **no** `properties.directory`. `subdirectory` is the scalar path string that matches the `session.info` `directory` field (as used by the `session.created`/`session.updated` mappings), whereas `location` is a nested object.
- `session.next.prompt.admitted`: `text: properties.text` → `text: properties.prompt.text`. `PromptAdmitted` uses the `PromptFields` shape, matching the sibling `session.next.prompted` mapping which already reads `properties.prompt.text`.

### Investigation
Confirmed each claim against the canonical schema on the current default branch:
- `Moved` → `{timestamp, sessionID, location: Location.Ref, subdirectory: RelativePath?}` (no `directory`).
- `PromptAdmitted` → `PromptFields` (text nested under `prompt`).
- `promoted` / `interrupt.requested` absent from the event inventory (`Definitions`/`All`).

### Scope guard
The upstream `session.next.revert.*` events do exist but are **out of scope** here (tracked in #175) and were not added.

## Verification
- ✅ YAML loader (`audit-yaml-mappings` job snippet): all 24 mappings load; `opencode` maps 43 events.
- ✅ `pytest tests/e2e/test_raw_traces.py -k opencode` — 2 passed (goldens unchanged; no fixture references the affected keys).
- ✅ `pytest tests/integration/test_opencode_e2e.py test_new_mappings.py test_pipeline_e2e.py` — 171 passed.
- ✅ `ruff check` + `ruff format --check` (0.15.20) — clean.

Closes #171