### PR TITLE
Fix codex.yaml mapping drift against upstream openai/codex (#169)

### DIFF
--- a/src/traceforge/mappings/codex.yaml
+++ b/src/traceforge/mappings/codex.yaml
@@ -123,26 +123,22 @@ events:
     kind: llm.output.chunk
     payload:
       delta: delta
-  event.agent_message_delta:
-    kind: llm.output.chunk
-    payload:
-      delta: delta
   event.exec_command_output_delta:
     kind: tool.output.chunk
     payload:
       call_id: call_id
       chunk: chunk
-  event.agent_reasoning_delta:
+  event.reasoning_content_delta:
     kind: llm.reasoning.chunk
     payload:
       delta: delta
 
-  # ── Item lifecycle v2 (#41: response_item passthrough as response.<type>) ──
-  response.item_started:
+  # ── Item lifecycle v2 (#41: event_msg passthrough as event.<type>) ──
+  event.item_started:
     kind: session.info
     payload:
       item: item
-  response.item_completed:
+  event.item_completed:
     kind: session.info
     payload:
       item: item
@@ -151,8 +147,8 @@ events:
   event.hook_started:
     kind: hook.started
     payload:
-      hook_name: hook_name
+      hook_name: run.event_name
   event.hook_completed:
     kind: hook.completed
     payload:
-      hook_name: hook_name
+      hook_name: run.event_name


### PR DESCRIPTION
Closes #169

## Summary

`src/traceforge/mappings/codex.yaml` had mapped event keys and payload fields that no longer resolve against upstream `openai/codex` (`codex-rs/protocol/src/protocol.rs`, current `main`). This resolves the drift only — no new events added.

| Fix | Before | After |
|---|---|---|
| Remove dead duplicate | `event.agent_message_delta` | *(removed)* |
| Rename reasoning delta | `event.agent_reasoning_delta` | `event.reasoning_content_delta` |
| Correct item lifecycle | `response.item_started` | `event.item_started` |
| Correct item lifecycle | `response.item_completed` | `event.item_completed` |
| Fix hook field source | `hook_name: hook_name` | `hook_name: run.event_name` (both hooks) |

## Investigation (verified against upstream `main`, not blindly applied)

Confirmed against `codex-rs/protocol/src/protocol.rs`:
- `EventMsg` (line 1280) is `#[serde(tag = "type", rename_all = "snake_case")]` → variants arrive as `event.<snake_case>` through the codex preprocessor's `event_msg` passthrough.
- `AgentMessageDelta` and `AgentReasoningDelta` variants **do not exist** (no matches). `AgentMessageContentDelta` (1452, already mapped) and `ReasoningContentDelta` (1454) are the real variants.
- `ItemStarted` (1447) and `ItemCompleted` (1448) are `EventMsg` variants, not `response_item`s → they arrive as `event.item_*`, so `response.item_*` keys were dead.
- `HookStartedEvent` (1597) / `HookCompletedEvent` (1604) carry `turn_id` + `run: HookRunSummary`; there is no top-level `hook_name`. `HookRunSummary` (1574) exposes `event_name`, so `run.event_name` is the correct source. The adapter's `_resolve_path` supports dotted nested paths, and the preprocessor hoists `run` to the top level of the normalized dict.

The codex golden fixture contained none of the affected event types, so no `.expected.json` changed.

## Verification (all via `uv run`)
- All 24 YAML mappings load (CI `audit-yaml-mappings` loader) — codex now 19 events.
- Codex raw-trace golden `tests/e2e/test_raw_traces.py -k codex`: 2 passed.
- Integration `tests/integration/test_new_mappings.py` + `test_pipeline_e2e.py`: 137 passed.
- Full codex-filtered suite: 42 passed.
- `ruff check .` + `ruff format --check .` (pinned 0.15.20): clean.

New replacement events remain out of scope (tracked in #175).