### PR TITLE
Release traceforge-toolkit 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   premium-request count, not dollars — never synthesized). Ingestion-side only; usage
   rides `usage_records` (Cost lens), never the enriched-events timeline.
 
+## [0.1.4] - 2026-08-02
+
+### Fixed
+
+- Native tool risk now consumes the canonical `metadata.file_targets` collection,
+  including normalized path, pattern, and glob selectors with raw provenance in
+  deterministic first-seen order. POSIX absolute targets paired with relative workspace
+  roots are safely classified as outside the root instead of raising.
+
 ## [0.1.3] - 2026-08-02
 
 ### Added
@@ -156,7 +165,8 @@ risk-scored, governed event streams with opt-in tool-call gating.
 - The gate IPC server binds a POSIX `AF_UNIX` socket; on Windows that path is skipped
   and a localhost TCP socket is used instead.
 
-[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/dfinson/traceforge/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/dfinson/traceforge/compare/v0.1.2...v0.1.3
 [0.1.1]: https://github.com/dfinson/traceforge/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/dfinson/traceforge/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "traceforge-toolkit"
-version = "0.1.3"
+version = "0.1.4"
 description = "Framework-agnostic, CPU-only pipeline that forges AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"
 license = "MIT"

--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -445,7 +445,7 @@ class Enricher:
 
     def _assess_tool_risk(self, event: SessionEvent, cls: Classification) -> SessionEvent:
         """Compute risk score for a native/MCP tool and store in payload._enrichment."""
-        targets = _risk_targets(event)
+        targets = [target.path for target in event.metadata.file_targets]
 
         risk = assess_tool_risk(
             classification=cls,
@@ -595,7 +595,7 @@ _INFRA_DIRS = frozenset({"helm", "charts", "k8s", "kubernetes", "terraform", "in
 _CONTAINER_FILES = frozenset({"docker-compose.yml", "docker-compose.yaml", ".dockerignore"})
 _DOC_FILES = frozenset({"readme.md", "contributing.md", "changelog.md", "license.md"})
 _PAYLOAD_PATH_KEYS = ("path", "file_path", "file", "filename")
-_RISK_TARGET_KEYS = (*_PAYLOAD_PATH_KEYS, "pattern", "glob")
+_PAYLOAD_TARGET_KEYS = (*_PAYLOAD_PATH_KEYS, "pattern", "glob")
 
 
 def _infer_scope_from_path(path: str) -> str | None:
@@ -646,9 +646,9 @@ def _extract_path_from_payload(payload: dict) -> str:
 
 
 def _extract_file_targets_from_payload(payload: dict) -> list[str]:
-    """Extract concrete file target strings from payload and arguments."""
+    """Extract native file targets and selectors from payload and arguments."""
 
-    return _extract_payload_targets(payload, _PAYLOAD_PATH_KEYS)
+    return _extract_payload_targets(payload, _PAYLOAD_TARGET_KEYS)
 
 
 def _extract_payload_targets(payload: dict, keys: tuple[str, ...]) -> list[str]:
@@ -747,21 +747,6 @@ def _extract_tool_call_id(event: SessionEvent) -> str | None:
     if value is not None and not isinstance(value, str):
         logger.debug("Ignoring non-string tool_call_id: %r", value)
     return None
-
-
-def _risk_targets(event: SessionEvent) -> list[str]:
-    """Return one ordered risk-target domain with concrete paths normalized."""
-
-    normalized_paths = {target.raw_path: target.path for target in event.metadata.file_targets}
-    targets: list[str] = []
-    for raw_target in _extract_payload_targets(event.payload, _RISK_TARGET_KEYS):
-        target = normalized_paths.get(raw_target, raw_target)
-        if target not in targets:
-            targets.append(target)
-    for file_target in event.metadata.file_targets:
-        if file_target.path not in targets:
-            targets.append(file_target.path)
-    return targets
 
 
 def _merge_metadata(

--- a/src/traceforge/paths.py
+++ b/src/traceforge/paths.py
@@ -70,7 +70,10 @@ def normalize_file_target(raw_path: str, workspace_root: str | None = None) -> F
     if normalized_root is None:
         return FileTarget(raw_path=raw_path, path=normalized)
     try:
-        inside = posixpath.commonpath([normalized, normalized_root]) == normalized_root
+        inside = (
+            posixpath.isabs(normalized) == posixpath.isabs(normalized_root)
+            and posixpath.commonpath([normalized, normalized_root]) == normalized_root
+        )
     except ValueError:
         inside = False
     path = posixpath.relpath(normalized, normalized_root) if inside else normalized

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -270,7 +270,12 @@ class TestToolClassification:
             "path": "/srv/repo/src",
             "glob": "**/*.pem",
         }
-        assert result.metadata.file_targets[0].path == "src"
+        assert tuple(
+            (target.raw_path, target.path) for target in result.metadata.file_targets
+        ) == (
+            ("/srv/repo/src", "src"),
+            ("**/*.pem", "**/*.pem"),
+        )
         assert result.metadata.classification.mechanism == "filesystem"
         assert result.metadata.classification.has_action("retrieve.search")
         assert result.payload["_enrichment"]["risk"]["score"] >= 21
@@ -290,7 +295,12 @@ class TestToolClassification:
             "path": "/srv/repo/src",
             "pattern": "*.key",
         }
-        assert result.metadata.file_targets[0].path == "src"
+        assert tuple(
+            (target.raw_path, target.path) for target in result.metadata.file_targets
+        ) == (
+            ("/srv/repo/src", "src"),
+            ("*.key", "*.key"),
+        )
         assert result.metadata.classification.mechanism == "filesystem"
         assert result.metadata.classification.has_action("retrieve.search")
         assert result.payload["_enrichment"]["risk"]["score"] >= 21

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -270,9 +270,7 @@ class TestToolClassification:
             "path": "/srv/repo/src",
             "glob": "**/*.pem",
         }
-        assert tuple(
-            (target.raw_path, target.path) for target in result.metadata.file_targets
-        ) == (
+        assert tuple((target.raw_path, target.path) for target in result.metadata.file_targets) == (
             ("/srv/repo/src", "src"),
             ("**/*.pem", "**/*.pem"),
         )
@@ -295,9 +293,7 @@ class TestToolClassification:
             "path": "/srv/repo/src",
             "pattern": "*.key",
         }
-        assert tuple(
-            (target.raw_path, target.path) for target in result.metadata.file_targets
-        ) == (
+        assert tuple((target.raw_path, target.path) for target in result.metadata.file_targets) == (
             ("/srv/repo/src", "src"),
             ("*.key", "*.key"),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -4174,7 +4174,7 @@ source = { editable = "packages/traceforge-title-model" }
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- make normalized `EventMetadata.file_targets` the single ordered target source for native risk, including path, file path, file, filename, pattern, and glob selectors with raw provenance
- classify POSIX absolute-target/relative-root mismatches as outside the workspace without raising
- release the root `traceforge-toolkit` package as 0.1.4 and document the patch; leave `traceforge-title-model` at 0.2.0

## Validation

- exact target regressions: 3 passed
- focused enrichment/path/risk suite: 177 passed
- full suite: 3716 passed, 10 skipped
- Ruff 0.15.20 check and format check
- root sdist/wheel build and lock/package/artifact version consistency