### PR TITLE
Fix Aider Markdown git tool mapping

### DIFF
--- a/src/traceforge/mappings/aider_markdown.yaml
+++ b/src/traceforge/mappings/aider_markdown.yaml
@@ -67,7 +67,7 @@ events:
   git_commit:
     kind: tool.call.completed
     payload:
-      tool_name: git
+      tool_name: "literal:git"
       result: commit_sha
       message: commit_message
 

--- a/tests/integration/test_aider_contract.py
+++ b/tests/integration/test_aider_contract.py
@@ -202,6 +202,13 @@ class TestEndToEndPipeline:
         assert kind_map.get("error") == "session.error"
         assert kind_map.get("token_usage") == "telemetry.usage"
 
+    def test_git_commit_has_literal_tool_name(self, adapter, parser_events):
+        commit = next(event for event in parser_events if event["type"] == "git_commit")
+
+        session_event = next(iter(adapter.parse(json.dumps(commit))))
+
+        assert session_event.payload["tool_name"] == "git"
+
     def test_raw_event_always_preserved(self, adapter, parser_events):
         """Every SessionEvent must carry the original parser dict as raw_event."""
         for event_dict in parser_events:


### PR DESCRIPTION
## Summary
- map Aider Markdown git commits with the adapter's `literal:git` syntax
- assert parsed commit events emit `payload.tool_name == "git"`

## Tests
- `pytest -q tests/integration/test_aider_contract.py tests/unit/test_mapped_json.py`
- `ruff check tests/integration/test_aider_contract.py`
- `ruff format --check tests/integration/test_aider_contract.py`

Closes #228