### PR TITLE
Add Cline plan completion event

### DIFF
--- a/src/traceforge/mappings/cline.yaml
+++ b/src/traceforge/mappings/cline.yaml
@@ -92,9 +92,11 @@ events:
     payload:
       output: text
   say.plan_completion_result:
-    kind: session.ended
+    # SDK plan mode presents this result for approval before Act mode continues.
+    # Unlike completion_result, it is not a terminal session lifecycle event.
+    kind: planning.completed
     payload:
-      output: text
+      plan: text
   say.user_feedback:
     kind: message.user
     payload:

--- a/src/traceforge/mappings/cline.yaml
+++ b/src/traceforge/mappings/cline.yaml
@@ -1,7 +1,8 @@
 # Cline / Roo Code event mapping for MappedJsonAdapter
 # Targets: cline >= 3.88 (VS Code extension globalStorage JSON format)
-# Source: cline/cline apps/vscode/src/shared/ExtensionMessage.ts (commit 01617f9)
+# Source: cline/cline apps/vscode/src/shared/ExtensionMessage.ts (v4.1.3, bbfcbcd)
 # say.compaction was added in Cline 4.0.0 (commit 8e5471d, 2026-07-23).
+# say.plan_completion_result was added in Cline 4.1.3.
 #
 # IMPORTANT: Real Cline uses a COMPOUND discriminator:
 #   - type_field "type" has ONLY two values: "ask" or "say"
@@ -40,7 +41,7 @@ motivation:
 
 events:
   # ── Say subtypes (preprocessor synthesizes "say.<subtype>") ──
-  # Verified against ClineSay at commit 01617f9 (36 current values).
+  # Verified against ClineSay at v4.1.3 (37 current values).
   # api_req_retried and error_retry remain for persisted pre-SDK transcripts.
   say.task:
     kind: session.started
@@ -87,6 +88,10 @@ events:
     payload:
       content: text
   say.completion_result:
+    kind: session.ended
+    payload:
+      output: text
+  say.plan_completion_result:
     kind: session.ended
     payload:
       output: text

--- a/tests/e2e/test_raw_traces.py
+++ b/tests/e2e/test_raw_traces.py
@@ -203,6 +203,6 @@ def test_cline_v4_1_3_sdk_completion_uses_upstream_text_fields() -> None:
     assert len(reasoning) == 1
     assert reasoning[0].payload["content"] == "We should update the route and its tests."
 
-    completed = [event for event in events if event.kind == EventKind.SESSION_ENDED]
+    completed = [event for event in events if event.kind == EventKind.PLANNING_COMPLETED]
     assert len(completed) == 1
-    assert completed[0].payload["output"] == "1. Update the route.\n2. Add regression tests."
+    assert completed[0].payload["plan"] == "1. Update the route.\n2. Add regression tests."

--- a/tests/e2e/test_raw_traces.py
+++ b/tests/e2e/test_raw_traces.py
@@ -192,3 +192,17 @@ def test_cline_compaction_preserves_native_payload() -> None:
     assert payload["tokens_after"] == 4300
     assert payload["messages_before"] == 48
     assert payload["messages_after"] == 17
+
+
+def test_cline_v4_1_3_sdk_completion_uses_upstream_text_fields() -> None:
+    """SDK plan completion and reasoning rows must read the fields Cline renders."""
+    trace = TRACES_ROOT / "cline" / "sdk_plan_completion_v4_1_3_shape.jsonl"
+    events = _parse_scenario("cline", trace)
+
+    reasoning = [event for event in events if event.kind == EventKind.LLM_REASONING_CHUNK]
+    assert len(reasoning) == 1
+    assert reasoning[0].payload["content"] == "We should update the route and its tests."
+
+    completed = [event for event in events if event.kind == EventKind.SESSION_ENDED]
+    assert len(completed) == 1
+    assert completed[0].payload["output"] == "1. Update the route.\n2. Add regression tests."

--- a/tests/fixtures/raw_traces/cline/meta.yaml
+++ b/tests/fixtures/raw_traces/cline/meta.yaml
@@ -1,6 +1,6 @@
 framework: cline
 scenario: demo_issue_tracker_get_endpoint_shape
 source_repo: demo-issue-tracker-api
-framework_version: "4.0.0"
+framework_version: "4.1.3"
 model: shape-fixture
-notes: SHAPE FIXTURE (VS Code GUI capture not run). Verbatim ui_messages.json ClineMessage shape verified against cline/cline ExtensionMessage.ts at 01617f9 — type ask|say, subtype in ask/say, api_req_started text=JSON ClineApiReqInfo, tool text=JSON ClineSayTool, compaction text=JSON ClineCompactionInfo added in 4.0.0 at 8e5471d. Replace with real capture when extension is run.
+notes: SHAPE FIXTURES (VS Code GUI capture not run). Verbatim ui_messages.json ClineMessage shapes verified against cline/cline v4.1.3 at bbfcbcd — type ask|say, subtype in ask/say, SDK reasoning carries accumulated content in both text and reasoning while the webview renders text, plan_completion_result carries final plan content in text, api_req_started text=JSON ClineApiReqInfo, tool text=JSON ClineSayTool, compaction text=JSON ClineCompactionInfo. Replace with real captures when the extension is run.

--- a/tests/fixtures/raw_traces/cline/sdk_plan_completion_v4_1_3_shape.expected.json
+++ b/tests/fixtures/raw_traces/cline/sdk_plan_completion_v4_1_3_shape.expected.json
@@ -2,7 +2,7 @@
   "event_count": 3,
   "kinds": {
     "llm.reasoning.chunk": 1,
-    "session.ended": 1,
+    "planning.completed": 1,
     "session.started": 1
   }
 }

--- a/tests/fixtures/raw_traces/cline/sdk_plan_completion_v4_1_3_shape.expected.json
+++ b/tests/fixtures/raw_traces/cline/sdk_plan_completion_v4_1_3_shape.expected.json
@@ -1,0 +1,8 @@
+{
+  "event_count": 3,
+  "kinds": {
+    "llm.reasoning.chunk": 1,
+    "session.ended": 1,
+    "session.started": 1
+  }
+}

--- a/tests/fixtures/raw_traces/cline/sdk_plan_completion_v4_1_3_shape.jsonl
+++ b/tests/fixtures/raw_traces/cline/sdk_plan_completion_v4_1_3_shape.jsonl
@@ -1,0 +1,3 @@
+{"ts":1722600000000,"type":"say","say":"task","text":"Plan the ticket endpoint changes."}
+{"ts":1722600000001,"type":"say","say":"reasoning","text":"We should update the route and its tests.","reasoning":"We should update the route and its tests.","partial":false}
+{"ts":1722600000002,"type":"say","say":"plan_completion_result","text":"1. Update the route.\n2. Add regression tests.","partial":false}

--- a/tests/integration/test_yaml_comprehensive_e2e.py
+++ b/tests/integration/test_yaml_comprehensive_e2e.py
@@ -1349,7 +1349,11 @@ class TestClineMappings:
             id="say.error_retry",
         ),
         pytest.param(
-            _cline_say("reasoning", "Thinking through solution"),
+            _cline_say(
+                "reasoning",
+                "Thinking through solution",
+                reasoning="This field must not win",
+            ),
             EventKind.LLM_REASONING_CHUNK,
             {"content": "Thinking through solution"},
             id="say.reasoning",
@@ -1362,8 +1366,8 @@ class TestClineMappings:
         ),
         pytest.param(
             _cline_say("plan_completion_result", "Here is the implementation plan"),
-            EventKind.SESSION_ENDED,
-            {"output": "Here is the implementation plan"},
+            EventKind.PLANNING_COMPLETED,
+            {"plan": "Here is the implementation plan"},
             id="say.plan_completion_result",
         ),
         pytest.param(

--- a/tests/integration/test_yaml_comprehensive_e2e.py
+++ b/tests/integration/test_yaml_comprehensive_e2e.py
@@ -1361,6 +1361,12 @@ class TestClineMappings:
             id="say.completion_result",
         ),
         pytest.param(
+            _cline_say("plan_completion_result", "Here is the implementation plan"),
+            EventKind.SESSION_ENDED,
+            {"output": "Here is the implementation plan"},
+            id="say.plan_completion_result",
+        ),
+        pytest.param(
             _cline_say("user_feedback", "Please also add tests"),
             EventKind.MESSAGE_USER,
             {"content": "Please also add tests"},

--- a/tests/unit/test_preprocessor_edge_cases.py
+++ b/tests/unit/test_preprocessor_edge_cases.py
@@ -490,6 +490,17 @@ class TestCline:
         out = preprocess_cline({"type": "say", "say": "text", "text": "hi"})
         assert out[0]["type"] == "say.text"
 
+    def test_plan_completion_result_preserves_upstream_text(self) -> None:
+        obj = {
+            "ts": 1722600000000,
+            "type": "say",
+            "say": "plan_completion_result",
+            "text": "Here is the implementation plan.",
+            "partial": False,
+        }
+        out = preprocess_cline(obj)
+        assert out == [{**obj, "type": "say.plan_completion_result"}]
+
     def test_ask_subtype(self) -> None:
         out = preprocess_cline({"type": "ask", "ask": "tool", "text": "{}"})
         assert out[0]["type"] == "ask.tool"


### PR DESCRIPTION
## Summary
- map Cline v4.1.3 `say.plan_completion_result` to canonical nonterminal `planning.completed` with `plan` from `text`
- add an upstream-shaped SDK fixture covering plan completion and reasoning payload fields
- preserve historical retry mappings and existing compaction support unchanged

## Upstream shape and semantics
Cline v4.1.3 retags the final plan text as `plan_completion_result` and carries the content in `text`. This represents a plan presented for approval before Act mode, not the end of the session; using `session.ended` would incorrectly drain pending tool state and finalize/evict governance state.

SDK reasoning rows populate both `text` and `reasoning`; the webview explicitly renders `text`, so the existing reasoning mapping remains correct. The faithful fixture preserves equal upstream values, while a focused mapping test uses distinct values to prove the mapping reads `text`.

## Validation
- targeted Cline mapping and preprocessor tests
- complete raw-trace test suite
- Ruff check and format check on changed Python files

Part of #229. Pydantic AI and Claude support are handled separately.