### PR TITLE
Add current Codex collaboration event coverage

### DIFF
--- a/src/traceforge/mappings/codex.yaml
+++ b/src/traceforge/mappings/codex.yaml
@@ -7,8 +7,13 @@
 # The "codex" preprocessor flattens the double-type nesting (type + payload.type)
 # into a single "block_type" discriminator.
 #
-# Source: openai/codex (codex-rs/protocol/src/protocol.rs)
-# Schema: RolloutLine → RolloutItem (session_meta | response_item | event_msg)
+# Source: openai/codex@bd2de422 (main, audited 2026-07-27)
+# Schema: codex-rs/protocol/src/protocol.rs (RolloutLine → RolloutItem)
+# Persistence: codex-rs/rollout/src/policy.rs
+# Durable collaboration is recorded as inter_agent_communication_metadata plus
+# response_item.agent_message. The collab_* EventMsg variants are transient at
+# this revision, but remain mapped for direct streams and older/alternate
+# producers that feed EventMsg records to this adapter.
 # Tool calls arrive via two paths:
 #   1. response_item.function_call → model's request (shell tool)
 #   2. event_msg.mcp_tool_call_begin/end → MCP tool execution lifecycle
@@ -118,6 +123,23 @@ events:
     payload:
       content: content
 
+  # ── Durable multi-agent communication ──────────────────────────────────────
+  agent.communication:
+    kind: agent.handoff
+    payload:
+      communication_id: id
+      from_agent: author
+      to_agent: recipient
+      other_recipients: other_recipients
+      content: content
+      trigger_turn: trigger_turn
+      turn_id: turn_id
+      content_encrypted: content_encrypted
+  agent.communication.metadata:
+    kind: session.info
+    payload:
+      trigger_turn: trigger_turn
+
   # ── Streaming deltas (#41: event_msg passthrough as event.<type>) ──
   event.agent_message_content_delta:
     kind: llm.output.chunk
@@ -132,6 +154,15 @@ events:
     kind: llm.reasoning.chunk
     payload:
       delta: delta
+  # Raw chain-of-thought is sensitive and opt-in upstream. Recognize the event,
+  # but deliberately omit delta so it cannot enter normal reasoning or sinks.
+  event.reasoning_raw_content_delta:
+    kind: raw
+    payload:
+      thread_id: thread_id
+      turn_id: turn_id
+      item_id: item_id
+      content_index: content_index
 
   # ── Item lifecycle v2 (#41: event_msg passthrough as event.<type>) ──
   event.item_started:
@@ -152,3 +183,105 @@ events:
     kind: hook.completed
     payload:
       hook_name: run.event_name
+
+  # ── Multi-agent lifecycle ──────────────────────────────────────────────────
+  # Only completions with an exact canonical meaning receive agent.* kinds.
+  # Ambiguous operation lifecycle events stay session.info rather than inventing
+  # kinds or misrepresenting an agent's final state.
+  event.collab_agent_spawn_begin:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      started_at_ms: started_at_ms
+      sender_thread_id: sender_thread_id
+      model: model
+      reasoning_effort: reasoning_effort
+  event.collab_agent_spawn_end:
+    kind: agent.spawned
+    payload:
+      operation_id: call_id
+      completed_at_ms: completed_at_ms
+      sender_thread_id: sender_thread_id
+      agent_id: new_thread_id
+      agent_nickname: new_agent_nickname
+      agent_role: new_agent_role
+      model: model
+      reasoning_effort: reasoning_effort
+      status: status
+  event.collab_agent_interaction_begin:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      started_at_ms: started_at_ms
+      sender_thread_id: sender_thread_id
+      receiver_thread_id: receiver_thread_id
+  event.collab_agent_interaction_end:
+    kind: agent.handoff
+    payload:
+      operation_id: call_id
+      completed_at_ms: completed_at_ms
+      sender_thread_id: sender_thread_id
+      receiver_thread_id: receiver_thread_id
+      receiver_agent_nickname: receiver_agent_nickname
+      receiver_agent_role: receiver_agent_role
+      status: status
+  event.collab_waiting_begin:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      started_at_ms: started_at_ms
+      sender_thread_id: sender_thread_id
+      receiver_thread_ids: receiver_thread_ids
+      receiver_agents: receiver_agents
+  event.collab_waiting_end:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      completed_at_ms: completed_at_ms
+      sender_thread_id: sender_thread_id
+      agent_statuses: agent_statuses
+      statuses: statuses
+  event.collab_close_begin:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      started_at_ms: started_at_ms
+      sender_thread_id: sender_thread_id
+      receiver_thread_id: receiver_thread_id
+  event.collab_close_end:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      completed_at_ms: completed_at_ms
+      sender_thread_id: sender_thread_id
+      receiver_thread_id: receiver_thread_id
+      receiver_agent_nickname: receiver_agent_nickname
+      receiver_agent_role: receiver_agent_role
+      status: status
+  event.collab_resume_begin:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      started_at_ms: started_at_ms
+      sender_thread_id: sender_thread_id
+      receiver_thread_id: receiver_thread_id
+      receiver_agent_nickname: receiver_agent_nickname
+      receiver_agent_role: receiver_agent_role
+  event.collab_resume_end:
+    kind: session.info
+    payload:
+      operation_id: call_id
+      completed_at_ms: completed_at_ms
+      sender_thread_id: sender_thread_id
+      receiver_thread_id: receiver_thread_id
+      receiver_agent_nickname: receiver_agent_nickname
+      receiver_agent_role: receiver_agent_role
+      status: status
+  event.sub_agent_activity:
+    kind: session.info
+    payload:
+      event_id: event_id
+      occurred_at_ms: occurred_at_ms
+      agent_thread_id: agent_thread_id
+      agent_path: agent_path
+      activity_kind: kind

--- a/src/traceforge/mappings/codex.yaml
+++ b/src/traceforge/mappings/codex.yaml
@@ -208,6 +208,17 @@ events:
       model: model
       reasoning_effort: reasoning_effort
       status: status
+  event.collab_agent_spawn_failed:
+    kind: agent.failed
+    payload:
+      operation_id: call_id
+      completed_at_ms: completed_at_ms
+      sender_thread_id: sender_thread_id
+      agent_nickname: new_agent_nickname
+      agent_role: new_agent_role
+      model: model
+      reasoning_effort: reasoning_effort
+      status: status
   event.collab_agent_interaction_begin:
     kind: session.info
     payload:

--- a/src/traceforge/preprocessors/codex.py
+++ b/src/traceforge/preprocessors/codex.py
@@ -8,6 +8,69 @@ from typing import Any
 from traceforge.preprocessors.registry import register_preprocessor
 
 
+_AGENT_STATUS_TAGS = frozenset(
+    {
+        "pending_init",
+        "running",
+        "interrupted",
+        "completed",
+        "errored",
+        "shutdown",
+        "not_found",
+    }
+)
+_STATUS_EVENT_TYPES = frozenset(
+    {
+        "collab_agent_spawn_end",
+        "collab_agent_spawn_failed",
+        "collab_agent_interaction_end",
+        "collab_waiting_end",
+        "collab_close_end",
+        "collab_resume_end",
+    }
+)
+
+
+def _sanitize_agent_statuses(value: Any) -> Any:
+    """Remove message/error bodies from externally tagged AgentStatus values."""
+    if isinstance(value, list):
+        return [_sanitize_agent_statuses(item) for item in value]
+    if isinstance(value, dict):
+        if len(value) == 1:
+            variant = next(iter(value))
+            if variant in _AGENT_STATUS_TAGS:
+                return variant
+        return {key: _sanitize_agent_statuses(item) for key, item in value.items()}
+    return value
+
+
+def _sanitize_collab_event(
+    block_type: str, payload: dict[str, Any], base: dict[str, Any]
+) -> dict[str, Any]:
+    normalized = {
+        key: _sanitize_agent_statuses(value)
+        if key in {"status", "agent_statuses", "statuses"}
+        else value
+        for key, value in payload.items()
+        if key not in {"type", "block_type"}
+    }
+    if block_type == "event.collab_agent_spawn_end" and not payload.get("new_thread_id"):
+        block_type = "event.collab_agent_spawn_failed"
+    return {**base, "block_type": block_type, **normalized}
+
+
+def _redact_agent_communication(obj: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(obj)
+    encrypted = normalized.get("content_encrypted") is True or (
+        "encrypted_content" in normalized and normalized["encrypted_content"] is not None
+    )
+    normalized.pop("encrypted_content", None)
+    if encrypted:
+        normalized.pop("content", None)
+        normalized["content_encrypted"] = True
+    return normalized
+
+
 @register_preprocessor("codex")
 def preprocess_codex(obj: dict[str, Any]) -> list[dict[str, Any]]:
     """Normalize a Codex CLI rollout line into traceforge-friendly dicts.
@@ -40,6 +103,11 @@ def preprocess_codex(obj: dict[str, Any]) -> list[dict[str, Any]]:
 
     # If already preprocessed (has block_type but no rollout structure), pass through
     if "block_type" in obj and not top_type:
+        block_type = str(obj["block_type"])
+        if block_type.removeprefix("event.") in _STATUS_EVENT_TYPES:
+            return [_sanitize_collab_event(block_type, obj, {})]
+        if block_type == "agent.communication":
+            return [_redact_agent_communication(obj)]
         return [obj]
 
     if not isinstance(payload, dict):
@@ -68,8 +136,11 @@ def preprocess_codex(obj: dict[str, Any]) -> list[dict[str, Any]]:
             "recipient": payload.get("recipient"),
             "other_recipients": payload.get("other_recipients", []),
             "trigger_turn": payload.get("trigger_turn"),
+            "turn_id": (payload.get("internal_chat_message_metadata_passthrough") or {}).get(
+                "turn_id"
+            ),
         }
-        if payload.get("encrypted_content"):
+        if "encrypted_content" in payload and payload["encrypted_content"] is not None:
             normalized["content_encrypted"] = True
         else:
             normalized["content"] = payload.get("content", "")
@@ -243,6 +314,9 @@ def _handle_response_item(payload: dict[str, Any], base: dict[str, Any]) -> list
 def _handle_event_msg(payload: dict[str, Any], base: dict[str, Any]) -> list[dict[str, Any]]:
     """Handle event_msg lines (lifecycle events)."""
     event_type = payload.get("type", "")
+
+    if event_type in _STATUS_EVENT_TYPES:
+        return [_sanitize_collab_event(f"event.{event_type}", payload, base)]
 
     if event_type == "exec_command_begin":
         return [

--- a/src/traceforge/preprocessors/codex.py
+++ b/src/traceforge/preprocessors/codex.py
@@ -27,6 +27,9 @@ def preprocess_codex(obj: dict[str, Any]) -> list[dict[str, Any]]:
     - event_msg.exec_command_end → "tool.exec_end"
     - event_msg.mcp_tool_call_begin → "tool.mcp_call"
     - event_msg.mcp_tool_call_end → "tool.mcp_result"
+    - inter_agent_communication → "agent.communication" (direct/legacy shape)
+    - inter_agent_communication_metadata → "agent.communication.metadata"
+    - response_item.agent_message → "agent.communication" (current persisted shape)
     - session_meta → "session.meta"
     - response_item.message (role=assistant) → "message.assistant"
     - event_msg.user_message → "message.user"
@@ -53,6 +56,31 @@ def preprocess_codex(obj: dict[str, Any]) -> list[dict[str, Any]]:
                 "model_provider": payload.get("model_provider", ""),
                 "cwd": payload.get("cwd", ""),
                 "cli_version": payload.get("cli_version", ""),
+            }
+        ]
+
+    if top_type == "inter_agent_communication":
+        normalized = {
+            **base,
+            "block_type": "agent.communication",
+            "id": payload.get("id"),
+            "author": payload.get("author"),
+            "recipient": payload.get("recipient"),
+            "other_recipients": payload.get("other_recipients", []),
+            "trigger_turn": payload.get("trigger_turn"),
+        }
+        if payload.get("encrypted_content"):
+            normalized["content_encrypted"] = True
+        else:
+            normalized["content"] = payload.get("content", "")
+        return [normalized]
+
+    if top_type == "inter_agent_communication_metadata":
+        return [
+            {
+                **base,
+                "block_type": "agent.communication.metadata",
+                "trigger_turn": payload.get("trigger_turn"),
             }
         ]
 
@@ -128,6 +156,37 @@ def _handle_response_item(payload: dict[str, Any], base: dict[str, Any]) -> list
                 "content": text,
             }
         ]
+
+    if item_type == "agent_message":
+        content_blocks = payload.get("content", [])
+        content_encrypted = False
+        text_parts: list[str] = []
+        if isinstance(content_blocks, list):
+            for block in content_blocks:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "encrypted_content":
+                    content_encrypted = True
+                    text_parts.clear()
+                    break
+                if block.get("type") == "input_text":
+                    text_parts.append(str(block.get("text", "")))
+
+        normalized = {
+            **base,
+            "block_type": "agent.communication",
+            "id": payload.get("id"),
+            "author": payload.get("author"),
+            "recipient": payload.get("recipient"),
+            "turn_id": (payload.get("internal_chat_message_metadata_passthrough") or {}).get(
+                "turn_id"
+            ),
+        }
+        if content_encrypted:
+            normalized["content_encrypted"] = True
+        else:
+            normalized["content"] = "\n".join(part for part in text_parts if part)
+        return [normalized]
 
     if item_type == "reasoning":
         return []

--- a/tests/integration/test_new_mappings.py
+++ b/tests/integration/test_new_mappings.py
@@ -100,11 +100,96 @@ class TestCodexMapping:
             "original_type": "event.reasoning_raw_content_delta",
         }
 
+    def test_successful_spawn_has_agent_id(self, adapter):
+        raw = {
+            "type": "event_msg",
+            "payload": {
+                "type": "collab_agent_spawn_end",
+                "call_id": "spawn-1",
+                "completed_at_ms": 100,
+                "sender_thread_id": "thread-1",
+                "new_thread_id": "thread-2",
+                "new_agent_nickname": "researcher",
+                "new_agent_role": "explore",
+                "model": "gpt-5",
+                "reasoning_effort": "high",
+                "status": {"completed": "SECRET FINAL MESSAGE"},
+            },
+        }
+        event = list(adapter.parse(json.dumps(raw)))[0]
+        assert event.kind == EventKind.AGENT_SPAWNED
+        assert event.payload == {
+            "operation_id": "spawn-1",
+            "completed_at_ms": 100,
+            "sender_thread_id": "thread-1",
+            "agent_id": "thread-2",
+            "agent_nickname": "researcher",
+            "agent_role": "explore",
+            "model": "gpt-5",
+            "reasoning_effort": "high",
+            "status": "completed",
+        }
+        assert "SECRET" not in json.dumps(event.payload)
+
+    def test_failed_spawn_is_not_emitted_as_spawned(self, adapter):
+        raw = {
+            "type": "event_msg",
+            "payload": {
+                "type": "collab_agent_spawn_end",
+                "call_id": "spawn-2",
+                "completed_at_ms": 200,
+                "sender_thread_id": "thread-1",
+                "new_thread_id": None,
+                "model": "gpt-5",
+                "reasoning_effort": "high",
+                "status": {"errored": "SECRET SPAWN ERROR"},
+            },
+        }
+        event = list(adapter.parse(json.dumps(raw)))[0]
+        assert event.kind == EventKind.AGENT_FAILED
+        assert event.payload == {
+            "operation_id": "spawn-2",
+            "completed_at_ms": 200,
+            "sender_thread_id": "thread-1",
+            "model": "gpt-5",
+            "reasoning_effort": "high",
+            "status": "errored",
+        }
+        assert "agent_id" not in event.payload
+        assert "SECRET" not in json.dumps(event.payload)
+
+    def test_wait_status_bodies_are_not_mapped(self, adapter):
+        raw = {
+            "type": "event_msg",
+            "payload": {
+                "type": "collab_waiting_end",
+                "call_id": "wait-1",
+                "completed_at_ms": 300,
+                "sender_thread_id": "thread-1",
+                "agent_statuses": [
+                    {
+                        "agent": {"thread_id": "thread-2"},
+                        "status": {"completed": "SECRET FINAL MESSAGE"},
+                    }
+                ],
+                "statuses": {"thread-2": {"errored": "SECRET ERROR"}},
+            },
+        }
+        event = list(adapter.parse(json.dumps(raw)))[0]
+        assert event.kind == EventKind.SESSION_INFO
+        assert event.payload == {
+            "operation_id": "wait-1",
+            "completed_at_ms": 300,
+            "sender_thread_id": "thread-1",
+            "agent_statuses": [{"agent": {"thread_id": "thread-2"}, "status": "completed"}],
+            "statuses": {"thread-2": "errored"},
+        }
+        assert "SECRET" not in json.dumps(event.payload)
+
     @pytest.mark.parametrize(
         ("event_type", "expected_kind"),
         [
             ("collab_agent_spawn_begin", EventKind.SESSION_INFO),
-            ("collab_agent_spawn_end", EventKind.AGENT_SPAWNED),
             ("collab_agent_interaction_begin", EventKind.SESSION_INFO),
             ("collab_agent_interaction_end", EventKind.AGENT_HANDOFF),
             ("collab_waiting_begin", EventKind.SESSION_INFO),
@@ -132,8 +217,10 @@ class TestCodexMapping:
         event = list(adapter.parse(json.dumps(raw)))[0]
         assert event.kind == expected_kind
         assert event.metadata.raw_kind == f"event.{event_type}"
-        correlation_field = "event_id" if event_type == "sub_agent_activity" else "operation_id"
-        assert event.payload[correlation_field] in {"call-1", "activity-1"}
+        if event_type == "sub_agent_activity":
+            assert event.payload["event_id"] == "activity-1"
+        else:
+            assert event.payload["operation_id"] == "call-1"
 
 
 class TestLangGraphMapping:

--- a/tests/integration/test_new_mappings.py
+++ b/tests/integration/test_new_mappings.py
@@ -1,4 +1,4 @@
-"""Integration tests for new YAML mappings: langgraph, pydantic_ai, smolagents.
+"""Integration tests for YAML mappings that need explicit behavior coverage.
 
 Validates that each YAML loads correctly, maps events to proper canonical kinds,
 and preserves payload extraction through dot-path resolution.
@@ -15,6 +15,125 @@ from traceforge.adapters.mapped_json import MappedJsonAdapter
 from traceforge.types import EventKind
 
 MAPPINGS_DIR = Path(__file__).resolve().parents[2] / "src" / "traceforge" / "mappings"
+
+
+class TestCodexMapping:
+    """Current Codex rollout and collaboration coverage."""
+
+    @pytest.fixture
+    def adapter(self) -> MappedJsonAdapter:
+        return MappedJsonAdapter.from_yaml(
+            str(MAPPINGS_DIR / "codex.yaml"), session_id="codex-session"
+        )
+
+    def test_durable_inter_agent_communication(self, adapter):
+        raw_lines = [
+            {
+                "type": "inter_agent_communication_metadata",
+                "payload": {"trigger_turn": True},
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "agent_message",
+                    "id": "amsg-1",
+                    "author": "/root",
+                    "recipient": "/root/researcher",
+                    "content": [{"type": "input_text", "text": "Inspect the parser"}],
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-1"},
+                },
+            },
+        ]
+        events = [event for raw in raw_lines for event in adapter.parse(json.dumps(raw))]
+        assert [event.kind for event in events] == [
+            EventKind.SESSION_INFO,
+            EventKind.AGENT_HANDOFF,
+        ]
+        assert events[0].payload == {"trigger_turn": True}
+        assert events[1].payload == {
+            "communication_id": "amsg-1",
+            "from_agent": "/root",
+            "to_agent": "/root/researcher",
+            "content": "Inspect the parser",
+            "turn_id": "turn-1",
+        }
+
+    def test_encrypted_inter_agent_content_is_not_exposed(self, adapter):
+        raw = {
+            "type": "response_item",
+            "payload": {
+                "type": "agent_message",
+                "id": "amsg-2",
+                "author": "/root",
+                "recipient": "/root/researcher",
+                "content": [
+                    {"type": "input_text", "text": "envelope"},
+                    {"type": "encrypted_content", "encrypted_content": "ciphertext"},
+                ],
+            },
+        }
+        event = list(adapter.parse(json.dumps(raw)))[0]
+        assert event.kind == EventKind.AGENT_HANDOFF
+        assert event.payload["content_encrypted"] is True
+        assert "content" not in event.payload
+        assert "encrypted_content" not in event.payload
+
+    def test_raw_reasoning_delta_is_not_exposed(self, adapter):
+        raw = {
+            "type": "event_msg",
+            "payload": {
+                "type": "reasoning_raw_content_delta",
+                "thread_id": "thread-1",
+                "turn_id": "turn-1",
+                "item_id": "item-1",
+                "content_index": 2,
+                "delta": "sensitive chain of thought",
+            },
+        }
+        event = list(adapter.parse(json.dumps(raw)))[0]
+        assert event.kind == EventKind.RAW
+        assert event.payload == {
+            "thread_id": "thread-1",
+            "turn_id": "turn-1",
+            "item_id": "item-1",
+            "content_index": 2,
+            "original_type": "event.reasoning_raw_content_delta",
+        }
+
+    @pytest.mark.parametrize(
+        ("event_type", "expected_kind"),
+        [
+            ("collab_agent_spawn_begin", EventKind.SESSION_INFO),
+            ("collab_agent_spawn_end", EventKind.AGENT_SPAWNED),
+            ("collab_agent_interaction_begin", EventKind.SESSION_INFO),
+            ("collab_agent_interaction_end", EventKind.AGENT_HANDOFF),
+            ("collab_waiting_begin", EventKind.SESSION_INFO),
+            ("collab_waiting_end", EventKind.SESSION_INFO),
+            ("collab_close_begin", EventKind.SESSION_INFO),
+            ("collab_close_end", EventKind.SESSION_INFO),
+            ("collab_resume_begin", EventKind.SESSION_INFO),
+            ("collab_resume_end", EventKind.SESSION_INFO),
+            ("sub_agent_activity", EventKind.SESSION_INFO),
+        ],
+    )
+    def test_collaboration_event_coverage(self, adapter, event_type, expected_kind):
+        raw = {
+            "type": "event_msg",
+            "payload": {
+                "type": event_type,
+                "call_id": "call-1",
+                "event_id": "activity-1",
+                "sender_thread_id": "thread-1",
+                "receiver_thread_id": "thread-2",
+                "new_thread_id": "thread-2",
+                "kind": "interacted",
+            },
+        }
+        event = list(adapter.parse(json.dumps(raw)))[0]
+        assert event.kind == expected_kind
+        assert event.metadata.raw_kind == f"event.{event_type}"
+        correlation_field = "event_id" if event_type == "sub_agent_activity" else "operation_id"
+        assert event.payload[correlation_field] in {"call-1", "activity-1"}
 
 
 class TestLangGraphMapping:

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -748,6 +748,98 @@ class TestCodex:
         assert out[0]["block_type"] == "tool.exec_begin"
         assert out[0]["command"] == ["ls"]
 
+    def test_inter_agent_communication_flattened(self) -> None:
+        out = preprocess_codex(
+            {
+                "type": "inter_agent_communication",
+                "payload": {
+                    "id": "comm-1",
+                    "author": "/root",
+                    "recipient": "/root/researcher",
+                    "content": "Investigate the parser",
+                    "trigger_turn": True,
+                },
+            }
+        )
+        assert out[0]["block_type"] == "agent.communication"
+        assert out[0]["author"] == "/root"
+        assert out[0]["recipient"] == "/root/researcher"
+        assert out[0]["trigger_turn"] is True
+
+    def test_current_inter_agent_communication_pair_flattened(self) -> None:
+        metadata = preprocess_codex(
+            {
+                "type": "inter_agent_communication_metadata",
+                "payload": {"trigger_turn": True},
+            }
+        )
+        message = preprocess_codex(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "agent_message",
+                    "id": "amsg-1",
+                    "author": "/root",
+                    "recipient": "/root/researcher",
+                    "content": [{"type": "input_text", "text": "Investigate the parser"}],
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-1"},
+                },
+            }
+        )
+        assert metadata == [
+            {
+                "_timestamp": "",
+                "block_type": "agent.communication.metadata",
+                "trigger_turn": True,
+            }
+        ]
+        assert message[0]["block_type"] == "agent.communication"
+        assert message[0]["content"] == "Investigate the parser"
+        assert message[0]["turn_id"] == "turn-1"
+
+    def test_encrypted_agent_message_content_is_not_exposed(self) -> None:
+        out = preprocess_codex(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "agent_message",
+                    "author": "/root",
+                    "recipient": "/root/researcher",
+                    "content": [
+                        {"type": "input_text", "text": "envelope"},
+                        {"type": "encrypted_content", "encrypted_content": "ciphertext"},
+                    ],
+                },
+            }
+        )
+        assert out[0]["content_encrypted"] is True
+        assert "content" not in out[0]
+        assert "encrypted_content" not in out[0]
+
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            "collab_close_begin",
+            "collab_close_end",
+            "collab_resume_begin",
+            "collab_resume_end",
+        ],
+    )
+    def test_close_and_resume_events_pass_through(self, event_type: str) -> None:
+        out = preprocess_codex(
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": event_type,
+                    "call_id": "call-1",
+                    "receiver_thread_id": "thread-2",
+                },
+            }
+        )
+        assert out[0]["block_type"] == f"event.{event_type}"
+        assert out[0]["call_id"] == "call-1"
+        assert out[0]["receiver_thread_id"] == "thread-2"
+
     def test_turn_context_dropped(self) -> None:
         assert preprocess_codex({"type": "turn_context", "payload": {}}) == []
 

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -22,6 +22,7 @@ reported to the epic coordinator rather than fixed here (this ticket is tests-on
 from __future__ import annotations
 
 import copy
+import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -758,6 +759,7 @@ class TestCodex:
                     "recipient": "/root/researcher",
                     "content": "Investigate the parser",
                     "trigger_turn": True,
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-legacy"},
                 },
             }
         )
@@ -765,6 +767,7 @@ class TestCodex:
         assert out[0]["author"] == "/root"
         assert out[0]["recipient"] == "/root/researcher"
         assert out[0]["trigger_turn"] is True
+        assert out[0]["turn_id"] == "turn-legacy"
 
     def test_current_inter_agent_communication_pair_flattened(self) -> None:
         metadata = preprocess_codex(
@@ -815,6 +818,116 @@ class TestCodex:
         assert out[0]["content_encrypted"] is True
         assert "content" not in out[0]
         assert "encrypted_content" not in out[0]
+        assert "ciphertext" not in json.dumps(out)
+        assert "envelope" not in json.dumps(out)
+
+    def test_empty_encrypted_content_still_redacts_legacy_plaintext(self) -> None:
+        out = preprocess_codex(
+            {
+                "type": "inter_agent_communication",
+                "payload": {
+                    "author": "/root",
+                    "recipient": "/root/researcher",
+                    "content": "SECRET PLAINTEXT",
+                    "encrypted_content": "",
+                },
+            }
+        )
+        assert out[0]["content_encrypted"] is True
+        assert "content" not in out[0]
+        assert "encrypted_content" not in out[0]
+        assert "SECRET" not in json.dumps(out)
+
+    def test_preprocessed_collab_events_are_still_sanitized(self) -> None:
+        out = preprocess_codex(
+            {
+                "block_type": "event.collab_waiting_end",
+                "statuses": {
+                    "thread-2": {"completed": "SECRET FINAL MESSAGE"},
+                    "thread-3": {"errored": "SECRET ERROR"},
+                },
+            }
+        )
+        assert out == [
+            {
+                "block_type": "event.collab_waiting_end",
+                "statuses": {"thread-2": "completed", "thread-3": "errored"},
+            }
+        ]
+        assert "SECRET" not in json.dumps(out)
+
+    def test_preprocessed_encrypted_communication_is_still_redacted(self) -> None:
+        out = preprocess_codex(
+            {
+                "block_type": "agent.communication",
+                "content": "SECRET ENVELOPE",
+                "encrypted_content": "",
+            }
+        )
+        assert out == [
+            {
+                "block_type": "agent.communication",
+                "content_encrypted": True,
+            }
+        ]
+        assert "SECRET" not in json.dumps(out)
+
+    def test_collab_status_bodies_are_sanitized_recursively(self) -> None:
+        out = preprocess_codex(
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "collab_waiting_end",
+                    "call_id": "call-1",
+                    "agent_statuses": [
+                        {
+                            "agent": {"thread_id": "thread-2"},
+                            "status": {"completed": "SECRET FINAL MESSAGE"},
+                        },
+                        {
+                            "agent": {"thread_id": "thread-3"},
+                            "status": {"errored": "SECRET ERROR"},
+                        },
+                    ],
+                    "statuses": {
+                        "thread-2": {"completed": "SECRET FINAL MESSAGE"},
+                        "thread-3": {"errored": "SECRET ERROR"},
+                    },
+                },
+            }
+        )
+        assert out[0]["agent_statuses"] == [
+            {"agent": {"thread_id": "thread-2"}, "status": "completed"},
+            {"agent": {"thread_id": "thread-3"}, "status": "errored"},
+        ]
+        assert out[0]["statuses"] == {
+            "thread-2": "completed",
+            "thread-3": "errored",
+        }
+        assert "SECRET" not in json.dumps(out)
+
+    def test_failed_spawn_gets_distinct_discriminator(self) -> None:
+        out = preprocess_codex(
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "collab_agent_spawn_end",
+                    "call_id": "spawn-1",
+                    "new_thread_id": None,
+                    "status": {"errored": "SECRET SPAWN ERROR"},
+                },
+            }
+        )
+        assert out == [
+            {
+                "_timestamp": "",
+                "block_type": "event.collab_agent_spawn_failed",
+                "call_id": "spawn-1",
+                "new_thread_id": None,
+                "status": "errored",
+            }
+        ]
+        assert "SECRET" not in json.dumps(out)
 
     @pytest.mark.parametrize(
         "event_type",


### PR DESCRIPTION
## Summary

- Normalize current durable Codex multi-agent rollouts: `inter_agent_communication_metadata` plus `response_item.agent_message` now become `session.info` plus canonical `agent.handoff` events.
- Cover current collaboration lifecycle variants, including the `collab_close_*` and `collab_resume_*` events omitted from #175. Exact spawn/interaction completions use existing `agent.spawned` / `agent.handoff`; ambiguous wait, close, resume, and activity notifications remain `session.info` rather than introducing speculative kinds.
- Split spawn completion by outcome: a created thread maps to `agent.spawned` with an `agent_id`; a null `new_thread_id` maps to existing `agent.failed` and can never emit a spawned event without an ID.
- Treat `event.reasoning_raw_content_delta` as explicit `raw` telemetry while omitting its sensitive `delta`. Encrypted inter-agent content is likewise never copied into normalized payloads.
- Sanitize externally tagged Codex `AgentStatus` values recursively: `completed` and `errored` retain only scalar variant tags, never final-message or error bodies, across `status`, `agent_statuses`, and `statuses` payloads. The same privacy rules apply to already-normalized events.
- Pin the mapping provenance to upstream `openai/codex@bd2de422` (audited 2026-07-27) and document the rollout persistence policy.

## Drift conclusions

The breaking claims in #212 are stale on current `main`: PR #207 already removed the dead `event.agent_message_delta`, replaced `event.agent_reasoning_delta` with `event.reasoning_content_delta`, and corrected `item_started` / `item_completed`. This PR does not repeat those changes.

For the Codex portion of #175, this adds the missing collaboration/sub-agent coverage and also includes the newer close/resume variants. Current upstream marks all `collab_*` `EventMsg` variants as transient, so watched rollout files use the durable metadata + `agent_message` pair; the transient mappings remain useful for direct streams and compatible producers. #175 still contains non-Codex framework work and remains open.

## Privacy and canonical kinds

Raw reasoning is opt-in upstream and can contain chain-of-thought. The adapter records only thread/turn/item correlation and content index under `raw`; it never maps or persists the raw `delta` as normal reasoning. Encrypted agent messages expose only `content_encrypted: true`, never ciphertext or envelope text. Collaboration statuses preserve only lifecycle tags such as `completed` or `errored`, never their associated message bodies.

No new `EventKind` strings are introduced.

## Verification

- Focused Codex preprocessor/mapping tests: 48 passed
- Full suite on current `main`: 3646 passed, 8 skipped
- `ruff check .` with ruff 0.15.20: passed
- `ruff format --check .` with ruff 0.15.20: passed