### PR TITLE
Add per-session finalization APIs (0.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-08-04
+
 ### Added
 
+- Per-session finalization, so a long-lived host can retire **one** session while
+  the rest keep streaming. `await EventPipeline.finalize_session(session_id)`
+  drains and emits everything that session still holds — its buffered enricher
+  orphans, its held leading plumbing, and the title updates for its trailing open
+  activity — awaits that session's in-flight title refinements, then reclaims only
+  that session's state (streams, progress/turn-summary state, recency entry,
+  lock). Every other session is untouched, the pipeline stays open (sinks are
+  neither flushed nor closed), repeated or unknown session ids are clean no-ops,
+  and the work runs under the session's own lock so it is safe alongside
+  concurrent pushes and finalizes. `Enricher.flush_session(session_id)` is the
+  matching public per-session orphan drain. `flush()` / `close()` keep their
+  global terminal semantics and now reuse the same per-session primitive.
 - **AI Units (AIU / "AI credits") are now the primary Copilot consumption signal**,
   captured end-to-end. The `copilot` preprocessor carries each model's
   `session.shutdown.data.modelMetrics.<model>.totalNanoAiu` (nano-AIU) onto its
@@ -165,7 +179,8 @@ risk-scored, governed event streams with opt-in tool-call gating.
 - The gate IPC server binds a POSIX `AF_UNIX` socket; on Windows that path is skipped
   and a localhost TCP socket is used instead.
 
-[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/dfinson/traceforge/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/dfinson/traceforge/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/dfinson/traceforge/compare/v0.1.2...v0.1.3
 [0.1.1]: https://github.com/dfinson/traceforge/compare/v0.1.0...v0.1.1

--- a/SPEC.md
+++ b/SPEC.md
@@ -599,6 +599,7 @@ class Enricher:
 
     def process(self, event: SessionEvent) -> SessionEvent | list[SessionEvent] | None: ...
     def flush(self) -> list[SessionEvent]: ...
+    def flush_session(self, session_id: str) -> list[SessionEvent]: ...
 `
 
 ### Enrichment Steps
@@ -607,7 +608,7 @@ class Enricher:
    targets into `metadata.file_targets` using host-independent Windows/POSIX
    normalization. Raw payload paths are never rewritten.
 
-2. **Tool call pairing**: Buffers `TOOL_CALL_STARTED` events, pairs them with matching `TOOL_CALL_COMPLETED` by `tool_call_id`. Merges payloads. Emits orphan starts on displacement or flush.
+2. **Tool call pairing**: Buffers `TOOL_CALL_STARTED` events, pairs them with matching `TOOL_CALL_COMPLETED` by `tool_call_id`. Merges payloads. Emits orphan starts on displacement or flush. `flush()` drains every session's buffered starts; `flush_session(session_id)` drains only that session's, in buffer order, leaving interleaved sessions untouched (idempotent for a repeated or unknown id).
 
 3. **Duration computation**: Calculates `metadata.duration_ms` from timestamp difference of start/complete pairs.
 
@@ -804,6 +805,7 @@ class EventPipeline:
     async def push_span(self, span: TelemetrySpan) -> None: ...
     async def push_usage(self, usage: UsageRecord) -> None: ...
     async def push_turn_summary(self, update: TurnSummaryUpdate) -> None: ...
+    async def finalize_session(self, session_id: str) -> None: ...
     async def flush(self) -> None: ...
     async def close(self) -> None: ...
 `
@@ -813,7 +815,20 @@ class EventPipeline:
 - **Enrichment**: If an enricher is configured, events pass through `enricher.process()` before reaching sinks. Enricher failures fall through gracefully (raw event passed to sinks).
 - **Error isolation**: Each sink call is wrapped in `asyncio.gather(return_exceptions=True)`. One failing sink does not block others.
 - **Fan-out**: All sinks receive every event concurrently.
-- **Flush**: Drains enricher buffer (unpaired tool starts), then flushes all sinks.
+- **Finalize session**: `finalize_session(session_id)` is the per-session analogue
+  of flush, for hosts that retire one session while others keep streaming. It
+  emits everything that session still holds — its buffered enricher orphans
+  (`Enricher.flush_session(session_id)`), its held leading plumbing, and the
+  boundary/title updates for its trailing open activity — awaits that session's
+  in-flight title refinements, then reclaims only that session's state
+  (phase/boundary/title streams, progress and turn-summary state, recency entry,
+  lock). It is **not** terminal for the pipeline: sinks are neither flushed nor
+  closed and other sessions are untouched. Idempotent for a repeated or unknown
+  `session_id`, and run under the session's own lock, so it is safe alongside
+  concurrent pushes and finalizes.
+- **Flush**: Drains enricher buffer (unpaired tool starts), finalizes every
+  session still holding live state through the same per-session primitive, then
+  flushes all sinks. Terminal and global — no `push` may run during or after it.
 - **Close**: Flush + close all sinks (also error-isolated).
 - **Turn projection**: one deterministic version-1 `TurnSummaryUpdate` is emitted
   for the first meaningful event of every turn. Later refinements use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "traceforge-toolkit"
-version = "0.1.4"
+version = "0.1.5"
 description = "Framework-agnostic, CPU-only pipeline that forges AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"
 license = "MIT"

--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -204,7 +204,7 @@ class Enricher:
             # ``flush_on_session_end`` (default True) gates this drain; disabling it
             # leaves the starts pending, subject only to the size/TTL bounds and the
             # final Enricher.flush — they are still never dropped.
-            orphans = self._flush_session(event.session_id) if self._flush_on_session_end else []
+            orphans = self.flush_session(event.session_id) if self._flush_on_session_end else []
             event = self._set_visibility(event)
             event = self._set_phase(event)
             result = [*orphans, event] if orphans else event
@@ -234,12 +234,24 @@ class Enricher:
         self._pending.clear()
         return result
 
-    def _flush_session(self, session_id: str) -> list[SessionEvent]:
-        """Emit and remove this session's buffered unpaired tool-starts as orphans.
+    def flush_session(self, session_id: str) -> list[SessionEvent]:
+        """Emit and remove **one** session's buffered unpaired tool-starts as orphans.
 
-        Like :meth:`flush` but scoped to a single session — used to drain pending
-        starts the instant that session ends, rather than waiting for pipeline
-        close, so a governance stage sees them before it finalizes the session."""
+        The per-session counterpart of :meth:`flush`: only ``session_id``'s
+        pending starts are drained (as orphans, ``duration_ms=None`` — never
+        dropped) and removed; every other session's buffered starts are left
+        exactly as they were, so interleaved sessions can be retired one at a
+        time. Returns them in buffer (insertion) order.
+
+        Idempotent — a second call, or a call for a session with nothing buffered
+        (including an unknown session id), returns an empty list and changes
+        nothing.
+
+        Used internally the instant a session ends (so a governance stage sees
+        its unpaired starts before it finalizes the session) rather than waiting
+        for pipeline close, and available publicly for hosts that finalize
+        sessions individually (see ``EventPipeline.finalize_session``).
+        """
         result: list[SessionEvent] = []
         for key, event in list(self._pending.items()):
             if event.session_id == session_id:

--- a/src/traceforge/pipeline.py
+++ b/src/traceforge/pipeline.py
@@ -419,17 +419,91 @@ class EventPipeline:
                 self._session_locks.pop(victim, None)
 
     async def _finalize_session(self, session_id: str) -> None:
-        """Drain + title a single session's trailing state, then drop it.
+        """Finalize an *evicted* session (the LRU path), cancelling its refinements.
 
-        Mirrors :meth:`flush` for one session: cancel any in-flight session-title
-        refinement (so it can't emit after this session's title stream is gone),
-        emit any held leading plumbing (phase drain), title the trailing open
-        activity (title-stream flush), and discard the boundary stream. Called
-        under the session's lock by :meth:`_evict_over_cap`. The phase drain runs
-        first so every event has reached the title stream before it is flushed,
-        matching flush ordering.
+        Called under the victim's lock by :meth:`_evict_over_cap`. Eviction is
+        involuntary, so it cancels the victim's in-flight title refinements —
+        a stale API title must never land after the stream it described was
+        dropped and possibly replaced by a fresh one on resume — and schedules no
+        new ones. The voluntary counterpart is :meth:`finalize_session`, which
+        awaits refinements instead of cancelling them.
         """
-        self._cancel_session_refinements(session_id)
+        await self._finalize_session_state(session_id, cancel_refinements=True)
+
+    async def finalize_session(self, session_id: str) -> None:
+        """Finalize one session and reclaim **only** that session's state.
+
+        The per-session analogue of :meth:`flush`: it drains and emits everything
+        still held for ``session_id`` — that session's buffered enricher orphans
+        (:meth:`Enricher.flush_session`), its held leading plumbing (phase drain),
+        the boundary/title updates for its trailing open activity — awaits that
+        session's in-flight title refinements so their updates have reached the
+        sinks before returning, and only then drops the session's live state
+        (phase/boundary/title streams, progress and turn-summary state, recency
+        entry, lock).
+
+        Scoping is strict: every *other* session's state is untouched, so a
+        long-lived multi-session host can retire one run while the rest keep
+        streaming. Unlike :meth:`flush` this is **not** terminal for the pipeline
+        — the sinks are neither flushed nor closed, and pushes for other sessions
+        remain valid throughout.
+
+        Idempotent: finalizing an unknown session, or the same session twice, is
+        a clean no-op.
+
+        Concurrency-safe: the work runs under the session's *current* lock, taken
+        through the same :meth:`_acquire_session` validation loop :meth:`push`
+        uses, so a concurrent same-session push lands wholly before or wholly
+        after this call, concurrent finalizes of the same session serialize (the
+        second finding nothing to do), and pushes/finalizes for *other* sessions
+        never block on it. A session that receives another event after being
+        finalized simply starts fresh with cold causal state, exactly as after
+        LRU eviction.
+        """
+        lock = await self._acquire_session(session_id)
+        try:
+            self._session_order.pop(session_id, None)
+            if self._enricher is not None:
+                for event in self._enricher.flush_session(session_id):
+                    await self._emit(event)
+            await self._finalize_session_state(session_id, cancel_refinements=False)
+            # Awaited under the lock so no title update for this session can land
+            # after finalize_session returns. Refinement tasks only fan out to
+            # sinks (they never take a session lock), so this cannot deadlock.
+            await self._await_session_refinements(session_id)
+        finally:
+            lock.release()
+        # Drop the lock only if it is still the one we held — the identity guard
+        # from :meth:`_evict_over_cap`. A concurrent eviction/finalize may already
+        # have replaced it, and removing a successor's lock would let two pushers
+        # for this session serialize under different locks.
+        if self._session_locks.get(session_id) is lock:
+            self._session_locks.pop(session_id, None)
+
+    async def _finalize_session_state(self, session_id: str, *, cancel_refinements: bool) -> None:
+        """Drain + title one session's trailing state, then drop it.
+
+        The single per-session finalize primitive, shared by LRU eviction
+        (:meth:`_finalize_session`), the public :meth:`finalize_session`, and the
+        global :meth:`flush`. Mirrors :meth:`flush` for one session: emit any held
+        leading plumbing (phase drain), title the trailing open activity
+        (title-stream flush), discard the boundary stream, and forget the
+        session's progress / turn-summary state. The phase drain runs first so
+        every event has reached the title stream before it is flushed, matching
+        flush ordering.
+
+        ``cancel_refinements`` selects the eviction contract: cancel this
+        session's in-flight API refinements and queue no new ones, so an evicted
+        session finalizes with packaged titles only and leaves no API task running
+        after its stream is gone. With it ``False`` the trailing activity's
+        refinements are queued as usual and the caller awaits them
+        (:meth:`_await_session_refinements`).
+
+        Callers must hold the session's lock, except terminal :meth:`flush`, where
+        no push may run by contract.
+        """
+        if cancel_refinements:
+            self._cancel_session_refinements(session_id)
         if self._phase_inferencer is not None:
             await self._drain_stream(session_id)
         if self._title_inferencer is not None:
@@ -439,7 +513,7 @@ class EventPipeline:
                     updates = await asyncio.to_thread(stream.flush)
                 except Exception as exc:
                     logger.error(
-                        "Title stream flush failed for evicted session %s: %s",
+                        "Title stream flush failed for session %s: %s",
                         session_id,
                         exc,
                         exc_info=True,
@@ -447,17 +521,46 @@ class EventPipeline:
                     updates = []
                 for update in updates:
                     await self._push_title_update(update)
-                # NOTE: eviction does not schedule API refinement for the trailing
-                # activity. It already cancelled this session's in-flight
-                # refinements above; finalizing with packaged titles only keeps a
-                # clean contract (evicted sessions get no API upgrades) and leaves
-                # no API task running after the stream is gone. Normally-completing
-                # sessions refine their trailing activity in _flush_title_streams.
+                if not cancel_refinements:
+                    # Upgrade the trailing activity's packaged titles off the hot
+                    # path when configured; the caller awaits these before it
+                    # returns (finalize_session) or before closing sinks (flush).
+                    for closed in stream.take_activity_refinements():
+                        self._schedule_activity_refine(session_id, closed)
         self._boundary_streams.pop(session_id, None)
         if self._progress is not None:
             self._progress.forget(session_id)
         if self._turn_summarizer is not None:
             self._turn_summarizer.forget(session_id)
+
+    async def _await_session_refinements(self, session_id: str) -> None:
+        """Await one session's in-flight title refinements. Error-isolated.
+
+        A slow-but-successful API upgrade must land (as its own title update)
+        before the session is reported finalized. Failures were already logged
+        inside the task, which left the heuristic title standing, so they are
+        absorbed here rather than propagated.
+        """
+        pending = list(self._refine_tasks.get(session_id, ()))
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def _tracked_sessions(self) -> list[str]:
+        """Every session id still holding live per-session state, first-seen order.
+
+        The union across the per-session maps, snapshotted into a list so callers
+        may finalize (and therefore mutate those maps) while iterating.
+        """
+        seen: dict[str, None] = {}
+        for source in (
+            self._phase_streams,
+            self._title_streams,
+            self._boundary_streams,
+            self._session_order,
+        ):
+            for session_id in source:
+                seen[session_id] = None
+        return list(seen)
 
     async def _push_locked(self, event: SessionEvent) -> None:
         if self._enricher is not None:
@@ -759,36 +862,6 @@ class EventPipeline:
                 ev = self._boundary_stamp(ev)
             await self._title_emit(ev)
 
-    async def _flush_title_streams(self) -> None:
-        """Title each session's final open activity and emit its updates.
-
-        Title streams persist for the whole ``session_id`` (never torn down on
-        mid-session SESSION_ENDED/PAUSED markers). The session's events have all
-        already been emitted live; at pipeline flush the trailing activity has no
-        closing boundary, so it is titled from its full context here and its
-        :class:`~traceforge.types.TitleUpdate` records are emitted.
-        """
-        if self._title_inferencer is None:
-            return
-        for session_id in list(self._title_streams):
-            stream = self._title_streams.pop(session_id)
-            try:
-                updates = await asyncio.to_thread(stream.flush)
-            except Exception as exc:
-                logger.error(
-                    "Title stream flush failed for session %s: %s",
-                    session_id,
-                    exc,
-                    exc_info=True,
-                )
-                updates = []
-            for update in updates:
-                await self._push_title_update(update)
-            # Upgrade the trailing activity's packaged titles off the hot path
-            # when configured; flush() below awaits these before closing sinks.
-            for closed in stream.take_activity_refinements():
-                self._schedule_activity_refine(session_id, closed)
-
     async def _fanout(
         self,
         coros: Iterable[Awaitable],
@@ -931,29 +1004,31 @@ class EventPipeline:
     async def flush(self) -> None:
         """Drain all buffered state to sinks. TERMINAL — see :meth:`push`.
 
-        Flushes the enricher, drains each session's held leading plumbing and
-        final open activity, reclaims every per-session map, then flushes the
-        sinks. This runs *outside* the session lock and reclaims state, so no
-        ``push`` may run during or after it (the caller stops pushing, then
-        flushes/closes). Error-isolated.
+        Flushes the enricher, finalizes every session still holding live state,
+        reclaims every per-session map, then flushes the sinks. This runs
+        *outside* the session lock and reclaims state, so no ``push`` may run
+        during or after it (the caller stops pushing, then flushes/closes).
+        Error-isolated.
+
+        Global terminal semantics are unchanged; the per-session work is the same
+        primitive the public :meth:`finalize_session` uses, so however a session
+        is retired it drains identically. To retire a single session while the
+        pipeline keeps running, call :meth:`finalize_session` instead.
         """
         if self._enricher is not None:
             for event in self._enricher.flush():
                 await self._emit(event)
 
-        # Drain any sessions still holding leading plumbing (no content event
-        # and no explicit SESSION_ENDED seen). Steady-state events are already
-        # emitted live, so only the leading hold-buffer can remain.
-        if self._phase_inferencer is not None:
-            for session_id in list(self._phase_streams):
-                await self._drain_stream(session_id)
-
-        # Title each session's final open activity. Its events were already
-        # emitted live (carrying their segment ids); the trailing activity has
-        # no closing boundary, so it is titled here and its TitleUpdate records
-        # emitted. Done after phase drain so every event has reached the title
-        # stream first.
-        await self._flush_title_streams()
+        # Finalize every session still holding live state: its held leading
+        # plumbing (no content event and no explicit SESSION_ENDED seen) is
+        # drained, then its final open activity is titled — its events were
+        # already emitted live carrying their segment ids, but the trailing
+        # activity has no closing boundary, so it is titled here and its
+        # TitleUpdate records emitted. Drain-before-title is a per-session
+        # invariant (the primitive enforces it) and the streams are per-session,
+        # so finalizing session-by-session is equivalent to the map-by-map order.
+        for session_id in self._tracked_sessions():
+            await self._finalize_session_state(session_id, cancel_refinements=False)
 
         # Await any in-flight session-title API refinements so a slow-but-
         # successful upgrade lands (as its own title update) before the sinks are
@@ -963,13 +1038,15 @@ class EventPipeline:
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
 
-        # Boundary streams and per-session locks carry no buffered output to
-        # drain (boundary is O(1) causal state; locks are bare mutexes), but
-        # they are per-session and would otherwise outlive every finalized
-        # session. Reclaim them here so all four per-session maps free together
-        # at teardown, matching the phase/title drain above. Safe because flush
-        # is terminal: no push holds a lock or touches a boundary stream now.
+        # The per-session finalize above reclaimed the phase/boundary/title
+        # streams and the progress / turn-summary state of every tracked session.
+        # Clear the maps outright anyway — flush is terminal, so nothing may hold
+        # them afterwards — and reclaim the per-session locks and recency order,
+        # which carry no buffered output to drain (locks are bare mutexes) but
+        # would otherwise outlive every finalized session.
+        self._phase_streams.clear()
         self._boundary_streams.clear()
+        self._title_streams.clear()
         self._session_locks.clear()
         self._session_order.clear()
         if self._progress is not None:

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -768,13 +768,13 @@ class TestIDStabilityAndRobustness:
         assert r2.metadata.duration_ms == 2000.0  # 12:00:01 -> 12:00:03
 
     def test_flush_session_scoped_to_one_session_on_id_collision(self):
-        """_flush_session drains only the ended session's buffered start even when
+        """flush_session drains only the ended session's buffered start even when
         another live session holds the same tool_call_id."""
         enricher = Enricher()
         enricher.process(_make_tool_start(tool_call_id="same", session_id="s1"))
         enricher.process(_make_tool_start(tool_call_id="same", session_id="s2"))
 
-        orphans = enricher._flush_session("s1")
+        orphans = enricher.flush_session("s1")
         assert [o.session_id for o in orphans] == ["s1"]
 
         # s2's start survives and still pairs.
@@ -782,6 +782,48 @@ class TestIDStabilityAndRobustness:
         assert not isinstance(paired, list)
         assert paired is not None
         assert paired.session_id == "s2"
+
+    def test_flush_session_leaves_other_sessions_buffered_and_is_idempotent(self):
+        """flush_session is strictly per-session and repeat-safe: it drains only
+        the target session's buffered starts, in buffer order, and a second call
+        (or an unknown session id) is a clean no-op that leaves interleaved
+        sessions untouched."""
+        enricher = Enricher()
+        enricher.process(_make_tool_start(tool_call_id="a1", session_id="s1"))
+        enricher.process(_make_tool_start(tool_call_id="b1", session_id="s2"))
+        enricher.process(_make_tool_start(tool_call_id="a2", session_id="s1"))
+
+        drained = enricher.flush_session("s1")
+        assert [o.payload["tool_call_id"] for o in drained] == ["a1", "a2"]
+        assert all(o.session_id == "s1" for o in drained)
+        assert all(o.metadata.duration_ms is None for o in drained)
+
+        # Idempotent: repeating it, or naming a session that never buffered
+        # anything, emits nothing and changes nothing.
+        assert enricher.flush_session("s1") == []
+        assert enricher.flush_session("never-seen") == []
+
+        # s2's interleaved start survived and is all the global flush has left.
+        remaining = enricher.flush()
+        assert [(o.session_id, o.payload["tool_call_id"]) for o in remaining] == [("s2", "b1")]
+
+    def test_flush_session_does_not_break_another_sessions_pairing(self):
+        """Draining s1 must not consume or displace s2's buffered start — s2's
+        completion still pairs and still carries a real duration."""
+        enricher = Enricher()
+        t0 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        enricher.process(_make_tool_start(tool_call_id="same", session_id="s1", ts=t0))
+        enricher.process(_make_tool_start(tool_call_id="same", session_id="s2", ts=t0))
+
+        assert [o.session_id for o in enricher.flush_session("s1")] == ["s1"]
+
+        paired = enricher.process(
+            _make_tool_complete(tool_call_id="same", session_id="s2", ts=t0 + timedelta(seconds=2))
+        )
+        assert not isinstance(paired, list)
+        assert paired is not None
+        assert paired.session_id == "s2"
+        assert paired.metadata.duration_ms == 2000.0
 
     def test_flushed_orphan_preserves_original_id(self):
         """Flushed orphan start preserves its original event ID."""

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -709,6 +709,330 @@ class TestPipelineActivityTitleRefinement:
         assert a_api == []
 
 
+class TestPipelineFinalizeSession:
+    """``finalize_session`` retires ONE session: everything it still holds is
+    emitted, that session's in-flight refinements are awaited, and only its state
+    is reclaimed. Every other live session keeps streaming, and unlike ``flush``
+    the pipeline itself stays open."""
+
+    @staticmethod
+    def _sev(session_id: str, i: int) -> SessionEvent:
+        from datetime import datetime, timezone
+
+        from traceforge.types import EventMetadata
+
+        return SessionEvent(
+            id=f"{session_id}-{i}",
+            kind="tool.call",
+            session_id=session_id,
+            timestamp=datetime.now(timezone.utc),
+            payload={"tool_name": "edit", "arguments": {"path": f"{session_id.lower()}{i}.py"}},
+            metadata=EventMetadata(source_framework="copilot"),
+        )
+
+    @staticmethod
+    def _plumbing(session_id: str, i: int) -> SessionEvent:
+        """A non-content-bearing event: the phase stream holds it as *leading*
+        plumbing until the session's first content event (or a drain)."""
+        from datetime import datetime, timezone
+
+        from traceforge.types import EventMetadata
+
+        return SessionEvent(
+            id=f"{session_id}-{i}",
+            kind="session.start",
+            session_id=session_id,
+            timestamp=datetime.now(timezone.utc),
+            payload={},
+            metadata=EventMetadata(source_framework="copilot"),
+        )
+
+    @staticmethod
+    def _umsg(session_id: str, text: str) -> SessionEvent:
+        from datetime import datetime, timezone
+
+        from traceforge.types import EventMetadata
+
+        return SessionEvent(
+            id=f"{session_id}-0",
+            kind="message.user",
+            session_id=session_id,
+            timestamp=datetime.now(timezone.utc),
+            payload={"content": text},
+            metadata=EventMetadata(source_framework="copilot"),
+        )
+
+    @staticmethod
+    def _titled(sinks, **titler_kwargs) -> EventPipeline:
+        """A pipeline driving the REAL title inferencer/stream (only the packaged
+        seq2seq model is faked), so these tests exercise the actual title path
+        rather than a stubbed TitleUpdate callback."""
+        from tests.unit.test_title_inferencer import _FakeTitle
+
+        from traceforge.title import TitleInferencer
+
+        return EventPipeline(
+            sinks=sinks,
+            enable_phase=False,
+            enable_boundary=False,
+            title_inferencer=TitleInferencer(model=_FakeTitle(), **titler_kwargs),
+        )
+
+    async def _interleaved(self, recorder: RecordingSink, extra_sinks=()) -> EventPipeline:
+        """Two interleaved live sessions, each with one open (untitled) activity."""
+        pipeline = self._titled([recorder.sink, *extra_sinks])
+        await pipeline.push(self._sev("A", 0))
+        await pipeline.push(self._sev("B", 0))
+        await pipeline.push(self._sev("A", 1))
+        await pipeline.push(self._sev("B", 1))
+        assert [e.id for e in recorder.events] == ["A-0", "B-0", "A-1", "B-1"]
+        assert recorder.title_updates == []  # both activities still open
+        return pipeline
+
+    async def test_finalize_emits_only_that_session_and_leaves_others_intact(self):
+        recorder = RecordingSink()
+        pipeline = await self._interleaved(recorder)
+
+        await pipeline.finalize_session("A")
+
+        # Only A's trailing activity was titled; B produced nothing.
+        assert {u.session_id for u in recorder.title_updates} == {"A"}
+        acts = [u for u in recorder.title_updates if u.kind == "activity"]
+        assert [u.segment_id for u in acts] == ["A-0"] and all(u.title for u in acts)
+        # A's per-session state is gone...
+        assert "A" not in pipeline._title_streams
+        assert "A" not in pipeline._session_locks
+        assert "A" not in pipeline._session_order
+        # ...and B's is untouched and still live.
+        assert "B" in pipeline._title_streams
+        assert "B" in pipeline._session_locks
+        assert "B" in pipeline._session_order
+
+    async def test_survivor_keeps_streaming_and_then_finalizes_exactly_once(self):
+        recorder = RecordingSink()
+        pipeline = await self._interleaved(recorder)
+        await pipeline.finalize_session("A")
+        seen = len(recorder.title_updates)
+
+        # B is unaffected by A's finalize: it keeps accepting pushes.
+        await pipeline.push(self._sev("B", 2))
+        assert [e.id for e in recorder.events] == ["A-0", "B-0", "A-1", "B-1", "B-2"]
+
+        await pipeline.finalize_session("B")
+        emitted = recorder.title_updates[seen:]
+        assert {u.session_id for u in emitted} == {"B"}
+        b_acts = [u for u in emitted if u.kind == "activity"]
+        assert [u.segment_id for u in b_acts] == ["B-0"] and all(u.title for u in b_acts)
+        assert pipeline._title_streams == {}
+
+    async def test_repeated_and_unknown_finalize_are_clean_no_ops(self):
+        recorder = RecordingSink()
+        pipeline = await self._interleaved(recorder)
+        await pipeline.finalize_session("A")
+        seen = len(recorder.title_updates)
+
+        await pipeline.finalize_session("A")  # repeat
+        await pipeline.finalize_session("never-pushed")  # unknown
+
+        assert len(recorder.title_updates) == seen
+        # An unknown/finalized id leaves behind no per-session state.
+        for sid in ("A", "never-pushed"):
+            assert sid not in pipeline._session_locks
+            assert sid not in pipeline._session_order
+            assert sid not in pipeline._title_streams
+        assert "B" in pipeline._title_streams  # still untouched
+
+    async def test_concurrent_finalize_of_same_session_titles_it_once(self):
+        import asyncio
+
+        recorder = RecordingSink()
+        pipeline = await self._interleaved(recorder)
+
+        # Both calls converge on the session's current lock, so the second finds
+        # the stream already gone rather than re-titling (or corrupting) it.
+        await asyncio.wait_for(
+            asyncio.gather(pipeline.finalize_session("A"), pipeline.finalize_session("A")),
+            timeout=5,
+        )
+
+        acts = [u for u in recorder.title_updates if u.kind == "activity"]
+        assert [(u.session_id, u.segment_id) for u in acts] == [("A", "A-0")]
+        assert "A" not in pipeline._session_locks
+        assert "B" in pipeline._title_streams
+
+    async def test_concurrent_finalize_of_distinct_sessions_each_title_once(self):
+        import asyncio
+
+        recorder = RecordingSink()
+        pipeline = await self._interleaved(recorder)
+
+        # Distinct sessions take distinct locks, so these run concurrently.
+        await asyncio.wait_for(
+            asyncio.gather(pipeline.finalize_session("A"), pipeline.finalize_session("B")),
+            timeout=5,
+        )
+
+        acts = [u for u in recorder.title_updates if u.kind == "activity"]
+        assert sorted((u.session_id, u.segment_id) for u in acts) == [("A", "A-0"), ("B", "B-0")]
+        assert pipeline._title_streams == {}
+        assert pipeline._session_locks == {}
+        assert len(pipeline._session_order) == 0
+
+    async def test_concurrent_push_and_finalize_of_same_session_is_safe(self):
+        import asyncio
+
+        recorder = RecordingSink()
+        pipeline = await self._interleaved(recorder)
+
+        # Which of the two lands first is the caller's business; the invariants
+        # are that neither is lost, neither deadlocks, and no segment is titled
+        # twice regardless of the interleaving.
+        await asyncio.wait_for(
+            asyncio.gather(pipeline.push(self._sev("A", 2)), pipeline.finalize_session("A")),
+            timeout=5,
+        )
+        await pipeline.flush()
+
+        ids = [e.id for e in recorder.events]
+        assert len(ids) == len(set(ids))
+        assert {"A-0", "A-1", "A-2", "B-0", "B-1"} == set(ids)
+        segs = [u.segment_id for u in recorder.title_updates if u.kind == "activity"]
+        assert len(segs) == len(set(segs))
+        assert "B-0" in segs
+
+    async def test_finalize_awaits_that_sessions_title_refinement(self):
+        # Eviction *cancels* a victim's in-flight refinement; an explicit
+        # finalize is voluntary, so it awaits instead — the API upgrade has
+        # already reached the sinks by the time finalize_session returns.
+        import asyncio
+        import threading
+
+        release = threading.Event()
+
+        def heuristic(text: str) -> str:
+            return "Heuristic " + text.split()[0]
+
+        def refiner(text: str) -> str:
+            release.wait(timeout=5)
+            return "Refined " + text.split()[0]
+
+        recorder = RecordingSink()
+        pipeline = self._titled([recorder.sink], session_titler=heuristic, session_refiner=refiner)
+        await pipeline.push(self._umsg("A", "Alpha add retry logic to the HTTP client"))
+        await pipeline.push(self._umsg("B", "Bravo build the pagination endpoint"))
+
+        task = asyncio.create_task(pipeline.finalize_session("A"))
+        await asyncio.sleep(0.05)
+        assert not task.done()  # blocked awaiting A's refinement, not cancelling it
+        release.set()
+        await asyncio.wait_for(task, timeout=5)
+
+        def titles(sid: str) -> list[str]:
+            return [
+                u.title
+                for u in recorder.title_updates
+                if u.session_id == sid and u.kind == "session"
+            ]
+
+        assert titles("A") == ["Heuristic Alpha", "Refined Alpha"]
+        assert "A" not in pipeline._refine_tasks
+        # B's refinement was neither awaited nor cancelled by A's finalize; the
+        # terminal flush still lands it.
+        await pipeline.flush()
+        assert titles("B") == ["Heuristic Bravo", "Refined Bravo"]
+
+    async def test_finalize_drains_only_that_sessions_held_plumbing(self):
+        # Phase inference holds contiguous *leading* plumbing until the session's
+        # first content event; finalizing one session must release only its hold.
+        recorder = RecordingSink()
+        pipeline = EventPipeline(sinks=[recorder.sink], enable_boundary=False)
+        await pipeline.push(self._plumbing("A", 0))
+        await pipeline.push(self._plumbing("B", 0))
+        assert recorder.events == []  # both sessions still holding
+
+        await pipeline.finalize_session("A")
+
+        assert [e.id for e in recorder.events] == ["A-0"]
+        assert all(e.metadata.phase for e in recorder.events)
+        assert "A" not in pipeline._phase_streams
+        assert "B" in pipeline._phase_streams  # B's hold is intact
+
+        # B's held plumbing still comes out at the terminal flush.
+        await pipeline.flush()
+        assert [e.id for e in recorder.events] == ["A-0", "B-0"]
+
+    async def test_finalize_flushes_only_that_sessions_enricher_orphans(self):
+        from traceforge import Enricher, EventKind
+
+        def _start(session_id: str) -> SessionEvent:
+            return make_event(
+                kind=EventKind.TOOL_CALL_STARTED,
+                session_id=session_id,
+                id=f"{session_id}-start",
+                payload={"tool_call_id": "same", "tool_name": "edit"},
+            )
+
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enricher=Enricher(),
+            enable_phase=False,
+            enable_boundary=False,
+        )
+        await pipeline.push(_start("A"))
+        await pipeline.push(_start("B"))
+        assert recorder.events == []  # both starts buffered awaiting completion
+
+        await pipeline.finalize_session("A")
+        assert [e.id for e in recorder.events] == ["A-start"]
+        assert recorder.events[0].metadata.duration_ms is None  # emitted as an orphan
+
+        # B's start survived A's finalize and still pairs with its completion.
+        await pipeline.push(
+            make_event(
+                kind=EventKind.TOOL_CALL_COMPLETED,
+                session_id="B",
+                id="B-complete",
+                payload={"tool_call_id": "same", "tool_name": "edit"},
+            )
+        )
+        assert [e.id for e in recorder.events] == ["A-start", "B-complete"]
+        assert recorder.events[-1].metadata.duration_ms is not None
+
+    async def test_finalize_forgets_only_that_sessions_turn_state(self):
+        recorder = RecordingSink()
+        pipeline = EventPipeline(sinks=[recorder.sink], enable_phase=False, enable_boundary=False)
+        await pipeline.push(make_event(session_id="A", id="A-0"))
+        await pipeline.push(make_event(session_id="B", id="B-0"))
+        summarizer = pipeline._turn_summarizer
+        assert set(summarizer._turn) == {"A", "B"}
+
+        await pipeline.finalize_session("A")
+        assert set(summarizer._turn) == {"B"}
+
+    async def test_global_flush_stays_terminal_after_per_session_finalize(self):
+        recorder = RecordingSink()
+        tracker = FlushTrackingSink()
+        pipeline = await self._interleaved(recorder, extra_sinks=[tracker])
+        await pipeline.finalize_session("A")
+        seen = len(recorder.title_updates)
+
+        await pipeline.close()
+
+        # flush finalized only what was left (B) — A is not re-emitted — and the
+        # global terminal semantics are unchanged.
+        remaining = recorder.title_updates[seen:]
+        assert {u.session_id for u in remaining} == {"B"}
+        b_acts = [u for u in remaining if u.kind == "activity"]
+        assert [u.segment_id for u in b_acts] == ["B-0"]
+        assert tracker.flushed and tracker.closed
+        assert pipeline._title_streams == {}
+        assert pipeline._phase_streams == {}
+        assert pipeline._boundary_streams == {}
+        assert pipeline._session_locks == {}
+        assert len(pipeline._session_order) == 0
+
+
 class TestPipelineSpanAndUsage:
     async def test_push_span_fanout(self):
         recorders = [RecordingSink() for _ in range(2)]

--- a/uv.lock
+++ b/uv.lock
@@ -4174,7 +4174,7 @@ source = { editable = "packages/traceforge-title-model" }
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Why

A long-lived multi-session host — CodePlane (dfinson/codeplane#40) — needs to retire **one** session and receive its trailing structural output (boundary/title/turn-summary), without tearing down a pipeline that other sessions are still streaming through.

Until now there was no way to do that:

- `EventPipeline._finalize_session` existed but was private and reachable only via *involuntary* LRU eviction, which deliberately **cancels** the session's in-flight title refinements.
- The only public drain was `flush()`, which is terminal and global — it reclaims every session's state and flushes/closes the sinks.
- `Enricher._flush_session` (the per-session orphan drain) was likewise private.

## What

Two stable **public** APIs.

### `await EventPipeline.finalize_session(session_id) -> None`

The per-session analogue of `flush`. It emits everything that session still holds — its buffered enricher orphans (`Enricher.flush_session`), its held leading plumbing (phase drain), the boundary/title updates for its trailing open activity — **awaits** that session's in-flight title refinements so their updates have reached the sinks, and only then reclaims **that session's** state (phase/boundary/title streams, progress and turn-summary state, recency entry, lock).

- Strictly scoped: every other session's state is untouched and keeps streaming.
- **Not** terminal for the pipeline: sinks are neither flushed nor closed.
- Idempotent: a repeated finalize, or an unknown `session_id`, is a clean no-op that mints no state.

### `Enricher.flush_session(session_id) -> list[SessionEvent]`

The former private `_flush_session`, promoted to public with no behavior change: drains only that session's buffered unpaired tool-starts as orphans (never dropped), in buffer order, leaving interleaved sessions untouched. Idempotent.

## Locking — not a race-prone wrapper

`finalize_session` does not wrap the private eviction path. It takes the session's **current** lock through the same `_acquire_session` validation loop `push` uses (so it converges on the live lock even if a concurrent eviction replaced it mid-acquire), and drops it under the same identity guard as `_evict_over_cap` (so it can never remove a *successor's* lock and let two pushers serialize under different locks). Consequences:

- A concurrent same-session push lands wholly before or wholly after the finalize.
- Concurrent finalizes of the same session serialize; the second finds nothing to do.
- Pushes/finalizes for *other* sessions never block on it.
- Refinements are awaited **under** the lock — refinement tasks only fan out to sinks and never take a session lock, so this cannot deadlock, and no title update for the session can land after `finalize_session` returns.

## One primitive, three callers

`_finalize_session` is refactored into a shared primitive, `_finalize_session_state(session_id, *, cancel_refinements)`:

| caller | `cancel_refinements` | rationale |
|---|---|---|
| LRU eviction (`_finalize_session`) | `True` | involuntary — a stale API title must never land after the stream it described was dropped and possibly replaced on resume. Contract unchanged. |
| `finalize_session` | `False` | voluntary — queue the trailing activity's refinements and await them. |
| `flush()` / `close()` | `False` | unchanged global terminal semantics, now expressed over the same primitive per tracked session. |

`flush()` now finalizes every session in `_tracked_sessions()` instead of running separate phase-drain and title-flush loops. Drain-before-title is a *per-session* invariant enforced inside the primitive and the streams are per-session, so this is equivalent to the previous map-by-map order. `_flush_title_streams` is gone (private, no other callers).

## Tests

11 new pipeline tests (`TestPipelineFinalizeSession`) + 2 new enricher tests, all driving the **real** `EventPipeline` and the **real** `SessionTitleStream` (only the packaged seq2seq model is faked) — no mocked `TitleUpdate` callbacks:

- Two interleaved sessions A/B: finalize A titles only A and leaves B's stream, lock, and recency entry intact.
- B keeps streaming after A is retired, then finalizes exactly once.
- Repeated finalize + unknown session id are clean no-ops that mint no state.
- Concurrent finalize of the *same* session titles it once; concurrent finalize of *distinct* sessions each title once.
- Concurrent push + finalize of the same session: no loss, no deadlock, no segment titled twice.
- Finalize **awaits** the session's refinement (asserted mid-flight via `not task.done()`), in contrast to eviction, which cancels — and leaves the other session's refinement neither awaited nor cancelled.
- Per-session scoping proven independently for the phase-drain hold buffer, the enricher orphan buffer (B's start still pairs afterwards), and turn-summary state.
- Global `flush`/`close` stay terminal: they finalize only what's left, never re-emit A, and still flush + close the sinks.

Mutation-checked: replacing `finalize_session`'s body with `await self.flush()` fails 8 of the new pipeline tests, and dropping the session filter in `Enricher.flush_session` fails all 3 enricher tests.

## Release

Patch release **traceforge-toolkit 0.1.5** (`pyproject.toml` + `uv.lock`); `traceforge-title-model` stays at 0.2.0. `CHANGELOG.md` gains a `[0.1.5]` section (the previously-unreleased AIU / Copilot-ingest entries fold into it), and SPEC §11 / the Enricher API section document both new methods.

Not merged, not tagged, not released.