### PR TITLE
ci: cache Git LFS model weights instead of re-fetching every run

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,9 +12,27 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
+      # Checkout WITHOUT fetching LFS objects. With lfs:false the *.onnx/*.safetensors
+      # files are left as ~133-byte LFS pointer text, so no LFS bandwidth is spent here.
       - uses: actions/checkout@v6
         with:
-          lfs: true
+          lfs: false
+      # Cache the local LFS object store. The cache key hashes the checked-out pointer
+      # files, whose content embeds each weight's sha256 OID, so the key changes exactly
+      # when a weight changes. On a cache hit, `git lfs pull` below finds every object
+      # locally and makes NO call to the LFS server.
+      - name: Cache Git LFS objects
+        uses: actions/cache@v4
+        with:
+          path: .git/lfs
+          key: lfs-v1-${{ hashFiles('**/*.onnx', '**/*.safetensors') }}
+          restore-keys: |
+            lfs-v1-
+      # Materialize weights into the working tree from the local (cached) store.
+      # Cache hit: zero network. Cache miss: one fetch from the LFS server (needs budget),
+      # then the cache step saves .git/lfs for subsequent runs.
+      - name: Materialize LFS weights
+        run: git lfs pull
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -25,9 +43,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Checkout WITHOUT fetching LFS objects (see the `test` job for the full rationale):
+      # lfs:false leaves the weights as LFS pointer text and spends no LFS bandwidth.
       - uses: actions/checkout@v6
         with:
-          lfs: true
+          lfs: false
+      # Cache the local LFS object store, keyed to the weight OIDs embedded in the
+      # checked-out pointer files. Cache hit => `git lfs pull` runs offline.
+      - name: Cache Git LFS objects
+        uses: actions/cache@v4
+        with:
+          path: .git/lfs
+          key: lfs-v1-${{ hashFiles('**/*.onnx', '**/*.safetensors') }}
+          restore-keys: |
+            lfs-v1-
+      # Materialize weights from the local (cached) store before anything loads them.
+      - name: Materialize LFS weights
+        run: git lfs pull
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"


### PR DESCRIPTION
## Root cause

`.github/workflows/ci-test.yml` had two jobs checking out with `lfs: true`:

- `test` (matrix python 3.11/3.12/3.13)
- `build`

`.gitattributes` tracks `*.onnx` and `*.safetensors` via Git LFS — 3 objects, ~125 MB total:

- `packages/traceforge-title-model/.../span/decoder.onnx` (~59 MB)
- `packages/traceforge-title-model/.../span/encoder.onnx` (~36 MB)
- `src/traceforge/phase/data/potion-base-8M/model.safetensors` (~30 MB)

Every CI run re-fetched **all** of these in **each** `lfs: true` job (3 test jobs + build → ~500 MB/run). That exhausted the repo's monthly GitHub LFS bandwidth budget, so `actions/checkout@v6` now fails at the `git lfs fetch` step with `batch response: This repository exceeded its LFS budget` — turning `test` and `build` **red before any test runs**.

The weights genuinely must be materialized (phase loads via `StaticModel.from_pretrained`, title via `ort.InferenceSession`, and `scripts/verify_no_lfs_pointers.py` guards against pointers), so dropping LFS isn't an option — the goal is to materialize **without** re-fetching from the LFS server every run.

## The fix (applied to `test` and `build` only)

For each of the two jobs:

1. **`actions/checkout@v6` → `lfs: false`** so checkout no longer performs the LFS fetch (the exact step that dies when the budget is exhausted). The working tree then holds the small ~133-byte LFS **pointer** text for each weight.
2. **`actions/cache@v4` on `.git/lfs`**, keyed `lfs-v1-${{ hashFiles('**/*.onnx', '**/*.safetensors') }}` with restore-key `lfs-v1-`. Because with `lfs: false` the checked-out weight files *are* the pointer text (and each pointer embeds its object's sha256 OID), the key changes exactly when a weight changes.
3. **`git lfs pull`** to materialize the weights from the local store. On a cache **hit**, git-lfs finds every object already in `.git/lfs/objects/<oid>` and makes **no** call to the LFS server. On a cache **miss** it fetches once (needs budget), and the cache step then saves `.git/lfs` for next time.

Step order per job: `checkout(lfs:false)` → `actions/cache` → `git lfs pull` → existing setup/build/test steps (weights materialized before anything loads them).

`lint` and `dashboard-frontend` are **unchanged** — they always used a plain checkout with no LFS.

## Cold-cache seeding caveat

Because `pull_request` runs this PR's version of the workflow, `test`/`build` start with a **cold cache**; the first `git lfs pull` needs budget > 0 to seed it. **If the monthly LFS budget is still exhausted, `test`/`build` may be red on that first run through no fault of this change.** The first successful run (after the budget resets or is raised) seeds the cache, and every run after that is a cache hit with **zero** LFS bandwidth. Steady-state signal to rely on: `lint` + `dashboard-frontend` staying green, the diff being exactly this workflow edit, and this description.

Change is scoped to `.github/workflows/ci-test.yml` only.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>