### PR TITLE
Fix Cline compaction event drift

### DIFF
--- a/src/traceforge/mappings/cline.yaml
+++ b/src/traceforge/mappings/cline.yaml
@@ -1,6 +1,7 @@
 # Cline / Roo Code event mapping for MappedJsonAdapter
 # Targets: cline >= 3.88 (VS Code extension globalStorage JSON format)
-# Source: cline/cline apps/vscode/src/shared/ExtensionMessage.ts (commit 9d59de4)
+# Source: cline/cline apps/vscode/src/shared/ExtensionMessage.ts (commit 01617f9)
+# say.compaction was added in Cline 4.0.0 (commit 8e5471d, 2026-07-23).
 #
 # IMPORTANT: Real Cline uses a COMPOUND discriminator:
 #   - type_field "type" has ONLY two values: "ask" or "say"
@@ -16,7 +17,7 @@
 #   {ts: number, type: "ask"|"say", ask?: ClineAsk, say?: ClineSay, text?: string, ...}
 # API metrics: JSON.parse(text) on say="api_req_started" → {tokensIn, tokensOut, cost, ...}
 #   ClineApiReqInfo fields: request, tokensIn, tokensOut, cacheWrites, cacheReads,
-#   cost, cancelReason, streamingFailedMessage, retryStatus
+#   cost, cancelReason, streamingFailedMessage
 #   NOTE: There is NO "model" field in ClineApiReqInfo.
 # Tool info: JSON.parse(text) on say="tool" → {tool, path, content, diff}
 
@@ -39,7 +40,8 @@ motivation:
 
 events:
   # ── Say subtypes (preprocessor synthesizes "say.<subtype>") ──
-  # Verified against ClineSay type in ExtensionMessage.ts (37 values)
+  # Verified against ClineSay at commit 01617f9 (36 current values).
+  # api_req_retried and error_retry remain for persisted pre-SDK transcripts.
   say.task:
     kind: session.started
     payload:
@@ -66,6 +68,7 @@ events:
       cost_usd: parsed.cost
       cache_read_tokens: parsed.cacheReads
       cache_write_tokens: parsed.cacheWrites
+  # Removed upstream in 01617f9; retained for historical-log compatibility.
   say.api_req_retried:
     kind: llm.call.retried
     payload:
@@ -74,6 +77,7 @@ events:
     kind: session.error
     payload:
       message: text
+  # Removed upstream in 01617f9; retained for historical-log compatibility.
   say.error_retry:
     kind: llm.call.retried
     payload:
@@ -194,6 +198,63 @@ events:
     kind: session.info
     payload:
       content: text
+  say.compaction.started:
+    kind: workflow.started
+    payload:
+      status: parsed.status
+      mode: parsed.mode
+      tokens_before: parsed.tokensBefore
+      tokens_after: parsed.tokensAfter
+      messages_before: parsed.messagesBefore
+      messages_after: parsed.messagesAfter
+  say.compaction.completed:
+    kind: workflow.completed
+    payload:
+      status: parsed.status
+      mode: parsed.mode
+      tokens_before: parsed.tokensBefore
+      tokens_after: parsed.tokensAfter
+      messages_before: parsed.messagesBefore
+      messages_after: parsed.messagesAfter
+  say.compaction.failed:
+    kind: workflow.failed
+    payload:
+      status: parsed.status
+      mode: parsed.mode
+      tokens_before: parsed.tokensBefore
+      tokens_after: parsed.tokensAfter
+      messages_before: parsed.messagesBefore
+      messages_after: parsed.messagesAfter
+  # No registered workflow skipped/cancelled kinds; preserve them as information.
+  say.compaction.skipped:
+    kind: session.info
+    payload:
+      status: parsed.status
+      mode: parsed.mode
+      tokens_before: parsed.tokensBefore
+      tokens_after: parsed.tokensAfter
+      messages_before: parsed.messagesBefore
+      messages_after: parsed.messagesAfter
+  say.compaction.cancelled:
+    kind: session.info
+    payload:
+      status: parsed.status
+      mode: parsed.mode
+      tokens_before: parsed.tokensBefore
+      tokens_after: parsed.tokensAfter
+      messages_before: parsed.messagesBefore
+      messages_after: parsed.messagesAfter
+  # Preserve malformed or future compaction statuses without raw fallthrough.
+  say.compaction:
+    kind: session.info
+    payload:
+      content: text
+      status: parsed.status
+      mode: parsed.mode
+      tokens_before: parsed.tokensBefore
+      tokens_after: parsed.tokensAfter
+      messages_before: parsed.messagesBefore
+      messages_after: parsed.messagesAfter
 
   # ── Ask subtypes (preprocessor synthesizes "ask.<subtype>") ──
   # Verified against ClineAsk type in ExtensionMessage.ts (18 values)

--- a/src/traceforge/mappings/cline.yaml
+++ b/src/traceforge/mappings/cline.yaml
@@ -198,9 +198,12 @@ events:
     kind: session.info
     payload:
       content: text
+  # Upstream emits only say.compaction; the preprocessor synthesizes these
+  # status-qualified keys from ClineCompactionInfo.status for canonical mapping.
   say.compaction.started:
     kind: workflow.started
     payload:
+      content: text
       status: parsed.status
       mode: parsed.mode
       tokens_before: parsed.tokensBefore
@@ -210,6 +213,7 @@ events:
   say.compaction.completed:
     kind: workflow.completed
     payload:
+      content: text
       status: parsed.status
       mode: parsed.mode
       tokens_before: parsed.tokensBefore
@@ -219,16 +223,19 @@ events:
   say.compaction.failed:
     kind: workflow.failed
     payload:
+      content: text
       status: parsed.status
       mode: parsed.mode
       tokens_before: parsed.tokensBefore
       tokens_after: parsed.tokensAfter
       messages_before: parsed.messagesBefore
       messages_after: parsed.messagesAfter
-  # No registered workflow skipped/cancelled kinds; preserve them as information.
+  # The current canonical vocabulary has no workflow skipped/cancelled constants;
+  # preserve these terminal states as session information.
   say.compaction.skipped:
     kind: session.info
     payload:
+      content: text
       status: parsed.status
       mode: parsed.mode
       tokens_before: parsed.tokensBefore
@@ -238,6 +245,7 @@ events:
   say.compaction.cancelled:
     kind: session.info
     payload:
+      content: text
       status: parsed.status
       mode: parsed.mode
       tokens_before: parsed.tokensBefore

--- a/src/traceforge/preprocessors/cline.py
+++ b/src/traceforge/preprocessors/cline.py
@@ -8,6 +8,9 @@ from typing import Any
 from traceforge.preprocessors.registry import register_preprocessor
 
 
+_COMPACTION_STATUSES = frozenset({"started", "completed", "skipped", "failed", "cancelled"})
+
+
 @register_preprocessor("cline")
 def preprocess_cline(obj: dict[str, Any]) -> list[dict[str, Any]]:
     """Synthesize compound type from Cline's type + say/ask subtype.
@@ -25,11 +28,18 @@ def preprocess_cline(obj: dict[str, Any]) -> list[dict[str, Any]]:
 
         # Parse JSON text field for known subtypes that embed structured data
         text = normalized.get("text")
-        if text and subtype in ("api_req_started", "api_req_finished", "tool"):
+        if text and subtype in ("api_req_started", "api_req_finished", "tool", "compaction"):
             try:
                 parsed = json.loads(text)
                 if isinstance(parsed, dict):
                     normalized["parsed"] = parsed
+                    status = parsed.get("status")
+                    if (
+                        subtype == "compaction"
+                        and isinstance(status, str)
+                        and status in _COMPACTION_STATUSES
+                    ):
+                        normalized["type"] = f"{normalized['type']}.{status}"
             except (json.JSONDecodeError, ValueError):
                 pass
         return [normalized]

--- a/tests/e2e/test_raw_traces.py
+++ b/tests/e2e/test_raw_traces.py
@@ -174,3 +174,21 @@ def test_pydantic_ai_part_end_carries_real_content() -> None:
     assert any("ticket" in t.lower() or "endpoint" in t.lower() for t in non_empty), (
         f"expected real captured task text, got {assistant_texts!r}"
     )
+
+
+def test_cline_compaction_preserves_native_payload() -> None:
+    """Cline's JSON-encoded compaction divider must stay useful on the timeline."""
+    if "cline" not in FRAMEWORKS:
+        pytest.skip("cline trace not captured")
+    compacted = [
+        event for event in _parse_trace("cline") if event.kind == EventKind.WORKFLOW_COMPLETED
+    ]
+    assert len(compacted) == 1
+    payload = compacted[0].payload
+    assert payload["content"]
+    assert payload["status"] == "completed"
+    assert payload["mode"] == "auto"
+    assert payload["tokens_before"] == 12000
+    assert payload["tokens_after"] == 4300
+    assert payload["messages_before"] == 48
+    assert payload["messages_after"] == 17

--- a/tests/fixtures/raw_traces/cline/demo_issue_tracker_get_endpoint_shape.expected.json
+++ b/tests/fixtures/raw_traces/cline/demo_issue_tracker_get_endpoint_shape.expected.json
@@ -1,5 +1,5 @@
 {
-  "event_count": 7,
+  "event_count": 8,
   "kinds": {
     "llm.call.started": 1,
     "message.assistant": 1,
@@ -7,6 +7,7 @@
     "reasoning.started": 1,
     "session.ended": 1,
     "session.started": 1,
-    "tool.call.completed": 1
+    "tool.call.completed": 1,
+    "workflow.completed": 1
   }
 }

--- a/tests/fixtures/raw_traces/cline/demo_issue_tracker_get_endpoint_shape.jsonl
+++ b/tests/fixtures/raw_traces/cline/demo_issue_tracker_get_endpoint_shape.jsonl
@@ -5,3 +5,4 @@
 {"ts":5,"type":"ask","ask":"tool","text":"{\"tool\":\"editedExistingFile\",\"path\":\"src/routes/tickets.py\"}"}
 {"ts":6,"type":"say","say":"tool","text":"{\"tool\":\"editedExistingFile\",\"path\":\"src/routes/tickets.py\"}"}
 {"ts":7,"type":"say","say":"completion_result","text":"Endpoint added and tested."}
+{"ts":8,"type":"say","say":"compaction","text":"{\"status\":\"completed\",\"mode\":\"auto\",\"tokensBefore\":12000,\"tokensAfter\":4300,\"messagesBefore\":48,\"messagesAfter\":17}","partial":false}

--- a/tests/fixtures/raw_traces/cline/meta.yaml
+++ b/tests/fixtures/raw_traces/cline/meta.yaml
@@ -1,6 +1,6 @@
 framework: cline
 scenario: demo_issue_tracker_get_endpoint_shape
 source_repo: demo-issue-tracker-api
-framework_version: ">=3.88"
+framework_version: "4.0.0"
 model: shape-fixture
-notes: SHAPE FIXTURE (VS Code GUI capture not run). Verbatim ui_messages.json ClineMessage shape verified against cline/cline ExtensionMessage.ts — type ask|say, subtype in ask/say, api_req_started text=JSON ClineApiReqInfo, tool text=JSON ClineSayTool. Replace with real capture when extension is run.
+notes: SHAPE FIXTURE (VS Code GUI capture not run). Verbatim ui_messages.json ClineMessage shape verified against cline/cline ExtensionMessage.ts at 01617f9 — type ask|say, subtype in ask/say, api_req_started text=JSON ClineApiReqInfo, tool text=JSON ClineSayTool, compaction text=JSON ClineCompactionInfo added in 4.0.0 at 8e5471d. Replace with real capture when extension is run.

--- a/tests/integration/test_yaml_comprehensive_e2e.py
+++ b/tests/integration/test_yaml_comprehensive_e2e.py
@@ -1523,6 +1523,65 @@ class TestClineMappings:
             id="say.conditional_rules_applied",
         ),
         pytest.param(
+            _cline_say("compaction", json.dumps({"status": "started", "mode": "auto"})),
+            EventKind.WORKFLOW_STARTED,
+            {"status": "started", "mode": "auto"},
+            id="say.compaction.started",
+        ),
+        pytest.param(
+            _cline_say(
+                "compaction",
+                json.dumps(
+                    {
+                        "status": "completed",
+                        "mode": "manual",
+                        "tokensBefore": 12000,
+                        "tokensAfter": 4300,
+                        "messagesBefore": 48,
+                        "messagesAfter": 17,
+                    }
+                ),
+            ),
+            EventKind.WORKFLOW_COMPLETED,
+            {
+                "status": "completed",
+                "mode": "manual",
+                "tokens_before": 12000,
+                "tokens_after": 4300,
+                "messages_before": 48,
+                "messages_after": 17,
+            },
+            id="say.compaction.completed",
+        ),
+        pytest.param(
+            _cline_say("compaction", json.dumps({"status": "skipped", "mode": "auto"})),
+            EventKind.SESSION_INFO,
+            {"status": "skipped", "mode": "auto"},
+            id="say.compaction.skipped",
+        ),
+        pytest.param(
+            _cline_say("compaction", json.dumps({"status": "failed", "mode": "manual"})),
+            EventKind.WORKFLOW_FAILED,
+            {"status": "failed", "mode": "manual"},
+            id="say.compaction.failed",
+        ),
+        pytest.param(
+            _cline_say("compaction", json.dumps({"status": "cancelled", "mode": "auto"})),
+            EventKind.SESSION_INFO,
+            {"status": "cancelled", "mode": "auto"},
+            id="say.compaction.cancelled",
+        ),
+        pytest.param(
+            _cline_say("compaction", json.dumps({"status": "paused", "mode": "auto"})),
+            EventKind.SESSION_INFO,
+            {
+                "content": json.dumps({"status": "paused", "mode": "auto"}),
+                "status": "paused",
+                "mode": "auto",
+            },
+            id="say.compaction.future-status",
+        ),
+        pytest.param(
             _cline_say(None, "Fallback assistant text"),
             EventKind.MESSAGE_ASSISTANT,
             {"content": "Fallback assistant text"},

--- a/tests/integration/test_yaml_comprehensive_e2e.py
+++ b/tests/integration/test_yaml_comprehensive_e2e.py
@@ -1525,7 +1525,11 @@ class TestClineMappings:
         pytest.param(
             _cline_say("compaction", json.dumps({"status": "started", "mode": "auto"})),
             EventKind.WORKFLOW_STARTED,
-            {"status": "started", "mode": "auto"},
+            {
+                "content": json.dumps({"status": "started", "mode": "auto"}),
+                "status": "started",
+                "mode": "auto",
+            },
             id="say.compaction.started",
         ),
         pytest.param(
@@ -1544,6 +1548,16 @@ class TestClineMappings:
             ),
             EventKind.WORKFLOW_COMPLETED,
             {
+                "content": json.dumps(
+                    {
+                        "status": "completed",
+                        "mode": "manual",
+                        "tokensBefore": 12000,
+                        "tokensAfter": 4300,
+                        "messagesBefore": 48,
+                        "messagesAfter": 17,
+                    }
+                ),
                 "status": "completed",
                 "mode": "manual",
                 "tokens_before": 12000,
@@ -1556,19 +1570,31 @@ class TestClineMappings:
         pytest.param(
             _cline_say("compaction", json.dumps({"status": "skipped", "mode": "auto"})),
             EventKind.SESSION_INFO,
-            {"status": "skipped", "mode": "auto"},
+            {
+                "content": json.dumps({"status": "skipped", "mode": "auto"}),
+                "status": "skipped",
+                "mode": "auto",
+            },
             id="say.compaction.skipped",
         ),
         pytest.param(
             _cline_say("compaction", json.dumps({"status": "failed", "mode": "manual"})),
             EventKind.WORKFLOW_FAILED,
-            {"status": "failed", "mode": "manual"},
+            {
+                "content": json.dumps({"status": "failed", "mode": "manual"}),
+                "status": "failed",
+                "mode": "manual",
+            },
             id="say.compaction.failed",
         ),
         pytest.param(
             _cline_say("compaction", json.dumps({"status": "cancelled", "mode": "auto"})),
             EventKind.SESSION_INFO,
-            {"status": "cancelled", "mode": "auto"},
+            {
+                "content": json.dumps({"status": "cancelled", "mode": "auto"}),
+                "status": "cancelled",
+                "mode": "auto",
+            },
             id="say.compaction.cancelled",
         ),
         pytest.param(

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -22,6 +22,7 @@ reported to the epic coordinator rather than fixed here (this ticket is tests-on
 from __future__ import annotations
 
 import copy
+import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -493,6 +494,52 @@ class TestCline:
     def test_invalid_json_text_left_unparsed(self) -> None:
         out = preprocess_cline({"type": "say", "say": "api_req_started", "text": "not json"})
         assert "parsed" not in out[0]
+
+    @pytest.mark.parametrize("status", ["started", "completed", "skipped", "failed", "cancelled"])
+    def test_compaction_status_qualifies_compound_type(self, status: str) -> None:
+        out = preprocess_cline(
+            {
+                "type": "say",
+                "say": "compaction",
+                "text": json.dumps({"status": status, "mode": "auto"}),
+            }
+        )
+        assert out[0]["type"] == f"say.compaction.{status}"
+
+    def test_compaction_json_preserves_structured_counters(self) -> None:
+        info = {
+            "status": "completed",
+            "mode": "manual",
+            "tokensBefore": 12000,
+            "tokensAfter": 4300,
+            "messagesBefore": 48,
+            "messagesAfter": 17,
+        }
+        out = preprocess_cline({"type": "say", "say": "compaction", "text": json.dumps(info)})
+        assert out[0]["parsed"] == info
+
+    def test_future_compaction_status_uses_safe_base_type(self) -> None:
+        out = preprocess_cline(
+            {
+                "type": "say",
+                "say": "compaction",
+                "text": '{"status":"paused","mode":"auto"}',
+            }
+        )
+        assert out[0]["type"] == "say.compaction"
+        assert out[0]["parsed"] == {"status": "paused", "mode": "auto"}
+
+    def test_invalid_compaction_json_uses_safe_base_type(self) -> None:
+        out = preprocess_cline({"type": "say", "say": "compaction", "text": "not json"})
+        assert out[0]["type"] == "say.compaction"
+        assert "parsed" not in out[0]
+
+    def test_non_string_compaction_status_uses_safe_base_type(self) -> None:
+        out = preprocess_cline(
+            {"type": "say", "say": "compaction", "text": '{"status":[],"mode":"auto"}'}
+        )
+        assert out[0]["type"] == "say.compaction"
+        assert out[0]["parsed"] == {"status": [], "mode": "auto"}
 
     def test_unknown_type_passthrough(self) -> None:
         obj = {"type": "other", "text": "x"}


### PR DESCRIPTION
## Summary

- Corrects #213's false premise: `say.generate_explanation` is not present in the current mapping; main already removed it in a0ea582 / #208, so this PR does not remove or restore it.
- Fixes the genuine current drift introduced by Cline 4.0.0 (`cline/cline@8e5471d`): the preprocessor parses upstream `say.compaction` JSON and synthesizes status-qualified mapping keys from `ClineCompactionInfo.status`.
- Maps started/completed/failed to the existing canonical workflow lifecycle vocabulary and keeps skipped/cancelled as `session.info`; Traceforge's kind registry remains open, and the exact upstream status is preserved in every payload.
- Preserves the raw JSON `content`, `status`, `mode`, token counts, and message counts so compaction rows remain renderable and useful. Malformed and future statuses remain visible as `session.info` instead of falling through to `raw`.
- Retains `say.api_req_retried` and `say.error_retry` for historical transcript compatibility even though upstream removed their current emission paths in `cline/cline@01617f9`.
- Does not add historical `generate_explanation` compatibility because no actual runtime emission path was established; schema history alone is insufficient.
- Extends the Cline upstream-shape raw corpus with a 4.0.0 compaction row and pins both its golden kind and full mapped payload.

## Mapping

- `started` -> `workflow.started`
- `completed` -> `workflow.completed`
- `failed` -> `workflow.failed`
- `skipped` / `cancelled` -> `session.info` (the current canonical vocabulary has no workflow skipped/cancelled constants; exact status remains in the payload)

## Verification

- Focused Cline unit/integration/raw-trace tests: 90 passed
- Full suite: 3615 passed, 8 skipped
- Ruff 0.15.20 check and format check

Closes #213