### PR TITLE
Release traceforge-toolkit 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "traceforge-toolkit"
-version = "0.1.1"
+version = "0.1.2"
 description = "Framework-agnostic, CPU-only pipeline that forges AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"
 license = "MIT"
@@ -159,4 +159,3 @@ dev = [
     "pydantic-ai-slim>=1.0",
     "agent-framework-core>=1.0",
 ]
-

--- a/uv.lock
+++ b/uv.lock
@@ -4174,7 +4174,7 @@ source = { editable = "packages/traceforge-title-model" }
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- bump traceforge-toolkit from 0.1.1 to 0.1.2
- regenerate uv.lock
- prepare the patch release containing the drift corrections and unified reasoning vocabulary now on main

## Release validation

- built wheel and sdist successfully
- verified both distributions contain real .safetensors binaries, not Git LFS pointers
- artifact names: traceforge_toolkit-0.1.2-py3-none-any.whl and traceforge_toolkit-0.1.2.tar.gz