### PR TITLE
Fix OpenCode schema drift without dropping V1 events

### DIFF
--- a/src/traceforge/mappings/opencode.yaml
+++ b/src/traceforge/mappings/opencode.yaml
@@ -53,7 +53,7 @@
 # Instance SSE also emits server.connected and server.heartbeat with empty properties.
 # Global SSE (/global/event) uses a DIFFERENT wire format — not covered by this YAML.
 #
-# 31 events defined in SessionEvent.Definitions at the verified upstream commit.
+# 32 events defined in SessionEvent.Definitions at the verified upstream commit.
 
 framework: opencode
 framework_version: ">=1.17,<2.0"
@@ -151,7 +151,9 @@ events:
       text: data.part.text
 
   message.part.text.unknown:
-    kind: message.assistant
+    # A watcher may start after the role-bearing message row. Keep the text
+    # without inventing user or assistant authorship.
+    kind: raw
     payload:
       session_id: data.sessionID
       message_id: data.part.messageID
@@ -245,6 +247,7 @@ events:
     kind: message.user
     payload:
       session_id: properties.sessionID
+      message_id: properties.messageID
       prompt_text: properties.prompt.text
       prompt_files: properties.prompt.files
       prompt_agents: properties.prompt.agents

--- a/src/traceforge/mappings/opencode.yaml
+++ b/src/traceforge/mappings/opencode.yaml
@@ -5,6 +5,10 @@
 #         anomalyco/opencode packages/core/src/session/event.ts (re-export of @opencode-ai/schema/session-event)
 #         anomalyco/opencode packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
 #         anomalyco/opencode packages/opencode/src/event-v2-bridge.ts
+#         anomalyco/opencode packages/schema/src/v1/session.ts (V1 durable schemas)
+#         anomalyco/opencode packages/opencode/src/session/session.ts (V1 publishers)
+# Verified against anomalyco/opencode@55b02116905efff9b8a245ea8f885f3c979101de
+# (dev, 2026-07-27).
 #
 # v1.17 SQLite format: ~/.local/share/opencode/opencode.db table `event`.
 # Rows are {id, aggregate_id=sessionID, seq, type, data}. The type has a
@@ -26,7 +30,8 @@
 #   {timestamp: number (ms UTC), sessionID: string, ...event-specific fields}
 #
 # Base schema: {timestamp: DateTimeUtcFromMillis, sessionID: Session.ID}
-# All events use aggregate: "sessionID", version: 1.
+# V2 events use aggregate "sessionID" and version 1 except step.ended/step.failed,
+# which currently use version 2 and are stored with a .2 suffix.
 #
 # Token usage: session.next.step.ended → properties.tokens =
 #   {input, output, reasoning, cache: {read, write}}
@@ -37,12 +42,9 @@
 # wire format bypasses Schema.encode — JSON.stringify calls DateTime.Utc.toJSON()
 # which returns an ISO 8601 UTC string (e.g. "2024-01-15T12:34:56.789Z").
 #
-# Prompt shape: {text: string, files?: FileAttachment[], agents?: AgentAttachment[],
-#   references?: ReferenceAttachment[]}
+# Prompt shape: {text: string, files?: FileAttachment[], agents?: AgentAttachment[]}
 # FileAttachment: {uri, mime, name?, description?, source?}
 # AgentAttachment: {name, source?}
-# ReferenceAttachment: {name, kind: "local"|"git"|"invalid", uri?, repository?,
-#   branch?, target?, targetUri?, problem?, source?}
 #
 # ToolOutput.Structured: Record<string, any> (plain JSON object)
 # ToolOutput.Content: tagged union on "type":
@@ -51,7 +53,7 @@
 # Instance SSE also emits server.connected and server.heartbeat with empty properties.
 # Global SSE (/global/event) uses a DIFFERENT wire format — not covered by this YAML.
 #
-# 26 total events defined in All union at v1.2.24.
+# 31 events defined in SessionEvent.Definitions at the verified upstream commit.
 
 framework: opencode
 framework_version: ">=1.17,<2.0"
@@ -72,6 +74,10 @@ motivation:
 
 events:
   # ── v1.17 SQLite event-sourced store ──
+  # KEEP all 14 normalized mappings: the local daemon still publishes and durably
+  # projects these V1 events alongside V2. message.updated.1 and
+  # message.part.updated.1 are the local persistence path for message/part content;
+  # deleting these mappings loses data.
   session.created:
     kind: session.started
     payload:
@@ -171,7 +177,6 @@ events:
       call_id: data.part.callID
       tool: data.part.tool
       input: data.part.state.input
-      raw_input: data.part.state.raw
       metadata: data.part.metadata
 
   message.part.tool.completed:
@@ -189,7 +194,7 @@ events:
       metadata: data.part.state.metadata
       time: data.part.state.time
 
-  message.part.tool.failed:
+  message.part.tool.error:
     kind: tool.call.failed
     payload:
       session_id: data.sessionID
@@ -198,9 +203,9 @@ events:
       call_id: data.part.callID
       tool: data.part.tool
       input: data.part.state.input
-      output: data.part.state.output
       error: data.part.state.error
       metadata: data.part.state.metadata
+      time: data.part.state.time
 
   message.part.step-start:
     kind: llm.call.started
@@ -243,7 +248,6 @@ events:
       prompt_text: properties.prompt.text
       prompt_files: properties.prompt.files
       prompt_agents: properties.prompt.agents
-      prompt_references: properties.prompt.references
 
   session.next.agent.switched:
     kind: workflow.agent_switched
@@ -282,6 +286,7 @@ events:
     kind: llm.call.started
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       agent: properties.agent
       model_id: properties.model.id
       provider_id: properties.model.providerID
@@ -292,6 +297,7 @@ events:
     kind: llm.call.completed
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       finish: properties.finish
       cost: properties.cost
       input_tokens: properties.tokens.input
@@ -305,6 +311,7 @@ events:
     kind: llm.call.failed
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       error_type: properties.error.type
       error_message: properties.error.message
 
@@ -313,17 +320,20 @@ events:
     kind: message.assistant.started
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
 
   session.next.text.delta:
     kind: message.assistant.chunk
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       delta: properties.delta
 
   session.next.text.ended:
     kind: message.assistant
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       text: properties.text
 
   # ── Reasoning streaming ──
@@ -331,12 +341,14 @@ events:
     kind: llm.reasoning.started
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       reasoning_id: properties.reasoningID
 
   session.next.reasoning.delta:
     kind: llm.reasoning.chunk
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       reasoning_id: properties.reasoningID
       delta: properties.delta
 
@@ -344,6 +356,7 @@ events:
     kind: llm.reasoning.completed
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       reasoning_id: properties.reasoningID
       text: properties.text
 
@@ -352,6 +365,7 @@ events:
     kind: tool.input.started
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       call_id: properties.callID
       name: properties.name
 
@@ -359,6 +373,7 @@ events:
     kind: tool.input.chunk
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       call_id: properties.callID
       delta: properties.delta
 
@@ -366,6 +381,7 @@ events:
     kind: tool.input.completed
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       call_id: properties.callID
       text: properties.text
 
@@ -374,6 +390,7 @@ events:
     kind: tool.call.started
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       call_id: properties.callID
       tool: properties.tool
       input: properties.input
@@ -384,6 +401,7 @@ events:
     kind: tool.call.progress
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       call_id: properties.callID
       structured: properties.structured
       content: properties.content
@@ -392,6 +410,7 @@ events:
     kind: tool.call.completed
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       call_id: properties.callID
       structured: properties.structured
       content: properties.content
@@ -402,6 +421,7 @@ events:
     kind: tool.call.failed
     payload:
       session_id: properties.sessionID
+      assistant_message_id: properties.assistantMessageID
       call_id: properties.callID
       error_type: properties.error.type
       error_message: properties.error.message
@@ -451,15 +471,24 @@ events:
     kind: session.info
     payload:
       session_id: properties.sessionID
-      directory: properties.subdirectory
+      directory: properties.location.directory
+      subdirectory: properties.subdirectory
   session.next.prompt.admitted:
     kind: message.user
     payload:
       session_id: properties.sessionID
+      message_id: properties.messageID
       delivery: properties.delivery
       text: properties.prompt.text
+      prompt_files: properties.prompt.files
+      prompt_agents: properties.prompt.agents
   session.next.context.updated:
     kind: session.info
     payload:
       session_id: properties.sessionID
       message_id: properties.messageID
+      text: properties.text
+
+  # RevertEvent.Staged/Cleared/Committed are schema/projector definitions, but the
+  # local daemon emits V1 session.updated.1 for revert operations. Leave them
+  # unmapped until an ingestible emission path and an honest canonical kind exist.

--- a/src/traceforge/preprocessors/opencode.py
+++ b/src/traceforge/preprocessors/opencode.py
@@ -12,6 +12,10 @@ _VERSION_SUFFIX_RE = re.compile(r"\.\d+$")
 _MESSAGE_ROLES: dict[tuple[str, str], str] = {}
 
 
+def _reset() -> None:
+    _MESSAGE_ROLES.clear()
+
+
 @register_preprocessor("opencode")
 def preprocess_opencode(obj: dict[str, Any]) -> list[dict[str, Any]]:
     """Normalize OpenCode's SQLite `event` rows to stable mapping types."""

--- a/src/traceforge/preprocessors/opencode.py
+++ b/src/traceforge/preprocessors/opencode.py
@@ -50,8 +50,9 @@ def preprocess_opencode(obj: dict[str, Any]) -> list[dict[str, Any]]:
         role = _MESSAGE_ROLES.get((session_id, message_id), "unknown")
         norm["message_role"] = role
 
-        if part_type == "text" and role in {"user", "assistant"}:
-            norm["type"] = f"message.part.text.{role}"
+        if part_type == "text":
+            text_role = role if role in {"user", "assistant"} else "unknown"
+            norm["type"] = f"message.part.text.{text_role}"
         elif part_type == "tool":
             state = part.get("state") if isinstance(part.get("state"), dict) else {}
             status = str(state.get("status") or "unknown")

--- a/tests/integration/test_opencode_e2e.py
+++ b/tests/integration/test_opencode_e2e.py
@@ -36,6 +36,26 @@ def _wire_event(event_type: str, **properties: object) -> dict:
     }
 
 
+_ASSISTANT_CORRELATED_EVENTS = [
+    "session.next.step.started",
+    "session.next.step.ended",
+    "session.next.step.failed",
+    "session.next.text.started",
+    "session.next.text.delta",
+    "session.next.text.ended",
+    "session.next.reasoning.started",
+    "session.next.reasoning.delta",
+    "session.next.reasoning.ended",
+    "session.next.tool.input.started",
+    "session.next.tool.input.delta",
+    "session.next.tool.input.ended",
+    "session.next.tool.called",
+    "session.next.tool.progress",
+    "session.next.tool.success",
+    "session.next.tool.failed",
+]
+
+
 class TestOpenCodeMappings:
     CASES = [
         pytest.param(
@@ -413,16 +433,6 @@ class TestOpenCodeMappings:
             {"uri": "file:///repo/README.md", "mime": "text/markdown", "name": "README.md"},
         ]
         agents = [{"name": "planner", "source": "builtin"}, {"name": "coder", "source": "builtin"}]
-        references = [
-            {
-                "name": "bug-123",
-                "kind": "git",
-                "repository": "dfinson/traceforge",
-                "branch": "main",
-                "target": "src/traceforge",
-            }
-        ]
-
         results = _parse(
             adapter,
             _wire_event(
@@ -431,7 +441,6 @@ class TestOpenCodeMappings:
                     "text": "Review these files",
                     "files": files,
                     "agents": agents,
-                    "references": references,
                 },
             ),
         )
@@ -442,7 +451,6 @@ class TestOpenCodeMappings:
         assert result.payload["prompt_text"] == "Review these files"
         assert result.payload["prompt_files"] == files
         assert result.payload["prompt_agents"] == agents
-        assert result.payload["prompt_references"] == references
 
     def test_tool_content_union(self, adapter: MappedJsonAdapter) -> None:
         content = [
@@ -465,6 +473,293 @@ class TestOpenCodeMappings:
         assert result.kind == EventKind.TOOL_CALL_COMPLETED
         assert result.payload["content"] == content
         assert result.payload["structured"] == {"status": "ok"}
+
+    @pytest.mark.parametrize("event_type", _ASSISTANT_CORRELATED_EVENTS)
+    def test_assistant_message_id_preserved(
+        self, adapter: MappedJsonAdapter, event_type: str
+    ) -> None:
+        result = _parse(
+            adapter,
+            _wire_event(event_type, assistantMessageID="msg-assistant-1"),
+        )[0]
+
+        assert result.payload["assistant_message_id"] == "msg-assistant-1"
+
+    def test_moved_uses_location_directory_and_preserves_subdirectory(
+        self, adapter: MappedJsonAdapter
+    ) -> None:
+        result = _parse(
+            adapter,
+            _wire_event(
+                "session.next.moved",
+                location={"directory": "C:\\repo", "workspaceID": "workspace-1"},
+                subdirectory="packages\\frontend",
+            ),
+        )[0]
+
+        assert result.payload == {
+            "session_id": "sess-abc",
+            "directory": "C:\\repo",
+            "subdirectory": "packages\\frontend",
+        }
+
+    def test_moved_without_subdirectory_keeps_canonical_directory(
+        self, adapter: MappedJsonAdapter
+    ) -> None:
+        result = _parse(
+            adapter,
+            _wire_event("session.next.moved", location={"directory": "C:\\repo"}),
+        )[0]
+
+        assert result.payload == {
+            "session_id": "sess-abc",
+            "directory": "C:\\repo",
+        }
+
+    def test_prompt_admitted_preserves_structured_prompt(self, adapter: MappedJsonAdapter) -> None:
+        files = [{"uri": "file:///repo/main.py", "mime": "text/x-python"}]
+        agents = [{"name": "reviewer", "source": "builtin"}]
+        result = _parse(
+            adapter,
+            _wire_event(
+                "session.next.prompt.admitted",
+                messageID="msg-user-2",
+                delivery="queue",
+                prompt={
+                    "text": "Review this file",
+                    "files": files,
+                    "agents": agents,
+                },
+            ),
+        )[0]
+
+        assert result.payload == {
+            "session_id": "sess-abc",
+            "message_id": "msg-user-2",
+            "delivery": "queue",
+            "text": "Review this file",
+            "prompt_files": files,
+            "prompt_agents": agents,
+        }
+
+    def test_context_updated_preserves_text(self, adapter: MappedJsonAdapter) -> None:
+        result = _parse(
+            adapter,
+            _wire_event(
+                "session.next.context.updated",
+                messageID="msg-system-1",
+                text="Updated working context",
+            ),
+        )[0]
+
+        assert result.payload == {
+            "session_id": "sess-abc",
+            "message_id": "msg-system-1",
+            "text": "Updated working context",
+        }
+
+    def test_v1_sqlite_message_and_part_mappings_remain_live(
+        self, adapter: MappedJsonAdapter
+    ) -> None:
+        rows = [
+            (
+                "session.created.1",
+                {"sessionID": "sqlite-session", "info": {"title": "SQLite session"}},
+                "session.started",
+            ),
+            (
+                "session.updated.1",
+                {"sessionID": "sqlite-session", "info": {"title": "Updated"}},
+                "session.info",
+            ),
+            (
+                "message.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "info": {
+                        "id": "msg-user",
+                        "sessionID": "sqlite-session",
+                        "role": "user",
+                    },
+                },
+                "message.user",
+            ),
+            (
+                "message.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "info": {
+                        "id": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "role": "assistant",
+                    },
+                },
+                "message.assistant",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-user",
+                        "messageID": "msg-user",
+                        "sessionID": "sqlite-session",
+                        "type": "text",
+                        "text": "question",
+                    },
+                },
+                "message.user",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-assistant",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "text",
+                        "text": "answer",
+                    },
+                },
+                "message.assistant",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-unknown",
+                        "messageID": "msg-unknown",
+                        "sessionID": "sqlite-session",
+                        "type": "text",
+                        "text": "uncorrelated",
+                    },
+                },
+                "message.assistant",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-reasoning",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "reasoning",
+                        "text": "thinking",
+                    },
+                },
+                "llm.reasoning.completed",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-tool-running",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "tool",
+                        "callID": "call-1",
+                        "tool": "search",
+                        "state": {"status": "running", "input": {"query": "traceforge"}},
+                    },
+                },
+                "tool.call.started",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-tool-completed",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "tool",
+                        "callID": "call-1",
+                        "tool": "search",
+                        "state": {"status": "completed", "output": "found"},
+                    },
+                },
+                "tool.call.completed",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-tool-error",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "tool",
+                        "callID": "call-2",
+                        "tool": "search",
+                        "state": {
+                            "status": "error",
+                            "input": {"query": "traceforge"},
+                            "error": "offline",
+                            "metadata": {"interrupted": True},
+                            "time": {"start": 10, "end": 20},
+                        },
+                    },
+                },
+                "tool.call.failed",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-step-start",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "step-start",
+                    },
+                },
+                "llm.call.started",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-step-finish",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "step-finish",
+                        "tokens": {"input": 1, "output": 2},
+                    },
+                },
+                "llm.call.completed",
+            ),
+            (
+                "message.part.updated.1",
+                {
+                    "sessionID": "sqlite-session",
+                    "part": {
+                        "id": "part-patch",
+                        "messageID": "msg-assistant",
+                        "sessionID": "sqlite-session",
+                        "type": "patch",
+                        "files": ["src/app.py"],
+                    },
+                },
+                "file.edited",
+            ),
+        ]
+
+        results = []
+        for event_type, data, expected in rows:
+            parsed = _parse(adapter, {"type": event_type, "data": json.dumps(data)})
+            assert parsed, f"{event_type} row for {expected} was dropped: {data}"
+            results.append(parsed[0])
+
+        assert [result.kind for result in results] == [expected for _, _, expected in rows]
+        assert results[4].payload["text"] == "question"
+        assert results[5].payload["text"] == "answer"
+        assert results[10].payload["error"] == "offline"
+        assert results[10].payload["metadata"] == {"interrupted": True}
 
     def test_literal_field_shell(self, adapter: MappedJsonAdapter) -> None:
         results = _parse(

--- a/tests/integration/test_opencode_e2e.py
+++ b/tests/integration/test_opencode_e2e.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from traceforge.adapters.mapped_json import MappedJsonAdapter
+from traceforge.preprocessors.opencode import _reset as _opencode_reset
 from traceforge.types import EventKind
 
 MAPPINGS_DIR = Path(__file__).resolve().parent.parent.parent / "src" / "traceforge" / "mappings"
@@ -17,6 +19,13 @@ def adapter() -> MappedJsonAdapter:
     return MappedJsonAdapter.from_yaml(
         str(MAPPINGS_DIR / "opencode.yaml"), session_id="opencode-e2e"
     )
+
+
+@pytest.fixture(autouse=True)
+def reset_opencode_state() -> Iterator[None]:
+    _opencode_reset()
+    yield
+    _opencode_reset()
 
 
 def _parse(adapter: MappedJsonAdapter, event: dict) -> list:
@@ -61,15 +70,19 @@ class TestOpenCodeMappings:
         pytest.param(
             _wire_event(
                 "session.next.prompted",
+                messageID="msg-user-1",
                 prompt={
                     "text": "Summarize this repo",
                     "files": None,
                     "agents": None,
-                    "references": None,
                 },
             ),
             "message.user",
-            {"session_id": "sess-abc", "prompt_text": "Summarize this repo"},
+            {
+                "session_id": "sess-abc",
+                "message_id": "msg-user-1",
+                "prompt_text": "Summarize this repo",
+            },
             id="session.next.prompted",
         ),
         pytest.param(
@@ -437,6 +450,7 @@ class TestOpenCodeMappings:
             adapter,
             _wire_event(
                 "session.next.prompted",
+                messageID="msg-user-attachments",
                 prompt={
                     "text": "Review these files",
                     "files": files,
@@ -448,9 +462,13 @@ class TestOpenCodeMappings:
         result = results[0]
         assert result.kind == "message.user"
         assert result.kind == EventKind.MESSAGE_USER
-        assert result.payload["prompt_text"] == "Review these files"
-        assert result.payload["prompt_files"] == files
-        assert result.payload["prompt_agents"] == agents
+        assert result.payload == {
+            "session_id": "sess-abc",
+            "message_id": "msg-user-attachments",
+            "prompt_text": "Review these files",
+            "prompt_files": files,
+            "prompt_agents": agents,
+        }
 
     def test_tool_content_union(self, adapter: MappedJsonAdapter) -> None:
         content = [
@@ -600,6 +618,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000000,
                     "part": {
                         "id": "part-user",
                         "messageID": "msg-user",
@@ -614,6 +633,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000001,
                     "part": {
                         "id": "part-assistant",
                         "messageID": "msg-assistant",
@@ -628,6 +648,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000002,
                     "part": {
                         "id": "part-unknown",
                         "messageID": "msg-unknown",
@@ -636,12 +657,13 @@ class TestOpenCodeMappings:
                         "text": "uncorrelated",
                     },
                 },
-                "message.assistant",
+                "raw",
             ),
             (
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000003,
                     "part": {
                         "id": "part-reasoning",
                         "messageID": "msg-assistant",
@@ -656,6 +678,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000004,
                     "part": {
                         "id": "part-tool-running",
                         "messageID": "msg-assistant",
@@ -672,6 +695,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000005,
                     "part": {
                         "id": "part-tool-completed",
                         "messageID": "msg-assistant",
@@ -688,6 +712,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000006,
                     "part": {
                         "id": "part-tool-error",
                         "messageID": "msg-assistant",
@@ -710,6 +735,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000007,
                     "part": {
                         "id": "part-step-start",
                         "messageID": "msg-assistant",
@@ -723,6 +749,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000008,
                     "part": {
                         "id": "part-step-finish",
                         "messageID": "msg-assistant",
@@ -737,6 +764,7 @@ class TestOpenCodeMappings:
                 "message.part.updated.1",
                 {
                     "sessionID": "sqlite-session",
+                    "time": 1719828000009,
                     "part": {
                         "id": "part-patch",
                         "messageID": "msg-assistant",
@@ -758,6 +786,15 @@ class TestOpenCodeMappings:
         assert [result.kind for result in results] == [expected for _, _, expected in rows]
         assert results[4].payload["text"] == "question"
         assert results[5].payload["text"] == "answer"
+        assert results[6].kind == EventKind.RAW
+        assert results[6].kind not in {EventKind.MESSAGE_ASSISTANT, EventKind.MESSAGE_USER}
+        assert results[6].payload == {
+            "session_id": "sqlite-session",
+            "message_id": "msg-unknown",
+            "part_id": "part-unknown",
+            "text": "uncorrelated",
+            "original_type": "message.part.text.unknown",
+        }
         assert results[10].payload["error"] == "offline"
         assert results[10].payload["metadata"] == {"interrupted": True}
 

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -22,7 +22,7 @@ reported to the epic coordinator rather than fixed here (this ticket is tests-on
 from __future__ import annotations
 
 import copy
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -40,12 +40,20 @@ from traceforge.preprocessors.copilot_vscode import preprocess_copilot_vscode
 from traceforge.preprocessors.goose import preprocess_goose
 from traceforge.preprocessors.maf_transcript import preprocess_maf_transcript
 from traceforge.preprocessors.openai_agents import preprocess_openai_agents
+from traceforge.preprocessors.opencode import _reset as _opencode_reset
 from traceforge.preprocessors.opencode import preprocess_opencode
 from traceforge.preprocessors.openhands import preprocess_openhands
 from traceforge.preprocessors.pydantic_ai import preprocess_pydantic_ai
 from traceforge.preprocessors.smolagents import preprocess_smolagents
 
 Preproc = Callable[[dict[str, Any]], list[dict[str, Any]]]
+
+
+@pytest.fixture(autouse=True)
+def reset_opencode_state() -> Iterator[None]:
+    _opencode_reset()
+    yield
+    _opencode_reset()
 
 
 # ─── Generic contract specification ──────────────────────────────────────────
@@ -904,7 +912,17 @@ class TestOpencode:
         out = preprocess_opencode(
             {
                 "type": "message.part.updated.1",
-                "data": {"part": {"type": "text", "messageID": "m9", "sessionID": "s9"}},
+                "data": {
+                    "sessionID": "s9",
+                    "time": 1719828000000,
+                    "part": {
+                        "id": "p9",
+                        "type": "text",
+                        "messageID": "m9",
+                        "sessionID": "s9",
+                        "text": "hello",
+                    },
+                },
             }
         )
         assert out[0]["type"] == "message.part.text.user"
@@ -914,7 +932,19 @@ class TestOpencode:
         out = preprocess_opencode(
             {
                 "type": "message.part.updated.1",
-                "data": {"part": {"type": "tool", "state": {"status": "pending"}}},
+                "data": {
+                    "sessionID": "s",
+                    "time": 1719828000000,
+                    "part": {
+                        "id": "p",
+                        "type": "tool",
+                        "messageID": "m",
+                        "sessionID": "s",
+                        "callID": "call",
+                        "tool": "search",
+                        "state": {"status": "pending", "input": {}, "raw": ""},
+                    },
+                },
             }
         )
         assert out == []


### PR DESCRIPTION
## Summary
- correct `session.next.moved` to use canonical `properties.location.directory` while preserving optional `subdirectory`
- preserve `messageID`, structured prompt/context fields, and `assistantMessageID` correlation across active V2 events
- retain and regression-test all 14 V1 SQLite mappings; current OpenCode still publishes and durably projects V1 message/part events alongside V2
- retain uncorrelated V1 text as neutral `raw` events instead of inventing user or assistant authorship when a watcher starts after the role-bearing row
- correct the V1 tool failure discriminator from dead `failed` to upstream `error`

## Upstream evidence
Verified against `anomalyco/opencode@55b02116905efff9b8a245ea8f885f3c979101de` (`dev`, 2026-07-27):
- `packages/schema/src/session-event.ts` defines the V2 payloads and correlation fields
- `packages/schema/src/v1/session.ts` defines active V1 durable schemas and `ToolStateError.status = "error"`
- `packages/opencode/src/session/session.ts` still publishes V1 session/message/part events
- `packages/core/src/session/projector.ts` durably projects both V1 and V2 event families

This corrects #214's dangerous claim that the V1 mappings are dead. Removing them would silently lose locally stored message and part content. `prompt.promoted` and `interrupt.requested` were already absent. Revert mappings remain deferred: the local daemon emits `session.updated.1` for revert operations, and no honest canonical kind exists for the schema-only V2 definitions.

## Validation
- focused OpenCode/preprocessor tests: 284 passed
- full suite after merging current `main`: 3639 passed, 8 skipped
- ruff 0.15.20 check and format check

Closes #214