### PR TITLE
Add stable event and turn projection contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A canonical event wire contract: `SessionEvent.id` is the stable identity,
+  `EventMetadata.sequence` is the sole ordering field (also exposed as
+  `event.sequence`), and `event_to_sse()` serializes both without payload
+  duplication.
+- Deterministic `TurnSummaryUpdate` projection. `EventPipeline` emits one version-1
+  summary per meaningful turn with activity/step linkage; callbacks, JSONL, and
+  SQLite consume the same public channel, and higher versions merge by
+  `(session_id, turn_id)`.
+- Host-independent file-target normalization via `normalize_file_target(s)` and
+  `Enricher(workspace_root=...)`. `metadata.file_targets` exposes root-relative
+  paths while retaining every raw path for provenance.
 - **AI Units (AIU / "AI credits") are now the primary Copilot consumption signal**,
   captured end-to-end. The `copilot` preprocessor carries each model's
   `session.shutdown.data.modelMetrics.<model>.totalNanoAiu` (nano-AIU) onto its
@@ -27,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `powershell` and `pwsh` tool calls now both canonicalize to the bundled shell
+  executor and use native PowerShell command classification.
 - GitHub Copilot CLI runs no longer render blank `model` / `repo` and an empty Cost
   lens. A new `copilot` preprocessor synthesizes per-model `assistant.usage` records
   from the authoritative `session.shutdown.data.modelMetrics` (Copilot emits no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A canonical event wire contract: `SessionEvent.id` is the stable identity,
-  `EventMetadata.sequence` is the sole ordering field (also exposed as
-  `event.sequence`), and `event_to_sse()` serializes both without payload
-  duplication.
-- Deterministic `TurnSummaryUpdate` projection. `EventPipeline` emits one version-1
-  summary per meaningful turn with activity/step linkage; callbacks, JSONL, and
-  SQLite consume the same public channel, and higher versions merge by
-  `(session_id, turn_id)`.
-- Host-independent file-target normalization via `normalize_file_target(s)` and
-  `Enricher(workspace_root=...)`. `metadata.file_targets` exposes root-relative
-  paths while retaining every raw path for provenance.
 - **AI Units (AIU / "AI credits") are now the primary Copilot consumption signal**,
   captured end-to-end. The `copilot` preprocessor carries each model's
   `session.shutdown.data.modelMetrics.<model>.totalNanoAiu` (nano-AIU) onto its
@@ -38,8 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `powershell` and `pwsh` tool calls now both canonicalize to the bundled shell
-  executor and use native PowerShell command classification.
 - GitHub Copilot CLI runs no longer render blank `model` / `repo` and an empty Cost
   lens. A new `copilot` preprocessor synthesizes per-model `assistant.usage` records
   from the authoritative `session.shutdown.data.modelMetrics` (Copilot emits no
@@ -49,6 +36,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `usage_records.attributes`; `cost_usd` stays `None` (Copilot's `requests.cost` is a
   premium-request count, not dollars — never synthesized). Ingestion-side only; usage
   rides `usage_records` (Cost lens), never the enriched-events timeline.
+
+## [0.1.3] - 2026-08-02
+
+### Added
+
+- A canonical event wire contract: `SessionEvent.id` is the stable identity,
+  `EventMetadata.sequence` is the sole ordering field (also exposed as
+  `event.sequence`), and `event_to_sse()` serializes both without payload
+  duplication.
+- Deterministic `TurnSummaryUpdate` projection. `EventPipeline` emits one version-1
+  summary per meaningful turn with activity/step linkage; callbacks, JSONL, and
+  SQLite consume the same public channel, and higher versions merge by
+  `(session_id, turn_id)`.
+- Host-independent file-target normalization via `normalize_file_target(s)` and
+  `Enricher(workspace_root=...)`. `metadata.file_targets` exposes root-relative
+  paths while retaining every raw path for provenance.
+
+### Fixed
+
+- `powershell` and `pwsh` tool calls now both canonicalize to the bundled shell
+  executor and use native PowerShell command classification.
 
 ## [0.1.1] - 2026-07-09
 
@@ -148,6 +156,7 @@ risk-scored, governed event streams with opt-in tool-call gating.
 - The gate IPC server binds a POSIX `AF_UNIX` socket; on Windows that path is skipped
   and a localhost TCP socket is used instead.
 
-[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/dfinson/traceforge/compare/v0.1.2...v0.1.3
 [0.1.1]: https://github.com/dfinson/traceforge/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/dfinson/traceforge/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ mapping file**: no code.
 1. **Sources** transport raw data from files, HTTP endpoints, SSE streams, SQLite databases, or replays.
 2. **Parsers** pre-process non-structured formats (markdown logs, chunked data) into structured dicts.
 3. **Adapters** parse raw input into a common `SessionEvent` type using declarative YAML mappings.
-4. **Enricher** adds metadata: tool pairing, duration, multi-dimensional classification, risk scoring, visibility.
-5. **Pipeline** stamps live structure, phase, activity/step boundaries, titles, then routes events to one or more sinks with error isolation.
+4. **Enricher** adds metadata: tool pairing, duration, normalized file targets, multi-dimensional classification, risk scoring, visibility.
+5. **Pipeline** stamps live structure, phase, activity/step boundaries, per-turn summaries, titles, then routes events to one or more sinks with error isolation.
 6. **Sinks** write to storage backends or call custom handlers.
 7. **Governance** (opt-in) assesses the same events (data labeling, taint / drift / budget tracking, rule evaluation) into per-event recommendations, with optional gate policies for enforcement.
 
@@ -90,6 +90,25 @@ native config — for Claude Code, a `PreToolUse` hook in `.claude/settings.json
 `traceforge gate --stdin`. It does not scaffold `~/.traceforge/` (that config bootstrap happens
 automatically on first config access).
 
+### Stable event and turn contracts
+
+`SessionEvent.id` is the stable event identity. Stream order lives only at
+`event.metadata.sequence` (with `event.sequence` as a convenience accessor), never
+at `payload.seq`. `event_to_sse(event)` writes the event ID to the SSE `id:` field
+and the complete canonical event JSON to `data:`.
+
+For live projections, subscribe to deterministic turn summaries:
+
+```python
+pipeline.subscribe(on_turn_summary=updates.append)
+```
+
+Each meaningful turn emits one `TurnSummaryUpdate` at version 1, linked to its
+native `activity_id` / `step_id`. A refiner can publish a higher version through
+`pipeline.push_turn_summary(update)`; materializing sinks keep the highest version.
+Declare `Enricher(workspace_root=...)` to receive normalized, root-relative
+`metadata.file_targets` while the raw payload remains unchanged.
+
 ## Dashboard
 
 `traceforge dashboard` opens a local, read-only web console over your SQLite output sink — the
@@ -114,7 +133,7 @@ See [`docs/dashboard-spec.md`](docs/dashboard-spec.md) for the full design and d
 | 🧩 **Framework-agnostic** | 22 bundled YAML mappings covering Copilot, Claude Code, Cline, Aider, CrewAI, LangGraph, OpenHands, PydanticAI, smolagents, Goose, and more. |
 | 🖥️ **Runs anywhere** | Runs from a laptop to CI. CPU-only, no heavyweight ML stack. |
 | 🏷️ **Classification & risk** | 7-dimension taxonomy, tree-sitter shell AST, MCP profiles, 0–100 risk scoring with MITRE ATT&CK mappings. |
-| 🧠 **Live structure** | Phase, activity/step boundaries, and human-readable titles stamped as events arrive. |
+| 🧠 **Live structure** | Phase, activity/step boundaries, deterministic turn summaries, and human-readable titles as events arrive. |
 | 🛡️ **Governance** | Data labeling, information-flow control, drift & budget tracking, and `allow/warn/escalate/deny/transform` recommendations. |
 | 🔌 **Pluggable sinks** | JSONL, SQLite, S3, Parquet, OpenTelemetry, webhook, console, and custom callbacks, all YAML-configurable. |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -188,6 +188,7 @@ class EventMetadata(FrozenModel):
     tool_display: str | None
     motivation: ToolMotivation | None
     duration_ms: float | None
+    file_targets: tuple[FileTarget, ...]
 `
 
 ### SessionEvent
@@ -201,7 +202,19 @@ class SessionEvent(FrozenModel):
     payload: dict[str, Any]
     raw_event: dict[str, Any] | None     # original event data, verbatim
     metadata: EventMetadata
+
+    @property
+    def sequence(self) -> int | None: ...  # canonical metadata.sequence accessor
 `
+
+`SessionEvent.id` is stable event identity. `EventMetadata.sequence` is the sole
+serialized ordering field; producers and consumers MUST NOT duplicate it into the
+open payload. `event_to_sse()` uses `id` as the SSE `id:` and serializes the whole
+event (including `metadata.sequence`) as JSON `data:`.
+
+`FileTarget(raw_path, path, inside_root)` retains verbatim provenance while exposing
+one normalized path: root-relative when inside a declared workspace, normalized
+absolute when outside.
 
 ### TelemetrySpan
 
@@ -581,6 +594,7 @@ class Enricher:
         custom_classifications: dict[str, Classification] | None = None,
         config: ClassifyConfig | None = None,
         config_path: Path | str | None = None,
+        workspace_root: Path | str | None = None,
     ) -> None: ...
 
     def process(self, event: SessionEvent) -> SessionEvent | list[SessionEvent] | None: ...
@@ -589,23 +603,27 @@ class Enricher:
 
 ### Enrichment Steps
 
-1. **Tool call pairing**: Buffers `TOOL_CALL_STARTED` events, pairs them with matching `TOOL_CALL_COMPLETED` by `tool_call_id`. Merges payloads. Emits orphan starts on displacement or flush.
+1. **File target normalization**: With `workspace_root` declared, stamps concrete
+   targets into `metadata.file_targets` using host-independent Windows/POSIX
+   normalization. Raw payload paths are never rewritten.
 
-2. **Duration computation**: Calculates `metadata.duration_ms` from timestamp difference of start/complete pairs.
+2. **Tool call pairing**: Buffers `TOOL_CALL_STARTED` events, pairs them with matching `TOOL_CALL_COMPLETED` by `tool_call_id`. Merges payloads. Emits orphan starts on displacement or flush.
 
-3. **Classification dispatch**: For `TOOL_CALL_STARTED` and unpaired `TOOL_CALL_COMPLETED`:
+3. **Duration computation**: Calculates `metadata.duration_ms` from timestamp difference of start/complete pairs.
+
+4. **Classification dispatch**: For `TOOL_CALL_STARTED` and unpaired `TOOL_CALL_COMPLETED`:
    - Shell tools → deep tree-sitter AST analysis (bash, PowerShell, cmd)
    - Native tools → static classification via engine lookup
    - MCP tools → profile-based classification
    - Scope refinement from file paths in payload
 
-4. **Risk scoring**: Computes a 0-100 risk score:
+5. **Risk scoring**: Computes a 0-100 risk score:
    - Shell commands: structural + flag modifiers + injection patterns + pipeline taint + context
    - Native/MCP tools: intent base + scope + capability escalation + context
 
-5. **Visibility assignment**: Sets `metadata.visibility` based on event kind (system events, bookkeeping → SYSTEM; similar repeated events → COLLAPSED).
+6. **Visibility assignment**: Sets `metadata.visibility` based on event kind (system events, bookkeeping → SYSTEM; similar repeated events → COLLAPSED).
 
-6. **Phase detection**: Derives `metadata.phases` from classification dimensions.
+7. **Phase detection**: Derives `metadata.phases` from classification dimensions.
 
 ### Return Semantics
 
@@ -785,6 +803,7 @@ class EventPipeline:
     async def push(self, event: SessionEvent) -> None: ...
     async def push_span(self, span: TelemetrySpan) -> None: ...
     async def push_usage(self, usage: UsageRecord) -> None: ...
+    async def push_turn_summary(self, update: TurnSummaryUpdate) -> None: ...
     async def flush(self) -> None: ...
     async def close(self) -> None: ...
 `
@@ -796,6 +815,9 @@ class EventPipeline:
 - **Fan-out**: All sinks receive every event concurrently.
 - **Flush**: Drains enricher buffer (unpaired tool starts), then flushes all sinks.
 - **Close**: Flush + close all sinks (also error-isolated).
+- **Turn projection**: one deterministic version-1 `TurnSummaryUpdate` is emitted
+  for the first meaningful event of every turn. Later refinements use
+  `push_turn_summary()` with the same `(session_id, turn_id)` and a higher version.
 
 ---
 
@@ -811,6 +833,7 @@ class StorageSink(ABC):
     async def on_event(self, event: SessionEvent) -> None: ...
     async def on_span(self, span: TelemetrySpan) -> None: ...   # default no-op
     async def on_usage(self, usage: UsageRecord) -> None: ...   # default no-op
+    async def on_turn_summary(self, update: TurnSummaryUpdate) -> None: ...
     async def flush(self) -> None: ...                          # default no-op
     async def close(self) -> None: ...                          # default no-op
 `
@@ -938,13 +961,18 @@ An in-process consumer can react to events without implementing a full sink: `St
 **The official lightweight pub/sub API is `EventPipeline.subscribe`:**
 
 ```python
-pipeline.subscribe(on_event, *, kind=None, to_thread=False) -> CallbackSink
+pipeline.subscribe(
+    on_event=None, *, on_progress=None, on_turn_summary=None,
+    kind=None, to_thread=False
+) -> CallbackSink
 pipeline.unsubscribe(sink) -> bool
 ```
 
 - `subscribe` wraps `on_event` in a `CallbackSink` and appends it to the fan-out; it returns that sink, which doubles as the handle for `unsubscribe`.
 - `on_event` may be **async or a plain sync callable** — the one genuinely new capability. Sync callbacks run inline on the event loop by default (right for append-to-list / put-on-queue consumers); pass `to_thread=True` to run a blocking callback via `asyncio.to_thread` so it never stalls the loop. (Adapter: `traceforge.sinks.callback.as_async_event_callback`.)
 - `kind` is an optional per-subscriber filter checked **before** dispatch: an exact kind, a `"prefix.*"` wildcard (e.g. `"tool.*"`), an iterable of those, or a predicate over the event.
+- `on_turn_summary` receives one deterministic initial summary per meaningful turn.
+  It uses the same error-isolated sink fan-out as events and progress.
 
 `EventPipeline(sinks=[CallbackSink(on_event=handler)])` remains equivalent for construction-time wiring; `subscribe` is the ergonomic path for adding/removing consumers on a live pipeline — no sink subclassing, no flush/close lifecycle, no persistence contract.
 
@@ -2027,6 +2055,7 @@ mid-session and survives `SESSION_ENDED` / `SESSION_PAUSED`.
 |-------|--------|--------|---------|
 | Phase classifier | `traceforge.phase` | `metadata.phase` (per event) | on (`enable_phase`) |
 | Boundary decoder | `traceforge.boundary` | `metadata.boundary` + `activity_id` / `step_id` | on (`enable_boundary`) |
+| Turn summarizer | `traceforge.turn_summary` | `TurnSummaryUpdate` records (out-of-band) | on (`enable_turn_summary`) |
 | Titler | `traceforge.title` | `TitleUpdate` records (out-of-band) | off (`enable_title`) |
 
 ### 23.1 — Shared foundations
@@ -2130,17 +2159,29 @@ distilled request-head was measured at ~9% coherent and dropped).
   the environment (the key is **never** read from config). It runs off the hot path on a worker thread and
   emits a later, refined `kind = "session"` `TitleUpdate` (`refine_title` / `take_session_refinement`).
 
-### 23.6 — Live-stamping & enablement contract
+### 23.6 — Deterministic turn summaries
+
+`TurnSummarizer` emits exactly one initial `TurnSummaryUpdate(version=1)` for each
+meaningful turn. An explicit `metadata.turn_id` is authoritative; otherwise a
+substantive user message opens an implicit turn. Lifecycle/plumbing events defer
+emission until useful text arrives. Every update carries its source event plus the
+current activity/step IDs. Refiners publish a later version on the same public
+channel, and consumers merge by keeping the highest version for
+`(session_id, turn_id)`.
+
+### 23.7 — Live-stamping & enablement contract
 
 - `enable_phase` — default **on**; stamps `metadata.phase` live.
 - `enable_boundary` — default **on**; stamps `metadata.boundary` (and assigns `activity_id` / `step_id`)
   live.
 - `enable_title` — default **off** (opt-in); emits `TitleUpdate` records out-of-band.
+- `enable_turn_summary` — default **on**; emits deterministic
+  `TurnSummaryUpdate` records out-of-band.
 - Live structuring runs at the `EventPipeline` layer, alongside — not inside — the enricher (which owns
   classification and risk). Structuring is the pipeline's observation plane and feeds sinks directly
   (including `on_title_update`).
 
-### 23.7 — Packaging
+### 23.8 — Packaging
 
 The base `traceforge` wheel is **model-free only for the titler.** Its build force-includes the small model
 artifacts — `phase/data/*.joblib`, `phase/data/potion-base-8M/*`, `boundary/data/*.joblib`, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "traceforge-toolkit"
-version = "0.2.0"
+version = "0.1.3"
 description = "Framework-agnostic, CPU-only pipeline that forges AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "traceforge-toolkit"
-version = "0.1.2"
+version = "0.2.0"
 description = "Framework-agnostic, CPU-only pipeline that forges AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"
 license = "MIT"

--- a/src/traceforge/__init__.py
+++ b/src/traceforge/__init__.py
@@ -21,6 +21,8 @@ from traceforge.enricher import Enricher
 from traceforge.parsers.aider import AiderPreParser
 from traceforge.pipeline import EventPipeline
 from traceforge.progress import ProgressEmitter
+from traceforge.paths import normalize_file_target, normalize_file_targets
+from traceforge.serialization import event_to_sse
 from traceforge.sinks.base import StorageSink
 from traceforge.sinks.callback import CallbackSink
 from traceforge.telemetry.attribution import (
@@ -37,11 +39,13 @@ from traceforge.types import (
     CostBreakdown,
     EventKind,
     EventMetadata,
+    FileTarget,
     IngestionMode,
     ProgressUpdate,
     SessionEvent,
     TelemetrySpan,
     TitleUpdate,
+    TurnSummaryUpdate,
     UsageRecord,
     is_known_kind,
 )
@@ -61,6 +65,7 @@ __all__ = [
     "Enricher",
     "EventKind",
     "EventMetadata",
+    "FileTarget",
     "EventPipeline",
     "IngestionMode",
     "KNOWN_KINDS",
@@ -72,6 +77,7 @@ __all__ = [
     "TelemetrySpan",
     "EventTrace",
     "TitleUpdate",
+    "TurnSummaryUpdate",
     "UsageRecord",
     "Visibility",
     "classify_cmd_command",
@@ -82,6 +88,9 @@ __all__ = [
     "is_known_kind",
     "load_config",
     "normalize_tool_name",
+    "normalize_file_target",
+    "normalize_file_targets",
+    "event_to_sse",
     # Attribution (U11)
     "Anomaly",
     "AttributionRollup",

--- a/src/traceforge/classify/data/canonical_tools.yaml
+++ b/src/traceforge/classify/data/canonical_tools.yaml
@@ -12,6 +12,7 @@ canonical_tools:
   shell: shell                     # OpenAI Codex CLI (Responses API native)
   bash: shell                      # GitHub Copilot, SWE-agent, Cline (native models)
   powershell: shell                # GitHub Copilot (Windows)
+  pwsh: shell                      # PowerShell 6+ executable/tool alias
   Bash: shell                      # Claude Code, OpenAI Codex RS (hook name)
   PowerShell: shell                # Claude Code (Windows)
   execute_command: shell           # Cline (GENERIC model), Roo Code

--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -18,6 +18,7 @@ from traceforge.classify.risk import assess_risk, assess_tool_risk
 from traceforge.classify.tool_display import ToolDisplayProvider, ToolDisplayResolver
 from traceforge.classify.tools import normalize_tool_name
 from traceforge.classify.workflow import Phase, Visibility
+from traceforge.paths import normalize_file_targets
 from traceforge.types import EventKind, EventMetadata, SessionEvent
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,7 @@ class Enricher:
         max_pending: int | None = _DEFAULT_MAX_PENDING,
         flush_on_session_end: bool = True,
         tool_display_providers: Sequence[ToolDisplayProvider] | None = None,
+        workspace_root: Path | str | None = None,
     ) -> None:
         """
         Args:
@@ -73,6 +75,9 @@ class Enricher:
                 ``metadata.tool_display``. The first non-empty result wins; when all
                 defer, the static map (built-in defaults + config overrides) is used,
                 then ``None``.
+            workspace_root: Optional declared session/worktree root. Concrete file
+                targets are normalized against it into ``metadata.file_targets``
+                while their raw payload values remain untouched.
 
         Raises:
             ValueError: if ``pairing_ttl_s`` is set and not > 0, or if
@@ -88,6 +93,7 @@ class Enricher:
         self._pairing_ttl_s = pairing_ttl_s
         self._max_pending = max_pending
         self._flush_on_session_end = flush_on_session_end
+        self._workspace_root = str(workspace_root) if workspace_root is not None else None
 
         # Build engine eagerly so config errors surface at construction time
         if config is not None:
@@ -115,6 +121,7 @@ class Enricher:
             # push the raw event straight to sinks and bypass the exactly-once
             # tool-call pairing guarantee the downstream governance stage relies on.
             event = event.model_copy(update={"metadata": EventMetadata()})
+        event = self._normalize_file_targets(event)
 
         # Stream time drives TTL eviction: the timestamp of the event currently
         # being processed is "now". Using stream time (not wallclock) keeps bounded
@@ -343,6 +350,16 @@ class Enricher:
 
         return event
 
+    def _normalize_file_targets(self, event: SessionEvent) -> SessionEvent:
+        """Stamp normalized concrete file targets without rewriting the payload."""
+
+        raw_targets = _extract_file_targets_from_payload(event.payload)
+        if not raw_targets:
+            return event
+        targets = normalize_file_targets(raw_targets, self._workspace_root)
+        metadata = event.metadata.model_copy(update={"file_targets": targets})
+        return event.model_copy(update={"metadata": metadata})
+
     def _classify_permission(self, event: SessionEvent) -> SessionEvent:
         """Set metadata.classification for a permission-gate event from its kind.
 
@@ -428,8 +445,11 @@ class Enricher:
 
     def _assess_tool_risk(self, event: SessionEvent, cls: Classification) -> SessionEvent:
         """Compute risk score for a native/MCP tool and store in payload._enrichment."""
-        # Extract file targets from payload
-        targets = _extract_targets_from_payload(event.payload)
+        # Match policies against normalized identity when available. Raw
+        # provenance remains in payload and each FileTarget.raw_path.
+        targets = [target.path for target in event.metadata.file_targets]
+        if not targets:
+            targets = _extract_targets_from_payload(event.payload)
 
         risk = assess_tool_risk(
             classification=cls,
@@ -637,6 +657,20 @@ def _extract_path_from_payload(payload: dict) -> str:
     return ""
 
 
+def _extract_file_targets_from_payload(payload: dict) -> list[str]:
+    """Extract concrete file target strings from payload and arguments."""
+
+    targets: list[str] = []
+    for container in (payload, payload.get("arguments", {})):
+        if not isinstance(container, dict):
+            continue
+        for key in _PAYLOAD_PATH_KEYS:
+            value = container.get(key)
+            if isinstance(value, str) and value and value not in targets:
+                targets.append(value)
+    return targets
+
+
 def _refine_scope_from_payload(cls: Classification, payload: dict) -> Classification:
     """Refine classification scope based on file paths in the event payload.
 
@@ -750,6 +784,13 @@ def _merge_metadata(
             continue
         start_val = getattr(start, field_name)
         complete_val = getattr(complete, field_name)
+        if field_name == "file_targets":
+            merged_targets = {
+                (target.raw_path, target.path): target
+                for target in (*start.file_targets, *complete.file_targets)
+            }
+            updates[field_name] = tuple(merged_targets.values())
+            continue
         if field_name in _start_authoritative:
             updates[field_name] = start_val if start_val is not None else complete_val
         else:

--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -445,11 +445,7 @@ class Enricher:
 
     def _assess_tool_risk(self, event: SessionEvent, cls: Classification) -> SessionEvent:
         """Compute risk score for a native/MCP tool and store in payload._enrichment."""
-        # Match policies against normalized identity when available. Raw
-        # provenance remains in payload and each FileTarget.raw_path.
-        targets = [target.path for target in event.metadata.file_targets]
-        if not targets:
-            targets = _extract_targets_from_payload(event.payload)
+        targets = _risk_targets(event)
 
         risk = assess_tool_risk(
             classification=cls,
@@ -599,6 +595,7 @@ _INFRA_DIRS = frozenset({"helm", "charts", "k8s", "kubernetes", "terraform", "in
 _CONTAINER_FILES = frozenset({"docker-compose.yml", "docker-compose.yaml", ".dockerignore"})
 _DOC_FILES = frozenset({"readme.md", "contributing.md", "changelog.md", "license.md"})
 _PAYLOAD_PATH_KEYS = ("path", "file_path", "file", "filename")
+_RISK_TARGET_KEYS = (*_PAYLOAD_PATH_KEYS, "pattern", "glob")
 
 
 def _infer_scope_from_path(path: str) -> str | None:
@@ -644,27 +641,24 @@ def _infer_scope_from_path(path: str) -> str | None:
 
 def _extract_path_from_payload(payload: dict) -> str:
     """Extract the first file path string from common payload keys."""
-    for key in _PAYLOAD_PATH_KEYS:
-        val = payload.get(key, "")
-        if isinstance(val, str) and val:
-            return val
-    args = payload.get("arguments", {})
-    if isinstance(args, dict):
-        for key in _PAYLOAD_PATH_KEYS:
-            val = args.get(key, "")
-            if isinstance(val, str) and val:
-                return val
-    return ""
+    targets = _extract_payload_targets(payload, _PAYLOAD_PATH_KEYS)
+    return targets[0] if targets else ""
 
 
 def _extract_file_targets_from_payload(payload: dict) -> list[str]:
     """Extract concrete file target strings from payload and arguments."""
 
+    return _extract_payload_targets(payload, _PAYLOAD_PATH_KEYS)
+
+
+def _extract_payload_targets(payload: dict, keys: tuple[str, ...]) -> list[str]:
+    """Extract ordered, unique target values from payload and arguments."""
+
     targets: list[str] = []
     for container in (payload, payload.get("arguments", {})):
         if not isinstance(container, dict):
             continue
-        for key in _PAYLOAD_PATH_KEYS:
+        for key in keys:
             value = container.get(key)
             if isinstance(value, str) and value and value not in targets:
                 targets.append(value)
@@ -755,19 +749,18 @@ def _extract_tool_call_id(event: SessionEvent) -> str | None:
     return None
 
 
-def _extract_targets_from_payload(payload: dict) -> list[str]:
-    """Extract file path targets from event payload for risk scoring."""
+def _risk_targets(event: SessionEvent) -> list[str]:
+    """Return one ordered risk-target domain with concrete paths normalized."""
+
+    normalized_paths = {target.raw_path: target.path for target in event.metadata.file_targets}
     targets: list[str] = []
-    primary = _extract_path_from_payload(payload)
-    if primary:
-        targets.append(primary)
-    # Also pick up pattern/glob from arguments
-    args = payload.get("arguments", {})
-    if isinstance(args, dict):
-        for key in ("pattern", "glob"):
-            val = args.get(key, "")
-            if isinstance(val, str) and val and val not in targets:
-                targets.append(val)
+    for raw_target in _extract_payload_targets(event.payload, _RISK_TARGET_KEYS):
+        target = normalized_paths.get(raw_target, raw_target)
+        if target not in targets:
+            targets.append(target)
+    for file_target in event.metadata.file_targets:
+        if file_target.path not in targets:
+            targets.append(file_target.path)
     return targets
 
 

--- a/src/traceforge/paths.py
+++ b/src/traceforge/paths.py
@@ -69,7 +69,10 @@ def normalize_file_target(raw_path: str, workspace_root: str | None = None) -> F
     normalized = _normalize_posix(candidate)
     if normalized_root is None:
         return FileTarget(raw_path=raw_path, path=normalized)
-    inside = posixpath.commonpath([normalized, normalized_root]) == normalized_root
+    try:
+        inside = posixpath.commonpath([normalized, normalized_root]) == normalized_root
+    except ValueError:
+        inside = False
     path = posixpath.relpath(normalized, normalized_root) if inside else normalized
     return FileTarget(raw_path=raw_path, path=path, inside_root=inside)
 

--- a/src/traceforge/paths.py
+++ b/src/traceforge/paths.py
@@ -1,0 +1,93 @@
+"""Host-independent file-target normalization."""
+
+from __future__ import annotations
+
+import ntpath
+import posixpath
+import re
+from collections.abc import Iterable
+
+from traceforge.types import FileTarget
+
+_WINDOWS_ABSOLUTE = re.compile(r"^[A-Za-z]:[\\/]")
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:")
+
+
+def _is_windows_path(path: str) -> bool:
+    return bool(_WINDOWS_DRIVE.match(path)) or path.startswith(("\\\\", "//"))
+
+
+def _normalize_windows(path: str) -> str:
+    normalized = ntpath.normpath(path.replace("/", "\\"))
+    drive, rest = ntpath.splitdrive(normalized)
+    if drive:
+        drive = drive.upper()
+    return (drive + rest).replace("\\", "/")
+
+
+def _normalize_posix(path: str) -> str:
+    return posixpath.normpath(path.replace("\\", "/"))
+
+
+def normalize_file_target(raw_path: str, workspace_root: str | None = None) -> FileTarget:
+    """Normalize one target, relativizing it only when it is within ``workspace_root``.
+
+    Windows drive comparisons are case-insensitive even when this function runs on
+    POSIX. Mixed separators are accepted for both Windows and POSIX inputs.
+    """
+
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError("raw_path must be a non-empty string")
+
+    raw = raw_path.strip()
+    root = workspace_root.strip() if isinstance(workspace_root, str) else None
+    windows = _is_windows_path(raw) or bool(root and _is_windows_path(root))
+
+    if windows:
+        normalized_root = _normalize_windows(root) if root else None
+        candidate = raw
+        if normalized_root and not _is_windows_path(candidate):
+            candidate = ntpath.join(normalized_root.replace("/", "\\"), candidate)
+        normalized = _normalize_windows(candidate)
+        if normalized_root is None:
+            return FileTarget(raw_path=raw_path, path=normalized)
+        try:
+            inside = ntpath.commonpath(
+                [ntpath.normcase(normalized), ntpath.normcase(normalized_root)]
+            ) == ntpath.normcase(normalized_root)
+        except ValueError:
+            inside = False
+        path = (
+            ntpath.relpath(normalized, normalized_root).replace("\\", "/") if inside else normalized
+        )
+        return FileTarget(raw_path=raw_path, path=path, inside_root=inside)
+
+    normalized_root = _normalize_posix(root) if root else None
+    candidate = raw
+    if normalized_root and not candidate.startswith("/"):
+        candidate = posixpath.join(normalized_root, candidate)
+    normalized = _normalize_posix(candidate)
+    if normalized_root is None:
+        return FileTarget(raw_path=raw_path, path=normalized)
+    inside = posixpath.commonpath([normalized, normalized_root]) == normalized_root
+    path = posixpath.relpath(normalized, normalized_root) if inside else normalized
+    return FileTarget(raw_path=raw_path, path=path, inside_root=inside)
+
+
+def normalize_file_targets(
+    raw_paths: Iterable[str], workspace_root: str | None = None
+) -> tuple[FileTarget, ...]:
+    """Normalize and de-duplicate targets while preserving first-seen order."""
+
+    seen: set[tuple[str, str]] = set()
+    targets: list[FileTarget] = []
+    for raw_path in raw_paths:
+        target = normalize_file_target(raw_path, workspace_root)
+        key = (target.raw_path, target.path)
+        if key not in seen:
+            seen.add(key)
+            targets.append(target)
+    return tuple(targets)
+
+
+__all__ = ["normalize_file_target", "normalize_file_targets"]

--- a/src/traceforge/pipeline.py
+++ b/src/traceforge/pipeline.py
@@ -17,15 +17,19 @@ from traceforge.sinks.callback import (
     EventCallback,
     KindFilter,
     ProgressCallback,
+    TurnSummaryCallback,
     as_async_event_callback,
     as_async_progress_callback,
+    as_async_turn_summary_callback,
 )
+from traceforge.turn_summary import TurnSummarizer
 from traceforge.types import (
     EventMetadata,
     ProgressUpdate,
     SessionEvent,
     TelemetrySpan,
     TitleUpdate,
+    TurnSummaryUpdate,
     UsageRecord,
 )
 
@@ -101,6 +105,10 @@ class EventPipeline:
     append-only :class:`~traceforge.types.TitleUpdate` records (``on_title_update``)
     keyed by segment id; consumers join them onto events. The trailing open
     activity is titled at pipeline close.
+
+    ``enable_turn_summary`` (on by default) emits one deterministic,
+    versioned :class:`~traceforge.types.TurnSummaryUpdate` for each meaningful
+    turn. It is independent of the optional title model.
     """
 
     def __init__(
@@ -113,6 +121,7 @@ class EventPipeline:
         enable_phase: bool = True,
         enable_boundary: bool = True,
         enable_title: bool = False,
+        enable_turn_summary: bool = True,
         max_sessions: int | None = _DEFAULT_MAX_SESSIONS,
         governance=None,
         metrics: PipelineMetrics | None = None,
@@ -147,6 +156,11 @@ class EventPipeline:
         self._boundary_streams: dict[str, object] = {}
         self._title_inferencer = title_inferencer
         self._title_streams: dict[str, object] = {}
+        self._turn_summarizer = (
+            TurnSummarizer(history_size=max_sessions or _DEFAULT_MAX_SESSIONS)
+            if enable_turn_summary
+            else None
+        )
         # Live progress-headline emitter (SPEC U7). Created lazily the first time
         # a caller subscribes with ``on_progress`` (see :meth:`subscribe`); stays
         # ``None`` otherwise, so every progress site on the hot path is a single
@@ -222,10 +236,11 @@ class EventPipeline:
         on_event: EventCallback | None = None,
         *,
         on_progress: ProgressCallback | None = None,
+        on_turn_summary: TurnSummaryCallback | None = None,
         kind: KindFilter = None,
         to_thread: bool = False,
     ) -> CallbackSink:
-        """Register a lightweight event and/or progress subscriber (SPEC §15 / #47, U7).
+        """Register lightweight event and structural-update subscribers.
 
         One-line sugar over the sink model: wraps the given callback(s) in a
         :class:`~traceforge.sinks.callback.CallbackSink` and appends it, so the
@@ -237,7 +252,9 @@ class EventPipeline:
         ``on_event`` receives every (post-structuring) :class:`SessionEvent`;
         ``on_progress`` receives a live :class:`~traceforge.types.ProgressUpdate`
         — a deterministic heuristic headline emitted the instant an activity/step
-        opens (U7). Pass either or both; at least one is required. Subscribing to
+        opens (U7). ``on_turn_summary`` receives one deterministic initial summary
+        per meaningful turn. Pass any callback combination; at least one is
+        required. Subscribing to
         ``on_progress`` lazily arms the progress emitter; not subscribing to it
         leaves the pipeline byte-identical to before (the emitter stays ``None``).
 
@@ -253,8 +270,10 @@ class EventPipeline:
         Returns the created :class:`CallbackSink`, which doubles as the handle for
         :meth:`unsubscribe`.
         """
-        if on_event is None and on_progress is None:
-            raise ValueError("subscribe requires at least one of on_event or on_progress")
+        if on_event is None and on_progress is None and on_turn_summary is None:
+            raise ValueError(
+                "subscribe requires at least one of on_event, on_progress, or on_turn_summary"
+            )
         event_cb = (
             as_async_event_callback(on_event, kind=kind, to_thread=to_thread)
             if on_event is not None
@@ -265,7 +284,16 @@ class EventPipeline:
             if on_progress is not None
             else None
         )
-        sink = CallbackSink(on_event=event_cb, on_progress=progress_cb)
+        turn_summary_cb = (
+            as_async_turn_summary_callback(on_turn_summary, to_thread=to_thread)
+            if on_turn_summary is not None
+            else None
+        )
+        sink = CallbackSink(
+            on_event=event_cb,
+            on_progress=progress_cb,
+            on_turn_summary=turn_summary_cb,
+        )
         if on_progress is not None and self._progress is None:
             self._progress = ProgressEmitter()
         self._sinks.append(sink)
@@ -428,6 +456,8 @@ class EventPipeline:
         self._boundary_streams.pop(session_id, None)
         if self._progress is not None:
             self._progress.forget(session_id)
+        if self._turn_summarizer is not None:
+            self._turn_summarizer.forget(session_id)
 
     async def _push_locked(self, event: SessionEvent) -> None:
         if self._enricher is not None:
@@ -511,14 +541,16 @@ class EventPipeline:
         for event in events:
             if self._boundary_inferencer is not None:
                 event = self._boundary_stamp(event)
-            await self._title_emit(event)
+            event = await self._title_emit(event)
             # Progress rides the same boundary-stamped event straight after it
             # reaches the sinks. Gated: on the default path ``_progress`` is None,
             # so this is a single bool check and nothing else runs (U7).
             if self._progress is not None:
                 await self._emit_progress(event)
+            if self._turn_summarizer is not None:
+                await self._emit_turn_summary(event)
 
-    async def _title_emit(self, event: SessionEvent) -> None:
+    async def _title_emit(self, event: SessionEvent) -> SessionEvent:
         """Stamp the event's live segment ids, emit it immediately, then emit
         any titles for the activity it just closed.
 
@@ -541,7 +573,7 @@ class EventPipeline:
 
         if self._title_inferencer is None:
             await self._push_to_sinks(event)
-            return
+            return event
 
         stream = self._title_streams.get(event.session_id)
         if stream is None:
@@ -576,6 +608,7 @@ class EventPipeline:
         # By default (strategy=model) nothing is queued, so this is a no-op.
         for closed in stream.take_activity_refinements():
             self._schedule_activity_refine(event.session_id, closed)
+        return event
 
     def _schedule_session_refine(self, session_id: str, text: str) -> None:
         """Refine a session title via the API off the hot path (fire-and-forget).
@@ -845,6 +878,34 @@ class EventPipeline:
             f"progress update for segment {update.segment_id}",
         )
 
+    async def _emit_turn_summary(self, event: SessionEvent) -> None:
+        """Derive and fan out the first deterministic summary for a turn."""
+
+        try:
+            update = self._turn_summarizer.observe(event)
+        except Exception as exc:
+            logger.error(
+                "Live turn summarization failed for event %s: %s — skipping",
+                event.id,
+                exc,
+                exc_info=True,
+            )
+            return
+        if update is not None:
+            await self.push_turn_summary(update)
+
+    async def push_turn_summary(self, update: TurnSummaryUpdate) -> None:
+        """Publish an initial or refined turn summary.
+
+        Refiners reuse the same ``session_id``/``turn_id`` with a higher
+        ``version``; materializing sinks keep the highest version.
+        """
+
+        await self._fanout(
+            (sink.on_turn_summary(update) for sink in self._sinks),
+            f"turn summary for {update.session_id}/{update.turn_id}",
+        )
+
     async def push_span(self, span: TelemetrySpan) -> None:
         """Fan-out span to all registered sinks.
 
@@ -913,6 +974,8 @@ class EventPipeline:
         self._session_order.clear()
         if self._progress is not None:
             self._progress.clear()
+        if self._turn_summarizer is not None:
+            self._turn_summarizer.clear()
 
         await self._fanout((sink.flush() for sink in self._sinks), "flush")
 

--- a/src/traceforge/sdk/pipeline.py
+++ b/src/traceforge/sdk/pipeline.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from traceforge.sdk.observe import ObservationHandle
     from traceforge.sinks.base import StorageSink
     from traceforge.trace import EventTrace
-    from traceforge.types import SessionEvent, TelemetrySpan, UsageRecord
+    from traceforge.types import SessionEvent, TelemetrySpan, TurnSummaryUpdate, UsageRecord
 
 
 class Pipeline:
@@ -181,6 +181,7 @@ class Pipeline:
             enable_phase=enable_structure,
             enable_boundary=enable_structure,
             enable_title=enable_title,
+            enable_turn_summary=enable_structure,
             governance=gov_engine if governance else None,
         )
         return cls(backbone=backbone, governance=gov_engine)
@@ -198,6 +199,16 @@ class Pipeline:
     async def push_usage(self, usage: "UsageRecord") -> None:
         """Emit a usage record to the sinks."""
         await self._backbone.push_usage(usage)
+
+    def subscribe(self, on_event=None, **kwargs):
+        """Subscribe to events and live structural updates on the backbone."""
+
+        return self._backbone.subscribe(on_event, **kwargs)
+
+    async def push_turn_summary(self, update: "TurnSummaryUpdate") -> None:
+        """Publish a refined turn summary through the backbone's sink fan-out."""
+
+        await self._backbone.push_turn_summary(update)
 
     async def flush(self) -> None:
         """Flush held plumbing and pending refinements, then flush all sinks."""

--- a/src/traceforge/serialization.py
+++ b/src/traceforge/serialization.py
@@ -1,0 +1,22 @@
+"""Canonical wire serialization helpers."""
+
+from __future__ import annotations
+
+from traceforge.types import SessionEvent
+
+
+def event_to_sse(event: SessionEvent) -> str:
+    """Serialize a :class:`SessionEvent` as one SSE frame.
+
+    The SSE ``id`` is always the stable :attr:`SessionEvent.id`; the complete
+    canonical event is the JSON ``data`` payload, including
+    ``metadata.sequence`` when present.
+    """
+
+    data = event.model_dump_json()
+    lines = [f"id: {event.id}", f"event: {event.kind}"]
+    lines.extend(f"data: {line}" for line in data.splitlines() or [""])
+    return "\n".join(lines) + "\n\n"
+
+
+__all__ = ["event_to_sse"]

--- a/src/traceforge/sinks/base.py
+++ b/src/traceforge/sinks/base.py
@@ -6,7 +6,14 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
-from traceforge.types import ProgressUpdate, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from traceforge.types import (
+    ProgressUpdate,
+    SessionEvent,
+    TelemetrySpan,
+    TitleUpdate,
+    TurnSummaryUpdate,
+    UsageRecord,
+)
 
 if TYPE_CHECKING:
     from traceforge.governance.envelope import EnrichedEvent
@@ -115,6 +122,13 @@ class StorageSink(ABC):
                 "dropped. Override on_title_update(update) to persist or forward them.",
                 cls,
             )
+
+    async def on_turn_summary(self, update: TurnSummaryUpdate) -> None:
+        """Handle a deterministic, versioned summary for one meaningful turn.
+
+        Default no-op. Sinks that materialize the live structural projection
+        override this and merge by ``(session_id, turn_id, version)``.
+        """
 
     async def flush(self) -> None:
         """Flush buffered writes. Default no-op."""

--- a/src/traceforge/sinks/callback.py
+++ b/src/traceforge/sinks/callback.py
@@ -7,7 +7,14 @@ import inspect
 from collections.abc import Awaitable, Callable, Iterable
 
 from traceforge.sinks.base import StorageSink
-from traceforge.types import ProgressUpdate, SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from traceforge.types import (
+    ProgressUpdate,
+    SessionEvent,
+    TelemetrySpan,
+    TitleUpdate,
+    TurnSummaryUpdate,
+    UsageRecord,
+)
 
 #: Accepted shapes for a lightweight event subscriber: a coroutine function or a
 #: plain sync callable (both taking a single :class:`SessionEvent`).
@@ -16,6 +23,7 @@ EventCallback = Callable[[SessionEvent], Awaitable[None] | None]
 #: Accepted shapes for a lightweight progress subscriber: a coroutine function or
 #: a plain sync callable (both taking a single :class:`ProgressUpdate`).
 ProgressCallback = Callable[[ProgressUpdate], Awaitable[None] | None]
+TurnSummaryCallback = Callable[[TurnSummaryUpdate], Awaitable[None] | None]
 
 #: Accepted shapes for a per-subscriber kind filter. ``None`` means "all events".
 #: A string is an exact kind, or a ``"prefix.*"`` wildcard matching that dotted
@@ -35,12 +43,14 @@ class CallbackSink(StorageSink):
         on_usage: Callable[[UsageRecord], Awaitable[None]] | None = None,
         on_title_update: Callable[[TitleUpdate], Awaitable[None]] | None = None,
         on_progress: Callable[[ProgressUpdate], Awaitable[None]] | None = None,
+        on_turn_summary: Callable[[TurnSummaryUpdate], Awaitable[None]] | None = None,
     ) -> None:
         self._on_event = on_event
         self._on_span = on_span
         self._on_usage = on_usage
         self._on_title_update = on_title_update
         self._on_progress = on_progress
+        self._on_turn_summary = on_turn_summary
 
     async def on_event(self, event: SessionEvent) -> None:
         if self._on_event is not None:
@@ -61,6 +71,10 @@ class CallbackSink(StorageSink):
     async def on_progress(self, update: ProgressUpdate) -> None:
         if self._on_progress is not None:
             await self._on_progress(update)
+
+    async def on_turn_summary(self, update: TurnSummaryUpdate) -> None:
+        if self._on_turn_summary is not None:
+            await self._on_turn_summary(update)
 
 
 def _kind_predicate(kind: KindFilter) -> Callable[[SessionEvent], bool] | None:
@@ -180,3 +194,29 @@ def as_async_progress_callback(
             await result
 
     return on_progress
+
+
+def as_async_turn_summary_callback(
+    callback: TurnSummaryCallback,
+    *,
+    to_thread: bool = False,
+) -> Callable[[TurnSummaryUpdate], Awaitable[None]]:
+    """Adapt a sync-or-async turn-summary callback to the sink protocol."""
+
+    if not callable(callback):
+        raise TypeError(f"turn summary callback must be callable, got {type(callback).__name__}")
+
+    is_async = asyncio.iscoroutinefunction(callback)
+
+    async def on_turn_summary(update: TurnSummaryUpdate) -> None:
+        if is_async:
+            await callback(update)
+            return
+        if to_thread:
+            await asyncio.to_thread(callback, update)
+            return
+        result = callback(update)
+        if inspect.isawaitable(result):
+            await result
+
+    return on_turn_summary

--- a/src/traceforge/sinks/jsonl.py
+++ b/src/traceforge/sinks/jsonl.py
@@ -7,7 +7,13 @@ import logging
 from pathlib import Path
 
 from traceforge.sinks.base import StorageSink
-from traceforge.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from traceforge.types import (
+    SessionEvent,
+    TelemetrySpan,
+    TitleUpdate,
+    TurnSummaryUpdate,
+    UsageRecord,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +124,19 @@ class JsonlSink(StorageSink):
             default=str,
         )
 
+        try:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+        except OSError as exc:
+            logger.error("JsonlSink: failed to write to %s: %s", path, exc)
+
+    async def on_turn_summary(self, update: TurnSummaryUpdate) -> None:
+        path = self._resolve_path(update.session_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(
+            {"record": "turn_summary", **update.model_dump(mode="json")},
+            default=str,
+        )
         try:
             with open(path, "a", encoding="utf-8") as f:
                 f.write(line + "\n")

--- a/src/traceforge/sinks/sqlite_output.py
+++ b/src/traceforge/sinks/sqlite_output.py
@@ -18,7 +18,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from traceforge.sinks.base import StorageSink
-from traceforge.types import SessionEvent, TelemetrySpan, TitleUpdate, UsageRecord
+from traceforge.types import (
+    SessionEvent,
+    TelemetrySpan,
+    TitleUpdate,
+    TurnSummaryUpdate,
+    UsageRecord,
+)
 
 if TYPE_CHECKING:
     from traceforge.telemetry.attribution import Anomaly, AttributionRollup
@@ -74,6 +80,22 @@ CREATE TABLE IF NOT EXISTS segment_titles (
 );
 
 CREATE INDEX IF NOT EXISTS idx_segment_titles_session ON segment_titles(session_id);
+
+CREATE TABLE IF NOT EXISTS turn_summaries (
+    session_id TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    source_event_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    version INTEGER NOT NULL,
+    activity_id TEXT,
+    step_id TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (session_id, turn_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_turn_summaries_session_sequence
+ON turn_summaries(session_id, sequence);
 
 CREATE TABLE IF NOT EXISTS context_gaps (
     id TEXT PRIMARY KEY,
@@ -436,6 +458,44 @@ class SqliteOutputSink(StorageSink):
             update.parent_id,
         )
         await asyncio.to_thread(self._write_title, params)
+
+    async def on_turn_summary(self, update: TurnSummaryUpdate) -> None:
+        params = (
+            update.session_id,
+            update.turn_id,
+            update.summary,
+            update.source_event_id,
+            update.sequence,
+            update.version,
+            update.activity_id,
+            update.step_id,
+        )
+        await asyncio.to_thread(self._write_turn_summary, params)
+
+    def _write_turn_summary(self, params: tuple) -> None:
+        """Upsert a turn summary, retaining the highest version."""
+
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO turn_summaries
+                   (session_id, turn_id, summary, source_event_id, sequence, version,
+                    activity_id, step_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(session_id, turn_id) DO UPDATE SET
+                       summary=excluded.summary,
+                       source_event_id=excluded.source_event_id,
+                       sequence=excluded.sequence,
+                       version=excluded.version,
+                       activity_id=excluded.activity_id,
+                       step_id=excluded.step_id,
+                       updated_at=datetime('now')
+                   WHERE excluded.version >= turn_summaries.version""",
+                params,
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.error("SqliteOutputSink: turn summary write failed: %s", exc)
 
     def _write_title(self, params: tuple) -> None:
         """Synchronous upsert keeping the highest version — called via to_thread."""

--- a/src/traceforge/turn_summary.py
+++ b/src/traceforge/turn_summary.py
@@ -1,0 +1,140 @@
+"""Deterministic live turn summaries over structured events."""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+
+from traceforge.phase.event_rows import event_to_feature_row
+from traceforge.phase.features import is_content_bearing
+from traceforge.title.context import payload_text
+from traceforge.title.heuristics import heuristic_title
+from traceforge.types import EventKind, SessionEvent, TurnSummaryUpdate
+
+_ACTIVITY = "activity-boundary"
+_STEP = "step-boundary"
+
+
+class TurnSummarizer:
+    """Emit one initial summary for each meaningful turn.
+
+    Explicit ``metadata.turn_id`` values are authoritative. For framework streams
+    without them, a substantive user message opens an implicit turn; a tool-only
+    stream opens one on its first meaningful event. Lifecycle/plumbing records are
+    ignored until meaningful text arrives.
+    """
+
+    def __init__(
+        self,
+        *,
+        method: str = "hybrid",
+        max_words: int = 8,
+        max_chars: int = 60,
+        history_size: int = 4096,
+    ):
+        if history_size < 1:
+            raise ValueError("history_size must be >= 1")
+        self._method = method
+        self._max_words = max_words
+        self._max_chars = max_chars
+        self._history_size = history_size
+        self._turn: dict[str, str] = {}
+        self._summarized: set[tuple[str, str]] = set()
+        self._activity: dict[str, str] = {}
+        self._step: dict[str, str] = {}
+        self._sequence: dict[str, int] = {}
+        self._forgotten: OrderedDict[str, None] = OrderedDict()
+
+    def observe(self, event: SessionEvent) -> TurnSummaryUpdate | None:
+        """Observe one event and return its turn's initial summary, if now known."""
+
+        session_id = event.session_id
+        self._forgotten.pop(session_id, None)
+        content_bearing = is_content_bearing(event_to_feature_row(event, 0))
+        self._advance_structure(event, synthesize=content_bearing)
+
+        explicit_turn = event.metadata.turn_id if event.metadata is not None else None
+        if explicit_turn:
+            turn_id = explicit_turn
+            self._turn[session_id] = turn_id
+        elif event.kind == EventKind.MESSAGE_USER:
+            turn_id = event.id
+            self._turn[session_id] = turn_id
+        else:
+            turn_id = self._turn.get(session_id)
+
+        summary = self._summary(event) if content_bearing else ""
+        if not summary:
+            return None
+        if turn_id is None:
+            turn_id = event.id
+            self._turn[session_id] = turn_id
+
+        key = (session_id, turn_id)
+        if key in self._summarized:
+            return None
+        self._summarized.add(key)
+
+        sequence = self._sequence.get(session_id, 0)
+        self._sequence[session_id] = sequence + 1
+        metadata = event.metadata
+        return TurnSummaryUpdate(
+            session_id=session_id,
+            turn_id=turn_id,
+            summary=summary,
+            source_event_id=event.id,
+            sequence=sequence,
+            activity_id=(metadata.activity_id if metadata else None)
+            or self._activity.get(session_id),
+            step_id=(metadata.step_id if metadata else None) or self._step.get(session_id),
+        )
+
+    def _advance_structure(self, event: SessionEvent, *, synthesize: bool) -> None:
+        session_id = event.session_id
+        metadata = event.metadata
+        boundary = metadata.boundary if metadata is not None else None
+        activity_id = metadata.activity_id if metadata is not None else None
+        step_id = metadata.step_id if metadata is not None else None
+
+        if activity_id:
+            self._activity[session_id] = activity_id
+        if step_id:
+            self._step[session_id] = step_id
+        if not synthesize:
+            return
+        if session_id not in self._activity or boundary == _ACTIVITY:
+            self._activity[session_id] = activity_id or event.id
+            self._step[session_id] = step_id or event.id
+        elif boundary == _STEP:
+            self._step[session_id] = step_id or event.id
+
+    def _summary(self, event: SessionEvent) -> str:
+        text = payload_text({"payload_json": json.dumps(event.payload, default=str)})
+        return heuristic_title(
+            text,
+            method=self._method,
+            max_words=self._max_words,
+            max_chars=self._max_chars,
+        )
+
+    def forget(self, session_id: str) -> None:
+        self._turn.pop(session_id, None)
+        self._activity.pop(session_id, None)
+        self._step.pop(session_id, None)
+        self._forgotten[session_id] = None
+        self._forgotten.move_to_end(session_id)
+        while len(self._forgotten) > self._history_size:
+            expired, _ = self._forgotten.popitem(last=False)
+            self._sequence.pop(expired, None)
+            self._summarized = {key for key in self._summarized if key[0] != expired}
+
+    def clear(self) -> None:
+        self._turn.clear()
+        self._activity.clear()
+        self._step.clear()
+        self._sequence.clear()
+        self._summarized.clear()
+        self._forgotten.clear()
+
+
+__all__ = ["TurnSummarizer"]

--- a/src/traceforge/types.py
+++ b/src/traceforge/types.py
@@ -209,7 +209,7 @@ class EventMetadata(FrozenModel):
     run_id: str | None = None  # top-level run/session identifier
 
     # --- Ordering ---
-    sequence: int | None = None  # monotonic ordering within a stream
+    sequence: int | None = Field(default=None, ge=0)  # monotonic ordering within a stream
     namespace: tuple[str, ...] | None = None  # scope path (subgraph, subagent)
     partial: bool = False  # True if this is a streaming chunk
 
@@ -239,6 +239,10 @@ class EventMetadata(FrozenModel):
     tool_display: str | None = None
     motivation: ToolMotivation | None = None
     duration_ms: float | None = None
+    # Concrete file targets normalized by Enricher against its declared
+    # workspace_root. The original payload and each target's raw_path remain
+    # untouched for provenance.
+    file_targets: tuple["FileTarget", ...] = Field(default_factory=tuple)
 
     # --- Governance (populated by enrichment pipeline before sink emission) ---
     governance: SessionMeta | None = None
@@ -255,7 +259,14 @@ class EventMetadata(FrozenModel):
 
 
 class SessionEvent(FrozenModel):
-    """The universal event type. Every adapter produces these."""
+    """The universal event type. Every adapter produces these.
+
+    ``id`` is the stable event identity. ``metadata.sequence`` is the canonical
+    optional ordering key within a producer stream; it is deliberately not
+    duplicated into ``payload``. The :attr:`sequence` accessor makes that
+    canonical metadata field convenient for live consumers while JSON round-trips
+    preserve its one wire location.
+    """
 
     id: str = Field(default_factory=_uuid4_str)
     kind: str  # Open string — use EventKind constants for canonical kinds
@@ -264,6 +275,26 @@ class SessionEvent(FrozenModel):
     payload: dict[str, Any]
     raw_event: dict[str, Any] | None = None  # Original event data, verbatim
     metadata: EventMetadata = Field(default_factory=EventMetadata)
+
+    @property
+    def sequence(self) -> int | None:
+        """Canonical producer-stream sequence from :attr:`metadata`."""
+
+        return self.metadata.sequence
+
+
+class FileTarget(FrozenModel):
+    """A file target with normalized identity and untouched source provenance.
+
+    ``path`` uses forward slashes. When a ``workspace_root`` was declared and
+    the target is inside it, ``path`` is root-relative and ``inside_root`` is
+    ``True``. Outside-root targets remain normalized absolute paths and carry
+    ``inside_root=False``. Without a root, ``inside_root`` is ``None``.
+    """
+
+    raw_path: str
+    path: str
+    inside_root: bool | None = None
 
 
 # ─── Trace-native attribution dimensions ────────────────────────────────────
@@ -401,3 +432,22 @@ class ProgressUpdate(FrozenModel):
     headline: str
     sequence: int = Field(default=0, ge=0)
     parent_id: str | None = None  # a step's activity segment id, for tree rebuild
+
+
+class TurnSummaryUpdate(FrozenModel):
+    """A deterministic, versioned summary for one meaningful agent turn.
+
+    The pipeline emits version 1 from the first meaningful event in a turn.
+    Refiners publish later versions with the same ``(session_id, turn_id)``;
+    consumers merge by keeping the highest version. ``activity_id`` and
+    ``step_id`` link the turn to TraceForge's native structural projection.
+    """
+
+    session_id: str
+    turn_id: str
+    summary: str
+    source_event_id: str
+    sequence: int = Field(ge=0)
+    version: int = Field(default=1, ge=1)
+    activity_id: str | None = None
+    step_id: str | None = None

--- a/tests/e2e/test_sink_sqlite_e2e.py
+++ b/tests/e2e/test_sink_sqlite_e2e.py
@@ -40,6 +40,7 @@ from traceforge.types import (
     EventMetadata,
     TelemetrySpan,
     TitleUpdate,
+    TurnSummaryUpdate,
     UsageRecord,
 )
 
@@ -150,6 +151,50 @@ async def test_sqlite_title_upsert_keeps_highest_version(tmp_path: Path) -> None
         ("seg-1", "activity"),
     )
     assert rows == [("final", 3)]
+
+
+@pytest.mark.e2e
+async def test_sqlite_turn_summary_upsert_keeps_highest_version(tmp_path: Path) -> None:
+    db = tmp_path / "turns.db"
+    sink = SqliteOutputSink(path=str(db))
+    initial = TurnSummaryUpdate(
+        session_id="s",
+        turn_id="turn-1",
+        summary="initial",
+        source_event_id="event-1",
+        sequence=0,
+        activity_id="activity-1",
+        step_id="step-1",
+    )
+    await sink.on_turn_summary(initial)
+    await sink.on_turn_summary(initial.model_copy(update={"summary": "refined", "version": 3}))
+    await sink.on_turn_summary(initial.model_copy(update={"summary": "stale", "version": 2}))
+    await sink.close()
+
+    rows = _query(
+        db,
+        "SELECT summary, version, activity_id, step_id FROM turn_summaries "
+        "WHERE session_id = ? AND turn_id = ?",
+        ("s", "turn-1"),
+    )
+    assert rows == [("refined", 3, "activity-1", "step-1")]
+
+
+@pytest.mark.e2e
+async def test_sqlite_event_metadata_preserves_canonical_sequence(tmp_path: Path) -> None:
+    db = tmp_path / "sequence.db"
+    sink = SqliteOutputSink(path=str(db))
+    event = make_event(id="stable-event", metadata=EventMetadata(sequence=12))
+    await sink.on_event(event)
+    await sink.close()
+
+    [(event_id, metadata_json)] = _query(
+        db,
+        "SELECT id, metadata_json FROM enriched_events WHERE id = ?",
+        ("stable-event",),
+    )
+    assert event_id == event.id
+    assert json.loads(metadata_json)["sequence"] == 12
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_classify.py
+++ b/tests/unit/test_classify.py
@@ -49,6 +49,7 @@ class TestNormalizeToolName:
 
     def test_alias_resolution(self):
         assert normalize_tool_name("powershell") == "shell"
+        assert normalize_tool_name("pwsh") == "shell"
         assert normalize_tool_name("read_file") == "view"
         assert normalize_tool_name("str_replace_editor") == "edit"
         assert normalize_tool_name("execute_command") == "shell"
@@ -114,6 +115,7 @@ class TestClassifyTool:
 
     def test_alias_classified(self):
         assert classify_tool("powershell").mechanism == "process.shell"
+        assert classify_tool("pwsh").mechanism == "process.shell"
         assert classify_tool("read_file").mechanism == "filesystem"
         assert classify_tool("str_replace_editor").mechanism == "filesystem"
         assert classify_tool("greptool").mechanism == "filesystem"

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -256,6 +256,46 @@ class TestToolClassification:
         assert result.metadata.classification.has_action("retrieve")
         assert result.metadata.tool_display == "shell"
 
+    def test_path_and_glob_both_contribute_to_risk(self):
+        enricher = Enricher(workspace_root="/srv/repo")
+        event = _make_tool_complete(
+            tool_name="search_files",
+            arguments={"path": "/srv/repo/src", "glob": "**/*.pem"},
+        )
+
+        result = enricher.process(event)
+
+        assert result is not None
+        assert result.payload["arguments"] == {
+            "path": "/srv/repo/src",
+            "glob": "**/*.pem",
+        }
+        assert result.metadata.file_targets[0].path == "src"
+        assert result.metadata.classification.mechanism == "filesystem"
+        assert result.metadata.classification.has_action("retrieve.search")
+        assert result.payload["_enrichment"]["risk"]["score"] >= 21
+        assert result.payload["_enrichment"]["risk"]["level"] == "caution"
+
+    def test_path_and_pattern_both_contribute_to_risk(self):
+        enricher = Enricher(workspace_root="/srv/repo")
+        event = _make_tool_complete(
+            tool_name="search_files",
+            arguments={"path": "/srv/repo/src", "pattern": "*.key"},
+        )
+
+        result = enricher.process(event)
+
+        assert result is not None
+        assert result.payload["arguments"] == {
+            "path": "/srv/repo/src",
+            "pattern": "*.key",
+        }
+        assert result.metadata.file_targets[0].path == "src"
+        assert result.metadata.classification.mechanism == "filesystem"
+        assert result.metadata.classification.has_action("retrieve.search")
+        assert result.payload["_enrichment"]["risk"]["score"] >= 21
+        assert result.payload["_enrichment"]["risk"]["level"] == "caution"
+
     def test_custom_classification_overrides_defaults(self):
         custom = Classification(mechanism="custom.write", effect="mutating")
         enricher = Enricher(custom_classifications={"edit": custom})

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -160,6 +160,19 @@ class TestToolPairing:
         assert result.payload["arguments"] == {"path": "/foo.py"}
         assert result.payload["result"] == "success"
 
+    def test_start_file_targets_survive_pathless_completion(self):
+        enricher = Enricher(workspace_root=r"C:\repo")
+        raw_path = r"C:\repo\src\api.py"
+        start = _make_tool_start(arguments={"path": raw_path})
+        complete = _make_tool_complete(result="success")
+
+        enricher.process(start)
+        result = enricher.process(complete)
+
+        assert result is not None
+        assert result.metadata.file_targets[0].raw_path == raw_path
+        assert result.metadata.file_targets[0].path == "src/api.py"
+
 
 # =============================================================================
 # Duration Calculation Tests
@@ -214,6 +227,34 @@ class TestToolClassification:
         cls = flushed[0].metadata.classification
         assert cls is not None
         assert cls.mechanism == "unknown"
+
+    def test_powershell_is_native_command_execution_with_display(self):
+        enricher = Enricher()
+        event = _make_tool_complete(
+            tool_name="powershell",
+            arguments={"command": "Get-ChildItem -Force"},
+        )
+
+        result = enricher.process(event)
+
+        assert result is not None
+        assert result.metadata.classification.mechanism == "process.shell"
+        assert result.metadata.classification.has_action("retrieve")
+        assert result.metadata.tool_display == "shell"
+
+    def test_pwsh_uses_powershell_command_classifier(self):
+        enricher = Enricher()
+        event = _make_tool_complete(
+            tool_name="pwsh",
+            arguments={"command": "Get-ChildItem -Force"},
+        )
+
+        result = enricher.process(event)
+
+        assert result is not None
+        assert result.metadata.classification.mechanism == "process.shell"
+        assert result.metadata.classification.has_action("retrieve")
+        assert result.metadata.tool_display == "shell"
 
     def test_custom_classification_overrides_defaults(self):
         custom = Classification(mechanism="custom.write", effect="mutating")

--- a/tests/unit/test_event_contract.py
+++ b/tests/unit/test_event_contract.py
@@ -1,0 +1,49 @@
+"""Stable event identity/order and wire serialization contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from traceforge import EventMetadata, SessionEvent, event_to_sse
+from tests.conftest import make_event
+
+
+def test_sequence_has_one_canonical_wire_location() -> None:
+    event = make_event(id="event-42", metadata=EventMetadata(sequence=17))
+
+    assert event.id == "event-42"
+    assert event.sequence == 17
+    wire = event.model_dump(mode="json")
+    assert wire["metadata"]["sequence"] == 17
+    assert "sequence" not in wire
+    assert "seq" not in wire["payload"]
+
+
+def test_event_json_round_trip_preserves_identity_and_sequence() -> None:
+    event = make_event(id="stable-id", metadata=EventMetadata(sequence=9))
+
+    restored = SessionEvent.model_validate_json(event.model_dump_json())
+
+    assert restored.id == event.id
+    assert restored.sequence == 9
+    assert restored == event
+
+
+def test_negative_sequence_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        EventMetadata(sequence=-1)
+
+
+def test_sse_frame_uses_event_id_and_canonical_json() -> None:
+    event = make_event(id="evt-sse", metadata=EventMetadata(sequence=3))
+
+    frame = event_to_sse(event)
+    lines = frame.rstrip("\n").splitlines()
+
+    assert lines[:2] == [f"id: {event.id}", f"event: {event.kind}"]
+    payload = json.loads("\n".join(line.removeprefix("data: ") for line in lines[2:]))
+    restored = SessionEvent.model_validate(payload)
+    assert restored.id == "evt-sse"
+    assert restored.sequence == 3

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -51,6 +51,22 @@ def test_relative_escape_is_outside_root() -> None:
     assert target.inside_root is False
 
 
+def test_posix_absolute_target_with_relative_root_is_outside() -> None:
+    raw = "/srv/repo/src/api.py"
+    event = make_event(
+        kind=EventKind.TOOL_CALL_COMPLETED,
+        payload={"tool_name": "edit", "arguments": {"path": raw}},
+    )
+
+    enriched = Enricher(workspace_root="repo").process(event)
+
+    assert enriched is not None
+    assert enriched.payload["arguments"]["path"] == raw
+    assert enriched.metadata.file_targets[0].raw_path == raw
+    assert enriched.metadata.file_targets[0].path == raw
+    assert enriched.metadata.file_targets[0].inside_root is False
+
+
 def test_enricher_stamps_normalized_target_without_rewriting_payload() -> None:
     raw = r"C:\Work\Repo\tests\test_api.py"
     event = make_event(

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,73 @@
+"""File-target normalization across host path dialects."""
+
+from __future__ import annotations
+
+from traceforge import Enricher, EventKind, normalize_file_target
+from tests.conftest import make_event
+
+
+def test_windows_absolute_path_is_root_relative_and_preserves_raw() -> None:
+    raw = r"c:\Work\Repo\src\api.py"
+    target = normalize_file_target(raw, r"C:\work\repo")
+
+    assert target.raw_path == raw
+    assert target.path == "src/api.py"
+    assert target.inside_root is True
+
+
+def test_windows_mixed_separators_and_drive_case_normalize() -> None:
+    target = normalize_file_target(r"c:/Work\Repo/src\api.py", r"C:\Work\Repo")
+
+    assert target.path == "src/api.py"
+    assert target.inside_root is True
+
+
+def test_windows_sibling_prefix_is_outside_root() -> None:
+    target = normalize_file_target(r"C:\work\repository\file.py", r"C:\work\repo")
+
+    assert target.path == "C:/work/repository/file.py"
+    assert target.inside_root is False
+
+
+def test_windows_different_drive_is_outside_root() -> None:
+    target = normalize_file_target(r"D:\work\repo\file.py", r"C:\work\repo")
+
+    assert target.path == "D:/work/repo/file.py"
+    assert target.inside_root is False
+
+
+def test_posix_inside_and_outside_root() -> None:
+    inside = normalize_file_target("/srv/repo/src/api.py", "/srv/repo")
+    outside = normalize_file_target("/srv/repository/api.py", "/srv/repo")
+
+    assert (inside.path, inside.inside_root) == ("src/api.py", True)
+    assert (outside.path, outside.inside_root) == ("/srv/repository/api.py", False)
+
+
+def test_relative_escape_is_outside_root() -> None:
+    target = normalize_file_target("../secret.txt", "/srv/repo")
+
+    assert target.path == "/srv/secret.txt"
+    assert target.inside_root is False
+
+
+def test_enricher_stamps_normalized_target_without_rewriting_payload() -> None:
+    raw = r"C:\Work\Repo\tests\test_api.py"
+    event = make_event(
+        kind=EventKind.TOOL_CALL_COMPLETED,
+        payload={
+            "tool_name": "edit",
+            "arguments": {"path": raw},
+        },
+    )
+
+    enriched = Enricher(workspace_root=r"c:\work\repo").process(event)
+
+    assert enriched is not None
+    assert enriched.payload["arguments"]["path"] == raw
+    assert len(enriched.metadata.file_targets) == 1
+    target = enriched.metadata.file_targets[0]
+    assert target.raw_path == raw
+    assert target.path == "tests/test_api.py"
+    assert target.inside_root is True
+    assert "artifact.test_code" in enriched.metadata.classification.scope

--- a/tests/unit/test_turn_summary.py
+++ b/tests/unit/test_turn_summary.py
@@ -1,0 +1,225 @@
+"""Deterministic per-turn summary projection."""
+
+from __future__ import annotations
+
+from traceforge import (
+    EventKind,
+    EventMetadata,
+    EventPipeline,
+    TurnSummaryUpdate,
+)
+from tests.conftest import make_event
+
+
+class _FakeTitle:
+    def candidates(self, _context, **_kwargs):
+        return ["Title"]
+
+
+def _event(
+    event_id: str,
+    turn_id: str,
+    content: str,
+    *,
+    boundary: str | None = None,
+    kind: str = EventKind.MESSAGE_USER,
+):
+    return make_event(
+        id=event_id,
+        session_id="job",
+        kind=kind,
+        payload={"content": content},
+        metadata=EventMetadata(turn_id=turn_id, boundary=boundary),
+    )
+
+
+async def test_five_meaningful_turns_with_twenty_eight_tools_emit_five_summaries() -> None:
+    summaries: list[TurnSummaryUpdate] = []
+    pipeline = EventPipeline(
+        sinks=[],
+        enable_phase=False,
+        enable_boundary=False,
+        enable_title=False,
+    )
+    pipeline.subscribe(on_turn_summary=summaries.append)
+
+    tools_remaining = 28
+    events = []
+    for turn in range(5):
+        boundary = "activity-boundary" if turn in (0, 3) else "step-boundary"
+        events.append(
+            _event(
+                f"user-{turn}", f"turn-{turn}", f"implement feature area {turn}", boundary=boundary
+            )
+        )
+        count = 6 if turn < 3 else 5
+        for tool in range(min(count, tools_remaining)):
+            events.append(
+                _event(
+                    f"tool-{turn}-{tool}",
+                    f"turn-{turn}",
+                    f"completed tool operation {turn} {tool}",
+                    kind=EventKind.TOOL_CALL_COMPLETED,
+                )
+            )
+            tools_remaining -= 1
+
+    assert tools_remaining == 0
+    for event in events:
+        await pipeline.push(event)
+    await pipeline.close()
+
+    assert [summary.turn_id for summary in summaries] == [f"turn-{i}" for i in range(5)]
+    assert [summary.sequence for summary in summaries] == list(range(5))
+    assert all(summary.version == 1 for summary in summaries)
+    assert summaries[0].activity_id == "user-0"
+    assert summaries[1].activity_id == "user-0"
+    assert summaries[1].step_id == "user-1"
+    assert summaries[3].activity_id == "user-3"
+
+
+async def test_plumbing_defers_summary_until_first_meaningful_event() -> None:
+    summaries: list[TurnSummaryUpdate] = []
+    pipeline = EventPipeline(
+        sinks=[],
+        enable_phase=False,
+        enable_boundary=False,
+        enable_title=False,
+    )
+    pipeline.subscribe(on_turn_summary=summaries.append)
+
+    await pipeline.push(
+        make_event(
+            id="turn-start",
+            session_id="job",
+            kind=EventKind.TURN_STARTED,
+            payload={},
+            metadata=EventMetadata(turn_id="turn-1"),
+        )
+    )
+    await pipeline.push(_event("tool-1", "turn-1", "run repository security checks"))
+    await pipeline.close()
+
+    assert len(summaries) == 1
+    assert summaries[0].turn_id == "turn-1"
+    assert summaries[0].source_event_id == "tool-1"
+
+
+async def test_hook_plumbing_cannot_consume_turn_summary() -> None:
+    summaries: list[TurnSummaryUpdate] = []
+    pipeline = EventPipeline(
+        sinks=[],
+        enable_phase=False,
+        enable_boundary=False,
+        enable_title=False,
+    )
+    pipeline.subscribe(on_turn_summary=summaries.append)
+
+    await pipeline.push(
+        make_event(
+            id="hook",
+            session_id="job",
+            kind="hook.started",
+            payload={"hook_name": "PreToolUse"},
+            metadata=EventMetadata(turn_id="turn-1"),
+        )
+    )
+    await pipeline.push(
+        _event(
+            "tool-1",
+            "turn-1",
+            "run repository security checks",
+            kind=EventKind.TOOL_CALL_COMPLETED,
+        )
+    )
+    await pipeline.close()
+
+    assert len(summaries) == 1
+    assert summaries[0].source_event_id == "tool-1"
+    assert summaries[0].activity_id == "tool-1"
+    assert summaries[0].step_id == "tool-1"
+
+
+async def test_eviction_resume_does_not_repeat_initial_summary() -> None:
+    summaries: list[TurnSummaryUpdate] = []
+    pipeline = EventPipeline(
+        sinks=[],
+        enable_phase=False,
+        enable_boundary=False,
+        enable_title=False,
+        max_sessions=1,
+    )
+    pipeline.subscribe(on_turn_summary=summaries.append)
+
+    await pipeline.push(_event("a-1", "turn-a", "implement alpha", boundary="activity-boundary"))
+    await pipeline.push(
+        make_event(
+            id="b-1",
+            session_id="other",
+            kind=EventKind.MESSAGE_USER,
+            payload={"content": "implement beta"},
+            metadata=EventMetadata(turn_id="turn-b"),
+        )
+    )
+    await pipeline.push(_event("a-2", "turn-a", "continue alpha"))
+    await pipeline.close()
+
+    assert [(update.session_id, update.turn_id, update.sequence) for update in summaries] == [
+        ("job", "turn-a", 0),
+        ("other", "turn-b", 0),
+    ]
+
+
+async def test_title_stamped_event_and_summary_share_structure_ids() -> None:
+    from traceforge.title import TitleInferencer
+
+    events = []
+    summaries: list[TurnSummaryUpdate] = []
+    pipeline = EventPipeline(
+        sinks=[],
+        enable_phase=False,
+        enable_boundary=False,
+        title_inferencer=TitleInferencer(model=_FakeTitle()),
+    )
+    pipeline.subscribe(on_event=events.append, on_turn_summary=summaries.append)
+    event = make_event(
+        id="event-1",
+        session_id="job",
+        kind=EventKind.MESSAGE_USER,
+        payload={"content": "implement the retry policy"},
+        metadata=EventMetadata(
+            turn_id="turn-1",
+            activity_id="upstream-activity",
+            step_id="upstream-step",
+        ),
+    )
+
+    await pipeline.push(event)
+    await pipeline.close()
+
+    assert events[0].metadata.activity_id == "event-1"
+    assert events[0].metadata.step_id == "event-1"
+    assert summaries[0].activity_id == events[0].metadata.activity_id
+    assert summaries[0].step_id == events[0].metadata.step_id
+
+
+async def test_higher_version_refinement_uses_same_public_channel() -> None:
+    summaries: list[TurnSummaryUpdate] = []
+    pipeline = EventPipeline(
+        sinks=[],
+        enable_phase=False,
+        enable_boundary=False,
+        enable_title=False,
+    )
+    pipeline.subscribe(on_turn_summary=summaries.append)
+
+    await pipeline.push(_event("user-1", "turn-1", "add retry handling"))
+    initial = summaries[0]
+    refined = initial.model_copy(update={"summary": "Add resilient retry handling", "version": 2})
+    await pipeline.push_turn_summary(refined)
+    await pipeline.close()
+
+    assert [(update.version, update.summary) for update in summaries] == [
+        (1, initial.summary),
+        (2, "Add resilient retry handling"),
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -4174,7 +4174,7 @@ source = { editable = "packages/traceforge-title-model" }
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.2.0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -4174,7 +4174,7 @@ source = { editable = "packages/traceforge-title-model" }
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- define `SessionEvent.id` as stable identity and `EventMetadata.sequence` as canonical stream order, with an accessor and canonical SSE serialization
- emit one deterministic, versioned `TurnSummaryUpdate` per meaningful turn with activity/step linkage and refinement support
- normalize Windows/POSIX file targets relative to a declared workspace root while preserving raw provenance
- preserve the complete ordered risk-target domain when normalized paths coexist with `pattern`/`glob` inputs
- classify both `powershell` and `pwsh` as native shell command execution
- persist and forward the new contracts through SDK and bundled sinks

## Ownership

- `payload.seq` consumption is integration misuse; TraceForge identity/order are `event.id` and `event.metadata.sequence`
- missing meaningful-turn summaries, absent normalized file-target metadata, and missing `pwsh` canonical mapping are TraceForge-owned defects fixed here
- existing `powershell` mapping was already present; direct command-classification coverage now locks it down

## Security and path hardening

- risk scoring uses the normalized metadata target domain, which includes concrete paths plus `pattern` and `glob` inputs in deterministic first-seen order while preserving raw provenance
- POSIX absolute/relative root-form mismatches are classified as outside-root targets instead of raising from `commonpath`

## Validation

- focused target/risk regression suite: 177 passed
- full suite: 3,716 passed, 10 skipped
- Ruff 0.15.20 check and format check: clean
- release metadata consistency: `traceforge-toolkit` root project and editable lock entry are `0.1.3`; independent `traceforge-title-model` remains `0.2.0`
- package build: `traceforge_toolkit-0.1.3.tar.gz` and `traceforge_toolkit-0.1.3-py3-none-any.whl`; packaged model weights verified as real binaries

## Consumer contract

Consume commit `cba9810` for the post-merge branch corrections. The package coordinate is `traceforge-toolkit==0.1.3` and its release tag is `v0.1.3`; the independent title-model package remains `0.2.0`. No tag or release was created by these corrections.