### PR TITLE
Fix VS Code v3 journal timing and citations

### DIFF
--- a/src/traceforge/mappings/copilot_vscode.yaml
+++ b/src/traceforge/mappings/copilot_vscode.yaml
@@ -157,6 +157,7 @@ events:
       license: license
       snippet: snippet
       request_id: request_id
+      model: model
 
   markdownContent:
     kind: message.assistant

--- a/src/traceforge/mappings/copilot_vscode.yaml
+++ b/src/traceforge/mappings/copilot_vscode.yaml
@@ -111,10 +111,8 @@ events:
       request_id: request_id
 
   # ── Additional VS Code chat part kinds ─────────────────────────────────────
-  # Proactively mapped (observed across VS Code chat versions but absent from the
-  # local dev sessions) so a one-shot paid capture won't trip the drift guard on
-  # a part type that simply didn't occur here. Missing nested fields resolve to
-  # None, so a sparse payload is harmless.
+  # These response kinds have direct canonical equivalents. Other v3 kinds are
+  # intentionally left to default_kind: raw until their semantics are observed.
   progressTaskSerialized:
     kind: tool.progress
     payload:
@@ -149,10 +147,15 @@ events:
     payload:
       request_id: request_id
 
-  codeCitation:
-    kind: file.read
+  # Citations are serialized separately at requests[i].codeCitations, not as
+  # response parts. They describe public-code similarity metadata rather than a
+  # file access, so preserve them as neutral request-correlated information.
+  code_citation:
+    kind: session.info
     payload:
-      uri: value
+      value: value
+      license: license
+      snippet: snippet
       request_id: request_id
 
   markdownContent:
@@ -179,5 +182,4 @@ events:
     payload:
       request_id: request_id
       model: model
-      first_progress_ms: first_progress_ms
-      duration_ms: total_elapsed_ms
+      duration_ms: elapsed_ms

--- a/src/traceforge/preprocessors/copilot_vscode.py
+++ b/src/traceforge/preprocessors/copilot_vscode.py
@@ -12,7 +12,8 @@ Paths mix dict keys and integer array indices, e.g.
 ``["requests", 2, "response"]``. The interesting state lives under ``requests[]``:
 each request carries the user ``message``, a streamed ``response`` part list
 (``thinking`` / ``toolInvocationSerialized`` / markdown text / file refs),
-request-level ``codeCitations``, and terminal request-level ``elapsedMs``.
+request-level ``codeCitations`` and ``elapsedMs``. Final response parts may be
+written after ``elapsedMs``.
 
 Because the adapter feeds records one physical line at a time, this preprocessor
 keeps a small amount of module-level state (a mirror of the ``requests`` index ->
@@ -105,6 +106,7 @@ def _emit_request(req: dict[str, Any], idx: int) -> list[dict[str, Any]]:
     _REQ_IDS[idx] = req.get("requestId")
     _REQ_MODELS[idx] = req.get("modelId")
     _REQ_TS[idx] = req.get("timestamp")
+    _REQ_CITATION_COUNTS.pop(idx, None)
 
     message = req.get("message")
     text = message.get("text") if isinstance(message, dict) else message

--- a/src/traceforge/preprocessors/copilot_vscode.py
+++ b/src/traceforge/preprocessors/copilot_vscode.py
@@ -11,8 +11,8 @@ Each physical line is one journal record:
 Paths mix dict keys and integer array indices, e.g.
 ``["requests", 2, "response"]``. The interesting state lives under ``requests[]``:
 each request carries the user ``message``, a streamed ``response`` part list
-(``thinking`` / ``toolInvocationSerialized`` / markdown text / file refs), and a
-terminal ``result`` with timings.
+(``thinking`` / ``toolInvocationSerialized`` / markdown text / file refs),
+request-level ``codeCitations``, and terminal request-level ``elapsedMs``.
 
 Because the adapter feeds records one physical line at a time, this preprocessor
 keeps a small amount of module-level state (a mirror of the ``requests`` index ->
@@ -31,6 +31,7 @@ from traceforge.preprocessors.registry import register_preprocessor
 _REQ_IDS: dict[int, str | None] = {}
 _REQ_MODELS: dict[int, Any] = {}
 _REQ_TS: dict[int, Any] = {}
+_REQ_CITATION_COUNTS: dict[int, int] = {}
 _REQ_COUNT = [0]  # boxed int so helpers can mutate it
 
 
@@ -38,6 +39,7 @@ def _reset() -> None:
     _REQ_IDS.clear()
     _REQ_MODELS.clear()
     _REQ_TS.clear()
+    _REQ_CITATION_COUNTS.clear()
     _REQ_COUNT[0] = 0
 
 
@@ -60,6 +62,42 @@ def _emit_part(part: Any, idx: int) -> dict[str, Any] | None:
     flat["model"] = _REQ_MODELS.get(idx)
     flat["timestamp"] = _REQ_TS.get(idx)
     return flat
+
+
+def _emit_citations(citations: Any, idx: int) -> list[dict[str, Any]]:
+    """Turn request-level VS Code code citations into informational events."""
+    if not isinstance(citations, list):
+        return []
+
+    citations = [citation for citation in citations if isinstance(citation, dict)]
+    start = min(_REQ_CITATION_COUNTS.get(idx, 0), len(citations))
+    _REQ_CITATION_COUNTS[idx] = len(citations)
+
+    out = []
+    for citation in citations[start:]:
+        out.append(
+            {
+                "event_type": "code_citation",
+                "request_id": _REQ_IDS.get(idx),
+                "model": _REQ_MODELS.get(idx),
+                "value": citation.get("value"),
+                "license": citation.get("license"),
+                "snippet": citation.get("snippet"),
+                "timestamp": _REQ_TS.get(idx),
+            }
+        )
+    return out
+
+
+def _emit_completion(elapsed_ms: int | float, idx: int) -> dict[str, Any]:
+    """Emit active generation duration from the v3 request-level field."""
+    return {
+        "event_type": "request_result",
+        "request_id": _REQ_IDS.get(idx),
+        "model": _REQ_MODELS.get(idx),
+        "elapsed_ms": elapsed_ms,
+        "timestamp": _REQ_TS.get(idx),
+    }
 
 
 def _emit_request(req: dict[str, Any], idx: int) -> list[dict[str, Any]]:
@@ -87,22 +125,11 @@ def _emit_request(req: dict[str, Any], idx: int) -> list[dict[str, Any]]:
         emitted = _emit_part(part, idx)
         if emitted is not None:
             out.append(emitted)
-    result = req.get("result")
-    if isinstance(result, dict):
-        out.append(_emit_result(result, idx))
+    out.extend(_emit_citations(req.get("codeCitations"), idx))
+    elapsed_ms = req.get("elapsedMs")
+    if isinstance(elapsed_ms, (int, float)) and not isinstance(elapsed_ms, bool):
+        out.append(_emit_completion(elapsed_ms, idx))
     return out
-
-
-def _emit_result(result: dict[str, Any], idx: int) -> dict[str, Any]:
-    timings = result.get("timings") if isinstance(result.get("timings"), dict) else {}
-    return {
-        "event_type": "request_result",
-        "request_id": _REQ_IDS.get(idx),
-        "model": _REQ_MODELS.get(idx),
-        "first_progress_ms": timings.get("firstProgress"),
-        "total_elapsed_ms": timings.get("totalElapsed"),
-        "timestamp": _REQ_TS.get(idx),
-    }
 
 
 @register_preprocessor("copilot_vscode")
@@ -161,11 +188,18 @@ def preprocess_copilot_vscode(obj: dict[str, Any]) -> list[dict[str, Any]]:
             return out
         return []
 
-    # ── Set records: only the terminal per-request result is interesting ──────
+    # ── Set records: request metadata serialized outside response parts ───────
     if kind == 1:
-        if len(path) == 3 and path[0] == "requests" and path[2] == "result":
-            if isinstance(value, dict):
-                return [_emit_result(value, path[1])]
+        if len(path) == 3 and path[0] == "requests":
+            idx = path[1]
+            if path[2] == "codeCitations":
+                return _emit_citations(value, idx)
+            if (
+                path[2] == "elapsedMs"
+                and isinstance(value, (int, float))
+                and not isinstance(value, bool)
+            ):
+                return [_emit_completion(value, idx)]
         return []
 
     return []

--- a/tests/integration/test_copilot_vscode_e2e.py
+++ b/tests/integration/test_copilot_vscode_e2e.py
@@ -174,6 +174,10 @@ def test_request_level_code_citations_preserve_metadata(adapter: MappedJsonAdapt
         if event.kind == EventKind.SESSION_INFO and event.payload.get("license")
     ]
     assert [event.payload["request_id"] for event in citations] == ["req-0", "req-0"]
+    assert [event.payload["model"] for event in citations] == [
+        "copilot/claude-opus-4.7",
+        "copilot/claude-opus-4.7",
+    ]
     assert citations[0].payload["value"] == appended_citation["value"]
     assert citations[0].payload["license"] == "MIT"
     assert citations[0].payload["snippet"] == "def one(): ..."

--- a/tests/integration/test_copilot_vscode_e2e.py
+++ b/tests/integration/test_copilot_vscode_e2e.py
@@ -14,7 +14,9 @@ import pytest
 from traceforge.adapters.mapped_json import MappedJsonAdapter
 from traceforge.types import EventKind
 
-MAPPINGS_DIR = Path(__file__).resolve().parent.parent.parent / "src" / "traceforge" / "mappings"
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MAPPINGS_DIR = REPO_ROOT / "src" / "traceforge" / "mappings"
+RAW_FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "raw_traces" / "copilot_vscode"
 
 
 @pytest.fixture
@@ -46,7 +48,12 @@ def _snapshot(session_id: str = "sess-1") -> dict:
     }
 
 
-def _request(request_id: str, text: str, model: str = "copilot/claude-opus-4.7") -> dict:
+def _request(
+    request_id: str,
+    text: str,
+    model: str = "copilot/claude-opus-4.7",
+    code_citations: list[dict] | None = None,
+) -> dict:
     return {
         "kind": 2,
         "k": ["requests"],
@@ -58,6 +65,7 @@ def _request(request_id: str, text: str, model: str = "copilot/claude-opus-4.7")
                 "agent": {"id": "github.copilot.editsAgent"},
                 "message": {"text": text, "parts": []},
                 "response": [],
+                "codeCitations": code_citations or [],
             }
         ],
     }
@@ -71,8 +79,15 @@ def _result(idx: int) -> dict:
     return {
         "kind": 1,
         "k": ["requests", idx, "result"],
-        "v": {"timings": {"firstProgress": 5142, "totalElapsed": 206179}},
+        "v": {
+            "details": "Claude Opus 4.7",
+            "timings": {"firstProgress": 5142, "totalElapsed": 206179},
+        },
     }
+
+
+def _elapsed(idx: int, elapsed_ms: int = 206241) -> dict:
+    return {"kind": 1, "k": ["requests", idx, "elapsedMs"], "v": elapsed_ms}
 
 
 def test_full_turn_maps_to_canonical_kinds(adapter: MappedJsonAdapter) -> None:
@@ -98,6 +113,7 @@ def test_full_turn_maps_to_canonical_kinds(adapter: MappedJsonAdapter) -> None:
                 ],
             ),
             _result(0),
+            _elapsed(0),
         ],
     )
     kinds = [e.kind for e in events]
@@ -120,6 +136,62 @@ def test_full_turn_maps_to_canonical_kinds(adapter: MappedJsonAdapter) -> None:
     assert tool.payload["tool_call_id"] == "call-1"
     assert tool.payload["invocation"] == "Reading app/main.py"
     assert tool.payload["request_id"] == "req-0"
+
+    completed = next(e for e in events if e.kind == EventKind.LLM_CALL_COMPLETED)
+    assert completed.payload["duration_ms"] == 206241
+    assert "first_progress_ms" not in completed.payload
+
+
+def test_request_level_code_citations_preserve_metadata(adapter: MappedJsonAdapter) -> None:
+    appended_citation = {
+        "kind": "codeCitation",
+        "value": {"scheme": "https", "authority": "github.com", "path": "/octo/one"},
+        "license": "MIT",
+        "snippet": "def one(): ...",
+    }
+    set_citation = {
+        "kind": "codeCitation",
+        "value": {"scheme": "https", "authority": "github.com", "path": "/octo/two"},
+        "license": "Apache-2.0",
+        "snippet": "def two(): ...",
+    }
+    events = _feed(
+        adapter,
+        [
+            _snapshot(),
+            _request("req-0", "first", code_citations=[appended_citation]),
+            {
+                "kind": 1,
+                "k": ["requests", 0, "codeCitations"],
+                "v": [appended_citation, set_citation],
+            },
+        ],
+    )
+
+    citations = [
+        event
+        for event in events
+        if event.kind == EventKind.SESSION_INFO and event.payload.get("license")
+    ]
+    assert [event.payload["request_id"] for event in citations] == ["req-0", "req-0"]
+    assert citations[0].payload["value"] == appended_citation["value"]
+    assert citations[0].payload["license"] == "MIT"
+    assert citations[0].payload["snippet"] == "def one(): ..."
+    assert citations[1].payload["license"] == "Apache-2.0"
+
+
+def test_real_fixture_uses_request_elapsed_ms(adapter: MappedJsonAdapter) -> None:
+    fixture = RAW_FIXTURES_DIR / "demo_issue_tracker_get_endpoint.jsonl"
+    records = [
+        json.loads(line) for line in fixture.read_text(encoding="utf-8").splitlines() if line
+    ]
+
+    events = _feed(adapter, records)
+
+    completed = [event for event in events if event.kind == EventKind.LLM_CALL_COMPLETED]
+    assert len(completed) == 1
+    assert completed[0].payload["duration_ms"] == 363545
+    assert "first_progress_ms" not in completed[0].payload
 
 
 def test_thinking_feeds_tool_motivation(adapter: MappedJsonAdapter) -> None:

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -35,6 +35,7 @@ from traceforge.preprocessors.claude import preprocess_claude
 from traceforge.preprocessors.cline import preprocess_cline
 from traceforge.preprocessors.codex import preprocess_codex
 from traceforge.preprocessors.continue_dev import preprocess_continue
+from traceforge.preprocessors.copilot_vscode import _emit_request as _copilot_vscode_emit_request
 from traceforge.preprocessors.copilot_vscode import _reset as _copilot_vscode_reset
 from traceforge.preprocessors.copilot_vscode import preprocess_copilot_vscode
 from traceforge.preprocessors.goose import preprocess_goose
@@ -966,6 +967,26 @@ class TestCopilotVscode:
         assert out[0]["event_type"] == "request_result"
         assert out[0]["elapsed_ms"] == 101
         assert "first_progress_ms" not in out[0]
+
+    def test_request_index_reuse_resets_citation_state(self) -> None:
+        citation = {
+            "kind": "codeCitation",
+            "value": {"path": "/source"},
+            "license": "MIT",
+            "snippet": "source",
+        }
+        _copilot_vscode_reset()
+
+        first = _copilot_vscode_emit_request(
+            {"requestId": "r1", "message": {"text": "one"}, "codeCitations": [citation]}, 0
+        )
+        second = _copilot_vscode_emit_request(
+            {"requestId": "r2", "message": {"text": "two"}, "codeCitations": [citation]}, 0
+        )
+
+        assert [event["event_type"] for event in first] == ["user_message", "code_citation"]
+        assert [event["event_type"] for event in second] == ["user_message", "code_citation"]
+        assert second[1]["request_id"] == "r2"
 
     def test_already_typed_row_passthrough(self) -> None:
         obj = {"event_type": "user_message", "text": "x"}

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -947,21 +947,25 @@ class TestCopilotVscode:
         assert out[0]["event_type"] == "user_message"
         assert out[0]["request_id"] == "r1"
 
-    def test_result_set_record(self) -> None:
+    def test_elapsed_ms_set_record(self) -> None:
         _copilot_vscode_reset()
         preprocess_copilot_vscode({"kind": 0, "v": {"sessionId": "s", "requests": []}})
         preprocess_copilot_vscode(
             {"kind": 2, "k": ["requests"], "v": [{"requestId": "r1", "message": {"text": "hi"}}]}
         )
-        out = preprocess_copilot_vscode(
+        result_out = preprocess_copilot_vscode(
             {
                 "kind": 1,
                 "k": ["requests", 0, "result"],
                 "v": {"timings": {"firstProgress": 10, "totalElapsed": 99}},
             }
         )
+        assert result_out == []
+
+        out = preprocess_copilot_vscode({"kind": 1, "k": ["requests", 0, "elapsedMs"], "v": 101})
         assert out[0]["event_type"] == "request_result"
-        assert out[0]["total_elapsed_ms"] == 99
+        assert out[0]["elapsed_ms"] == 101
+        assert "first_progress_ms" not in out[0]
 
     def test_already_typed_row_passthrough(self) -> None:
         obj = {"event_type": "user_message", "text": "x"}


### PR DESCRIPTION
## Summary
- emit `llm.call.completed.duration_ms` from request-level `elapsedMs`, the v3 active-generation duration that excludes confirmation waits
- stop emitting misleading `first_progress_ms` and ignore agent-defined `result.timings` as a canonical timing source
- ingest request-level `codeCitations` from appended requests and subsequent cumulative set records, preserving `value`, `license`, `snippet`, and `request_id` without duplicates
- replace the dead response-part `codeCitation` mapping with neutral `session.info` citation events
- keep `steering` unchanged because it was already intentionally absent; unrelated additive v3 response kinds continue through `raw` rather than speculative mappings

Verified against the current Microsoft VS Code v3 journal schema at [`e823aaba`](https://github.com/microsoft/vscode/blob/e823aaba403669e10bc2308efc7f69f8cc3510cf/src/vs/workbench/contrib/chat/common/model/chatSessionOperationLog.ts), where `elapsedMs` and `codeCitations` are request-level fields and `responseTimestamp` is separate response-start metadata.

## Tests
- focused Copilot VS Code adapter/preprocessor tests: 13 passed
- full suite: 3,601 passed, 8 skipped
- Ruff 0.15.20 check and format check

Closes #215