### PR TITLE
Remove dead cline say.generate_explanation mapping (#170)

### DIFF
--- a/src/traceforge/mappings/cline.yaml
+++ b/src/traceforge/mappings/cline.yaml
@@ -39,7 +39,7 @@ motivation:
 
 events:
   # ── Say subtypes (preprocessor synthesizes "say.<subtype>") ──
-  # Verified against ClineSay type in ExtensionMessage.ts (38 values)
+  # Verified against ClineSay type in ExtensionMessage.ts (37 values)
   say.task:
     kind: session.started
     payload:
@@ -160,10 +160,6 @@ events:
       content: text
   say.checkpoint_created:
     kind: checkpoint.created
-    payload:
-      content: text
-  say.generate_explanation:
-    kind: reasoning.started
     payload:
       content: text
   say.info:

--- a/tests/integration/test_yaml_comprehensive_e2e.py
+++ b/tests/integration/test_yaml_comprehensive_e2e.py
@@ -1475,12 +1475,6 @@ class TestClineMappings:
             id="say.checkpoint_created",
         ),
         pytest.param(
-            _cline_say("generate_explanation", "Explaining changes"),
-            EventKind.REASONING_STARTED,
-            {"content": "Explaining changes"},
-            id="say.generate_explanation",
-        ),
-        pytest.param(
             _cline_say("info", "General info"),
             EventKind.SESSION_INFO,
             {"content": "General info"},


### PR DESCRIPTION
Closes #170

## Summary
`generate_explanation` was removed from the upstream `ClineSay` union in `cline/cline` (`apps/vscode/src/shared/ExtensionMessage.ts`, current `main`). The union now has **37 members (was 38)**, and `generate_explanation` is no longer among them, so `src/traceforge/mappings/cline.yaml` mapped a dead event key.

## Investigation (verified before editing)
Downloaded the real upstream `ExtensionMessage.ts` from `main` and cross-checked **every** mapped key programmatically:
- `ClineSay` upstream = 37 members; `'generate_explanation' in ClineSay` → **False** ✔
- `ClineAsk` upstream = 18 members ✔
- Dead `say.*` keys in YAML vs upstream: **`['generate_explanation']`** (the only one)
- Dead `ask.*` keys: **none**; every other `say.*`/`ask.*` key still resolves (0 unmapped upstream members)

> Note: the issue cites `src/shared/ExtensionMessage.ts`, but on current `main` that path 404s — the file now lives at `apps/vscode/src/shared/ExtensionMessage.ts` (monorepo layout). Content verified there.

## Changes
- **`src/traceforge/mappings/cline.yaml`**: removed the `say.generate_explanation` block; updated the `ClineSay` count comment `38 → 37`.
- **`tests/integration/test_yaml_comprehensive_e2e.py`**: removed the now-fabricated `say.generate_explanation` parametrized case (it asserted a mapping upstream no longer emits; without removal it would fall through to the `say:` fallback and fail).

The raw-trace golden fixture was **not** touched — it contained no fabricated `generate_explanation` event, so no re-bless was needed.

## Verification (all via `uv run`)
- ✅ **(a)** All 24 YAML mappings load (`audit-yaml-mappings` loader) — cline now 57 events (was 58).
- ✅ **(b)** cline raw-trace golden: `tests/e2e/test_raw_traces.py -k cline` — 2 passed, incl. no-`raw`-fallthrough; golden unchanged.
- ✅ **(c)** `tests/integration/test_new_mappings.py` + `test_pipeline_e2e.py` + `TestClineMappings` — 194 passed.
- ✅ **(d)** `ruff check .` and `ruff format --check .` (pinned `0.15.20`) clean.

Scope: only this one dead key.