### PR TITLE
Add public per-session lifecycle APIs (finalize_session, flush_session); release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   premium-request count, not dollars — never synthesized). Ingestion-side only; usage
   rides `usage_records` (Cost lens), never the enriched-events timeline.
 
+## [0.1.5] - 2026-08-04
+
+### Added
+
+- `EventPipeline.finalize_session(session_id)` — a public, per-session lifecycle
+  primitive for callers that multiplex many sessions through one shared pipeline.
+  It is the per-session analogue of `flush()`: it drains and emits everything still
+  pending for that one session (its held leading plumbing, its trailing open
+  activity's titles, and any configured off-hot-path API title upgrades), awaits
+  that session's in-flight title-refinement tasks so their `TitleUpdate` records
+  have reached the sinks, then reclaims only that session's
+  phase/boundary/title/progress/turn-summary/lock/order state — leaving every other
+  active session behaviourally untouched and the sinks neither flushed nor closed.
+  It runs under the session's own lock (serialising with concurrent `push()` for the
+  same session), is idempotent (a repeat or concurrent finalize emits no duplicates
+  and does not raise), and treats an unknown session id as a no-op. A `push()` that
+  lands after finalization starts the session fresh from cold state, matching the
+  LRU-eviction contract. `flush()` / `close()` keep their global semantics and now
+  share the same per-session finalize primitive.
+- `Enricher.flush_session(session_id)` — a public, per-session analogue of the
+  enricher's global `flush()`. It drains and returns only that session's buffered
+  unpaired tool-starts as orphan completions (`duration_ms=None`), leaving every
+  other session's buffer untouched, so a caller multiplexing many sessions through
+  one shared enricher can retire one finished session's orphan buffer without
+  emitting or clearing the others. Synchronous and atomic with respect to the event
+  loop, idempotent (a repeat, already-drained, or unknown session returns an empty
+  list and never duplicates an orphan completion), and leaves the global `flush()`
+  semantics unchanged.
+
 ## [0.1.4] - 2026-08-02
 
 ### Fixed
@@ -165,7 +194,8 @@ risk-scored, governed event streams with opt-in tool-call gating.
 - The gate IPC server binds a POSIX `AF_UNIX` socket; on Windows that path is skipped
   and a localhost TCP socket is used instead.
 
-[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/dfinson/traceforge/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/dfinson/traceforge/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/dfinson/traceforge/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/dfinson/traceforge/compare/v0.1.2...v0.1.3
 [0.1.1]: https://github.com/dfinson/traceforge/compare/v0.1.0...v0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "traceforge-toolkit"
-version = "0.1.4"
+version = "0.1.5"
 description = "Framework-agnostic, CPU-only pipeline that forges AI agent traces into classified, risk-scored, governed output"
 readme = "README.md"
 license = "MIT"

--- a/src/traceforge/enricher.py
+++ b/src/traceforge/enricher.py
@@ -234,12 +234,39 @@ class Enricher:
         self._pending.clear()
         return result
 
+    def flush_session(self, session_id: str) -> list[SessionEvent]:
+        """Flush **one** session's buffered unpaired tool-starts as orphans.
+
+        The per-session analogue of :meth:`flush`: it removes and returns only
+        ``session_id``'s still-pending tool-starts (each re-stamped as an orphan
+        completion with ``duration_ms=None``), leaving every other session's
+        buffered starts byte-for-byte untouched. This is the supported way for a
+        caller multiplexing many sessions through one shared enricher to drain a
+        finished session's orphan buffer without disturbing the others — e.g.
+        terminal cleanup for one job when concurrent jobs share the enricher,
+        where the global :meth:`flush` would wrongly emit and clear every session.
+
+        Synchronous and atomic with respect to the event loop (no ``await``), so
+        it never interleaves with an in-flight :meth:`process` or a flush of a
+        different session. **Idempotent**: a session's starts are removed as they
+        are emitted, so a repeat call — or a flush of a session with nothing
+        pending, including an unknown / never-seen ``session_id`` — returns an
+        empty list and emits no duplicate orphan completions. The global
+        :meth:`flush` keeps its all-sessions semantics unchanged.
+
+        Returns the flushed orphan-completion events in buffer (insertion) order,
+        or an empty list when the session has nothing pending.
+        """
+        return self._flush_session(session_id)
+
     def _flush_session(self, session_id: str) -> list[SessionEvent]:
         """Emit and remove this session's buffered unpaired tool-starts as orphans.
 
-        Like :meth:`flush` but scoped to a single session — used to drain pending
-        starts the instant that session ends, rather than waiting for pipeline
-        close, so a governance stage sees them before it finalizes the session."""
+        Like :meth:`flush` but scoped to a single session. It is the shared
+        implementation behind both the automatic drain when a ``SESSION_ENDED``
+        event is processed (so a governance stage sees the orphans before it
+        finalizes the session, rather than waiting for pipeline close) and the
+        public :meth:`flush_session`."""
         result: list[SessionEvent] = []
         for key, event in list(self._pending.items()):
             if event.session_id == session_id:

--- a/src/traceforge/pipeline.py
+++ b/src/traceforge/pipeline.py
@@ -418,18 +418,132 @@ class EventPipeline:
             if self._session_locks.get(victim) is lock:
                 self._session_locks.pop(victim, None)
 
-    async def _finalize_session(self, session_id: str) -> None:
-        """Drain + title a single session's trailing state, then drop it.
+    async def finalize_session(self, session_id: str) -> None:
+        """Finalize and reclaim a **single** session's live state, non-terminally.
 
-        Mirrors :meth:`flush` for one session: cancel any in-flight session-title
-        refinement (so it can't emit after this session's title stream is gone),
-        emit any held leading plumbing (phase drain), title the trailing open
-        activity (title-stream flush), and discard the boundary stream. Called
-        under the session's lock by :meth:`_evict_over_cap`. The phase drain runs
-        first so every event has reached the title stream before it is flushed,
-        matching flush ordering.
+        The per-session analogue of :meth:`flush`: it drains and emits everything
+        still pending for ``session_id`` — its held leading plumbing (phase
+        drain), its trailing open activity's titles (title-stream flush), and any
+        configured off-hot-path API title upgrades for that session — then frees
+        that session's phase/boundary/title/progress/turn-summary/lock/order
+        state. **Every other active session is left byte-for-byte behaviourally
+        unaffected**, and the sinks are *not* flushed or closed — that stays the
+        global, terminal job of :meth:`flush` / :meth:`close`. This is the
+        supported way for a caller multiplexing many sessions through one shared
+        pipeline to retire one finished session without disturbing the others.
+
+        Serialization / races (single-threaded asyncio):
+
+        * Runs under the session's own lock (:meth:`_acquire_session`), so it is
+          serialised against a concurrent :meth:`push` for the *same* session
+          exactly as two pushes are — whichever takes the lock first runs to
+          completion before the other proceeds. Finalizing distinct sessions, or
+          finalizing while pushing a *different* session, never contends.
+        * A :meth:`push` for this session that races finalization is serialised on
+          the session lock: it either runs first (and is included), or waits until
+          finalization has fully completed — including delivering this session's
+          refinements (below) — and then begins a fresh session from cold causal
+          state, identical to the post-eviction contract. Stop pushing a session
+          before finalizing it if you want the finalize to be truly last.
+        * **Idempotent.** Per-session state is popped as it is finalized, so a
+          repeat call — or a concurrent second finalize of the same session —
+          finds nothing to drain, emits no duplicate updates, and does not raise.
+          An unknown / never-seen ``session_id`` is a no-op.
+
+        Before returning it awaits that session's in-flight title-refinement tasks
+        (session *and* activity), so their append-only
+        :class:`~traceforge.types.TitleUpdate` records have been delivered to the
+        sinks — a caller can rely on the session's structural updates being
+        complete once this resolves. The await happens *while still holding the
+        session lock*: a refinement emits a later title on this session's segment,
+        so a late same-session push must not be allowed to start a fresh
+        incarnation (and emit a newer heuristic title) until every captured
+        refinement has been delivered — otherwise a slow refine could clobber the
+        fresh title. The session is dropped from the recency order the instant its
+        lock is acquired (before any awaiting), so it can no longer be selected as
+        an eviction victim while its refinements are in flight — its tasks can
+        never be cancelled out from under this await.
+
+        Because sessions hold distinct locks, finalizing one never blocks a
+        :meth:`push` for a *different* session. (The one theoretical exception: a
+        different session's push whose bounded-buffer eviction had *already*
+        selected this exact session as its LRU victim and is parked on its lock
+        will wait out this finalize before skipping it — a window reduced to
+        near-zero by the immediate order-pop, and unreachable under any
+        ``max_sessions`` cap that is not routinely exceeded.) :meth:`flush` /
+        :meth:`close` are terminal and must not be called *concurrently* with
+        ``finalize_session`` (same rule as concurrent ``push``). Error-isolated: a
+        failed refinement already logged inside its task and left the heuristic /
+        packaged title standing.
+        """
+        lock = await self._acquire_session(session_id)
+        try:
+            # Drop the session from the recency order the instant we hold its lock,
+            # before any await: it can then never be picked as an LRU eviction
+            # victim while we drain it and await its refinements below (eviction
+            # would otherwise park on this lock, and — worse — cancel the very
+            # refinement tasks we must deliver). Nothing here reads the order, so
+            # popping first is behaviour-neutral for the drain itself.
+            self._session_order.pop(session_id, None)
+            await self._finalize_session_streams(session_id, schedule_refine=True)
+            # Await this session's refinements (earlier live ones + any just queued
+            # for its trailing activity) WHILE STILL HOLDING the lock, so a late
+            # same-session push cannot start a fresh incarnation until every
+            # captured refinement has landed — no stale refine can clobber a newer
+            # title. Then discard exactly the awaited tasks so the session's refine
+            # bucket is reclaimed (a fresh incarnation's tasks can't exist yet, as
+            # its push is still blocked on this lock).
+            pending = list(self._refine_tasks.get(session_id, ()))
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+                for task in pending:
+                    self._discard_refine_task(session_id, task)
+        finally:
+            lock.release()
+            # Identity-guarded lock drop (mirrors _evict_over_cap): remove only the
+            # lock we actually held, never a successor a late same-session push
+            # minted after we released — that pusher owns the fresh session.
+            if self._session_locks.get(session_id) is lock:
+                self._session_locks.pop(session_id, None)
+
+    async def _finalize_session(self, session_id: str) -> None:
+        """Evict-path finalize of a single session (cancel refines, no upgrade).
+
+        The eviction variant. It first *cancels* any in-flight session-title
+        refinement — a stale refine must never emit after this session's title
+        stream is dropped and possibly replaced by a fresh stream on resume — then
+        drains and titles the session's trailing state with the packaged model
+        only, so no API task outlives the reclaimed stream. Called under the
+        session's lock by :meth:`_evict_over_cap`.
+
+        The public :meth:`finalize_session` shares the same per-session
+        drain/title/clear body (:meth:`_finalize_session_streams`) but keeps the
+        API upgrade (``schedule_refine=True``) and awaits it, because an
+        explicitly finalized session is completing normally rather than being
+        reclaimed under memory pressure.
         """
         self._cancel_session_refinements(session_id)
+        await self._finalize_session_streams(session_id, schedule_refine=False)
+
+    async def _finalize_session_streams(self, session_id: str, *, schedule_refine: bool) -> None:
+        """Drain one session's held phase plumbing, title its trailing open
+        activity, and drop its boundary/progress/turn-summary state.
+
+        The shared per-session finalize body, reused by :meth:`flush` (every
+        session), :meth:`_finalize_session` (one evicted victim,
+        ``schedule_refine=False`` — packaged titles only), and
+        :meth:`finalize_session` (one explicitly finalized session,
+        ``schedule_refine=True``). The phase drain runs first so every held event
+        has reached the title stream before it is flushed, matching flush
+        ordering.
+
+        With ``schedule_refine`` the just-titled trailing activity is queued for
+        an off-hot-path API upgrade when a refiner is configured (mirrors live
+        :meth:`_title_emit`); the *caller* awaits the resulting task. Eviction
+        passes ``False`` so no API task outlives the dropped stream. Pop-based
+        throughout, so a second call for the same session finds the streams
+        already gone and emits nothing.
+        """
         if self._phase_inferencer is not None:
             await self._drain_stream(session_id)
         if self._title_inferencer is not None:
@@ -439,7 +553,7 @@ class EventPipeline:
                     updates = await asyncio.to_thread(stream.flush)
                 except Exception as exc:
                     logger.error(
-                        "Title stream flush failed for evicted session %s: %s",
+                        "Title stream flush failed for session %s: %s",
                         session_id,
                         exc,
                         exc_info=True,
@@ -447,12 +561,13 @@ class EventPipeline:
                     updates = []
                 for update in updates:
                     await self._push_title_update(update)
-                # NOTE: eviction does not schedule API refinement for the trailing
-                # activity. It already cancelled this session's in-flight
-                # refinements above; finalizing with packaged titles only keeps a
-                # clean contract (evicted sessions get no API upgrades) and leaves
-                # no API task running after the stream is gone. Normally-completing
-                # sessions refine their trailing activity in _flush_title_streams.
+                if schedule_refine:
+                    # Upgrade the trailing activity's packaged titles off the hot
+                    # path when an API refiner is configured; the caller awaits
+                    # these before returning so a slow-but-successful upgrade is
+                    # never lost. Default (strategy=model) queues nothing.
+                    for closed in stream.take_activity_refinements():
+                        self._schedule_activity_refine(session_id, closed)
         self._boundary_streams.pop(session_id, None)
         if self._progress is not None:
             self._progress.forget(session_id)
@@ -759,36 +874,6 @@ class EventPipeline:
                 ev = self._boundary_stamp(ev)
             await self._title_emit(ev)
 
-    async def _flush_title_streams(self) -> None:
-        """Title each session's final open activity and emit its updates.
-
-        Title streams persist for the whole ``session_id`` (never torn down on
-        mid-session SESSION_ENDED/PAUSED markers). The session's events have all
-        already been emitted live; at pipeline flush the trailing activity has no
-        closing boundary, so it is titled from its full context here and its
-        :class:`~traceforge.types.TitleUpdate` records are emitted.
-        """
-        if self._title_inferencer is None:
-            return
-        for session_id in list(self._title_streams):
-            stream = self._title_streams.pop(session_id)
-            try:
-                updates = await asyncio.to_thread(stream.flush)
-            except Exception as exc:
-                logger.error(
-                    "Title stream flush failed for session %s: %s",
-                    session_id,
-                    exc,
-                    exc_info=True,
-                )
-                updates = []
-            for update in updates:
-                await self._push_title_update(update)
-            # Upgrade the trailing activity's packaged titles off the hot path
-            # when configured; flush() below awaits these before closing sinks.
-            for closed in stream.take_activity_refinements():
-                self._schedule_activity_refine(session_id, closed)
-
     async def _fanout(
         self,
         coros: Iterable[Awaitable],
@@ -941,19 +1026,17 @@ class EventPipeline:
             for event in self._enricher.flush():
                 await self._emit(event)
 
-        # Drain any sessions still holding leading plumbing (no content event
-        # and no explicit SESSION_ENDED seen). Steady-state events are already
-        # emitted live, so only the leading hold-buffer can remain.
-        if self._phase_inferencer is not None:
-            for session_id in list(self._phase_streams):
-                await self._drain_stream(session_id)
-
-        # Title each session's final open activity. Its events were already
-        # emitted live (carrying their segment ids); the trailing activity has
-        # no closing boundary, so it is titled here and its TitleUpdate records
-        # emitted. Done after phase drain so every event has reached the title
-        # stream first.
-        await self._flush_title_streams()
+        # Finalize every session that still holds live per-session stream state:
+        # drain its held leading plumbing, title its trailing open activity, and
+        # queue any configured off-hot-path API title upgrades. Iterate the union
+        # of phase- and title-stream keys — draining a phase stream can create a
+        # title stream for that same session, and _finalize_session_streams
+        # drains-then-titles per session, so one pass covers both. This reuses the
+        # exact per-session primitive as finalize_session, so global and
+        # per-session finalization can never drift. The union is materialised up
+        # front, so per-session pops during the loop are safe.
+        for session_id in dict.fromkeys((*self._phase_streams, *self._title_streams)):
+            await self._finalize_session_streams(session_id, schedule_refine=True)
 
         # Await any in-flight session-title API refinements so a slow-but-
         # successful upgrade lands (as its own title update) before the sinks are
@@ -963,12 +1046,13 @@ class EventPipeline:
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
 
-        # Boundary streams and per-session locks carry no buffered output to
-        # drain (boundary is O(1) causal state; locks are bare mutexes), but
-        # they are per-session and would otherwise outlive every finalized
-        # session. Reclaim them here so all four per-session maps free together
-        # at teardown, matching the phase/title drain above. Safe because flush
-        # is terminal: no push holds a lock or touches a boundary stream now.
+        # _finalize_session_streams already dropped each finalized session's
+        # boundary/progress/turn-summary state; these global clears reclaim any
+        # residue not tied to a phase/title stream — a session left with only a
+        # lock/order entry, or progress/turn-summary state without a stream (e.g.
+        # phase+title disabled). Locks are bare mutexes and boundary is O(1)
+        # causal state, so nothing here needs draining. Safe because flush is
+        # terminal: no push holds a lock or touches a stream now.
         self._boundary_streams.clear()
         self._session_locks.clear()
         self._session_order.clear()

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -1335,3 +1335,94 @@ class TestInfraDirScopeInference:
         flushed = enricher.flush()
         cls = flushed[0].metadata.classification
         assert "configuration.infrastructure" in cls.scope
+
+
+# =============================================================================
+# Public per-session lifecycle API: Enricher.flush_session
+# =============================================================================
+
+
+class TestEnricherFlushSession:
+    """``flush_session(sid)`` is the public, per-session analogue of ``flush``: it
+    drains ONLY that session's buffered unpaired tool-starts as orphans, leaving
+    every other session's buffer untouched. Idempotent and safe to call for an
+    unknown or already-drained session."""
+
+    def test_flush_session_emits_only_that_session_and_leaves_others_untouched(self):
+        # Two interleaved sessions each hold a buffered start. Flushing A returns
+        # only A's orphan; B's start is untouched and still pairs normally later.
+        enricher = Enricher()
+        a_start = _make_tool_start(tool_call_id="a", session_id="A")
+        b_start = _make_tool_start(tool_call_id="b", session_id="B")
+        assert enricher.process(a_start) is None  # buffered
+        assert enricher.process(b_start) is None  # buffered
+
+        orphans = enricher.flush_session("A")
+        assert [o.session_id for o in orphans] == ["A"]
+        assert orphans[0].id == a_start.id  # original identity preserved
+        assert orphans[0].metadata.duration_ms is None  # emitted as an orphan
+
+        # B was not touched: its start survives and still pairs into a real
+        # completion (duration computed), proving flushing A did not reset B.
+        paired = enricher.process(_make_tool_complete(tool_call_id="b", session_id="B"))
+        assert not isinstance(paired, list)
+        assert paired is not None and paired.session_id == "B"
+        assert paired.metadata.duration_ms is not None
+
+    def test_flush_session_is_idempotent_no_duplicate_orphans(self):
+        # Flushing the same session again yields nothing — its starts were removed
+        # as they were emitted — so no orphan completion is ever duplicated.
+        enricher = Enricher()
+        enricher.process(_make_tool_start(tool_call_id="a", session_id="A"))
+
+        first = enricher.flush_session("A")
+        assert [o.session_id for o in first] == ["A"]
+        assert enricher.flush_session("A") == []  # repeat: nothing left
+        assert enricher.flush_session("A") == []
+        # A global flush afterwards also finds nothing for A (no resurrection).
+        assert enricher.flush() == []
+
+    def test_flush_session_unknown_session_is_noop(self):
+        enricher = Enricher()
+        enricher.process(_make_tool_start(tool_call_id="a", session_id="A"))
+        # An unknown session flushes nothing and leaves A's buffer intact.
+        assert enricher.flush_session("never-seen") == []
+        remaining = enricher.flush_session("A")
+        assert [o.session_id for o in remaining] == ["A"]
+
+    def test_flush_session_drains_all_of_one_sessions_starts(self):
+        # Multiple unpaired starts for one session all drain in insertion order;
+        # a concurrently-buffered other session is left entirely alone.
+        enricher = Enricher()
+        enricher.process(_make_tool_start(tool_call_id="a1", session_id="A"))
+        enricher.process(_make_tool_start(tool_call_id="b1", session_id="B"))
+        enricher.process(_make_tool_start(tool_call_id="a2", session_id="A"))
+
+        orphans = enricher.flush_session("A")
+        assert [o.payload["tool_call_id"] for o in orphans] == ["a1", "a2"]
+        assert all(o.session_id == "A" and o.metadata.duration_ms is None for o in orphans)
+        # B remains buffered and flushes independently.
+        assert [o.session_id for o in enricher.flush_session("B")] == ["B"]
+
+    def test_flush_session_then_global_flush_is_compatible(self):
+        # flush_session + the global flush coexist: flush() drains the sessions
+        # flush_session did not, and never re-emits an already-drained session.
+        enricher = Enricher()
+        enricher.process(_make_tool_start(tool_call_id="a", session_id="A"))
+        enricher.process(_make_tool_start(tool_call_id="b", session_id="B"))
+
+        assert [o.session_id for o in enricher.flush_session("A")] == ["A"]
+        remaining = enricher.flush()
+        assert [o.session_id for o in remaining] == ["B"]  # only B left; A not re-emitted
+
+    def test_flush_session_does_not_disturb_other_session_on_id_collision(self):
+        # Even when a live session holds the SAME tool_call_id, flushing one
+        # session drains only its own buffered start (keyed by (session, id)).
+        enricher = Enricher()
+        enricher.process(_make_tool_start(tool_call_id="same", session_id="A"))
+        enricher.process(_make_tool_start(tool_call_id="same", session_id="B"))
+
+        assert [o.session_id for o in enricher.flush_session("A")] == ["A"]
+        paired = enricher.process(_make_tool_complete(tool_call_id="same", session_id="B"))
+        assert not isinstance(paired, list)
+        assert paired is not None and paired.session_id == "B"

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -840,3 +840,365 @@ class TestPipelineInferencerDefaults:
         explicit = PhaseInferencer()
         pipeline = EventPipeline(sinks=[], phase_inferencer=explicit, enable_phase=False)
         assert pipeline._phase_inferencer is explicit
+
+
+# ─── finalize_session (public per-session lifecycle) ─────────────────────────
+
+_FINALIZE_TEXT = "Alpha add retry logic to the HTTP client with backoff"
+
+
+def _fev(session_id: str, eid: str) -> SessionEvent:
+    """A tool.call that opens a titleable activity for ``session_id``."""
+    from datetime import datetime, timezone
+
+    from traceforge.types import EventMetadata
+
+    return SessionEvent(
+        id=eid,
+        kind="tool.call",
+        session_id=session_id,
+        timestamp=datetime.now(timezone.utc),
+        payload={"tool_name": "edit", "arguments": {"path": "client.py"}},
+        metadata=EventMetadata(source_framework="copilot"),
+    )
+
+
+def _fmsg(session_id: str, eid: str, text: str) -> SessionEvent:
+    """A substantive user message (drives the session-title + refinement path)."""
+    from datetime import datetime, timezone
+
+    from traceforge.types import EventMetadata
+
+    return SessionEvent(
+        id=eid,
+        kind="message.user",
+        session_id=session_id,
+        timestamp=datetime.now(timezone.utc),
+        payload={"content": text},
+        metadata=EventMetadata(source_framework="copilot"),
+    )
+
+
+def _title_pipeline(sinks: list[StorageSink], **titler_kwargs) -> EventPipeline:
+    """A pipeline whose only live structuring is the (fake-model) titler.
+
+    Phase/boundary/turn-summary are off so assertions isolate title behaviour;
+    the fake title model keeps titles deterministic and offline.
+    """
+    from tests.unit.test_title_inferencer import _FakeTitle
+
+    from traceforge.title import TitleInferencer
+
+    return EventPipeline(
+        sinks=sinks,
+        enable_phase=False,
+        enable_boundary=False,
+        enable_turn_summary=False,
+        title_inferencer=TitleInferencer(model=_FakeTitle(), **titler_kwargs),
+    )
+
+
+class TestPipelineFinalizeSession:
+    """``finalize_session(sid)`` is the public, per-session analogue of flush: it
+    drains + titles ONE session and reclaims only that session's live state,
+    leaving every other active session untouched, and never flushes the sinks."""
+
+    async def test_finalize_emits_only_that_session_and_leaves_others_untouched(self):
+        # Two interleaved sessions. Finalizing A titles A's trailing activity and
+        # reclaims A's state; B emits nothing, its stream is not reset, and it
+        # keeps flowing on the SAME stream until it too is finalized — each
+        # session's updates landing exactly once, correctly attributed.
+        recorder = RecordingSink()
+        pipeline = _title_pipeline([recorder.sink])
+
+        await pipeline.push(_fev("A", "A0"))
+        await pipeline.push(_fev("B", "B0"))
+        assert recorder.title_updates == []  # both activities still open
+
+        b_stream = pipeline._title_streams["B"]
+        await pipeline.finalize_session("A")
+
+        a_acts = [u for u in recorder.title_updates if u.session_id == "A" and u.kind == "activity"]
+        assert len(a_acts) == 1 and a_acts[0].segment_id == "A0"
+        # B was not touched: no updates, same stream object, still resident.
+        assert [u for u in recorder.title_updates if u.session_id == "B"] == []
+        assert pipeline._title_streams["B"] is b_stream
+        # A's per-session state is fully reclaimed; B's is intact.
+        assert "A" not in pipeline._title_streams
+        assert "A" not in pipeline._session_locks
+        assert "A" not in pipeline._session_order
+        assert {"B"} == set(pipeline._session_order) == set(pipeline._session_locks)
+
+        # B keeps flowing on its original (un-reset) stream, then finalizes with
+        # exactly-once, correctly-attributed updates; A is never re-emitted.
+        await pipeline.push(_fev("B", "B1"))
+        await pipeline.finalize_session("B")
+        b_acts = [u for u in recorder.title_updates if u.session_id == "B" and u.kind == "activity"]
+        assert len(b_acts) == 1 and b_acts[0].segment_id == "B0"
+        a_acts = [u for u in recorder.title_updates if u.session_id == "A" and u.kind == "activity"]
+        assert len(a_acts) == 1  # unchanged — finalizing B did not re-emit A
+        assert not pipeline._session_order  # everything reclaimed
+
+    async def test_repeated_finalize_is_idempotent(self):
+        # Finalizing the same session again emits no duplicate updates and does
+        # not raise — the per-session state is popped as it is finalized.
+        recorder = RecordingSink()
+        pipeline = _title_pipeline([recorder.sink])
+        await pipeline.push(_fev("A", "A0"))
+
+        await pipeline.finalize_session("A")
+        after_first = list(recorder.title_updates)
+        assert [u for u in after_first if u.kind == "activity"]  # something was emitted
+
+        await pipeline.finalize_session("A")
+        await pipeline.finalize_session("A")
+        assert recorder.title_updates == after_first  # no duplicates on repeat
+
+    async def test_finalize_unknown_session_is_noop(self):
+        # An unknown / never-seen session id is a clean no-op.
+        recorder = RecordingSink()
+        pipeline = EventPipeline(
+            sinks=[recorder.sink],
+            enable_phase=False,
+            enable_boundary=False,
+            enable_turn_summary=False,
+        )
+        await pipeline.finalize_session("never-seen")  # must not raise
+        assert recorder.events == []
+        assert recorder.title_updates == []
+        assert "never-seen" not in pipeline._session_locks
+        assert "never-seen" not in pipeline._session_order
+
+    async def test_finalize_reclaims_only_that_sessions_transport_state(self):
+        # Transport-only: the per-session state is just the lock + recency entry.
+        # Finalizing one drops exactly its entries and leaves the other's intact.
+        pipeline = EventPipeline(
+            sinks=[],
+            enable_phase=False,
+            enable_boundary=False,
+            enable_turn_summary=False,
+            max_sessions=None,
+        )
+        await pipeline.push(make_event(session_id="a", id="a0"))
+        await pipeline.push(make_event(session_id="b", id="b0"))
+        assert set(pipeline._session_order) == {"a", "b"}
+
+        await pipeline.finalize_session("a")
+        assert set(pipeline._session_order) == {"b"}
+        assert "a" not in pipeline._session_locks
+        assert "b" in pipeline._session_locks and "b" in pipeline._session_order
+
+    async def test_finalize_forgets_progress_and_turn_summary_for_that_session_only(self):
+        # The live progress + turn-summary emitters hold O(1) per-session state;
+        # finalizing one session forgets ITS state and no other's.
+        pipeline = EventPipeline(
+            sinks=[],
+            enable_phase=False,
+            enable_boundary=False,
+            enable_turn_summary=True,
+        )
+        pipeline.subscribe(on_progress=lambda _u: None)  # arm the progress emitter
+        await pipeline.push(_fev("a", "a0"))
+        await pipeline.push(_fev("b", "b0"))
+        assert {"a", "b"} <= set(pipeline._turn_summarizer._activity)
+        assert {"a", "b"} <= set(pipeline._progress._activity)
+
+        await pipeline.finalize_session("a")
+        assert "a" not in pipeline._turn_summarizer._activity
+        assert "b" in pipeline._turn_summarizer._activity
+        assert "a" not in pipeline._progress._activity
+        assert "b" in pipeline._progress._activity
+
+    async def test_finalize_awaits_and_reclaims_session_refinement(self):
+        # An off-hot-path API session-title refinement scheduled while pushing
+        # must be AWAITED by finalize (its update lands exactly once) and its task
+        # bucket reclaimed before finalize returns.
+        import threading
+
+        release = threading.Event()
+
+        def heuristic(text: str) -> str:
+            return "Heuristic " + text.split()[0]
+
+        def refiner(text: str) -> str:
+            release.wait(timeout=5)  # keep the refinement in-flight
+            return "Refined " + text.split()[0]
+
+        recorder = RecordingSink()
+        pipeline = _title_pipeline(
+            [recorder.sink], session_titler=heuristic, session_refiner=refiner
+        )
+        await pipeline.push(_fmsg("A", "A0", _FINALIZE_TEXT))
+        # Only the heuristic session title so far; the refinement is blocked.
+        sess = [u.title for u in recorder.title_updates if u.kind == "session"]
+        assert sess == ["Heuristic Alpha"]
+        assert pipeline._refine_tasks.get("A")  # a refinement is in flight
+
+        release.set()
+        await pipeline.finalize_session("A")
+        # finalize awaited the refinement: the API title landed exactly once, and
+        # the session's refine bucket + lock/order state were reclaimed.
+        sess = [u.title for u in recorder.title_updates if u.kind == "session"]
+        assert sess == ["Heuristic Alpha", "Refined Alpha"]
+        assert "A" not in pipeline._refine_tasks
+        assert "A" not in pipeline._session_locks
+        assert "A" not in pipeline._session_order
+
+    async def test_concurrent_finalize_same_session_titles_exactly_once(self):
+        import asyncio
+
+        recorder = RecordingSink()
+        pipeline = _title_pipeline([recorder.sink])
+        await pipeline.push(_fev("A", "A0"))
+
+        # Two finalizations of the same session race on its lock; the loser finds
+        # the stream already gone, so the activity is titled exactly once.
+        await asyncio.gather(pipeline.finalize_session("A"), pipeline.finalize_session("A"))
+        a_acts = [u for u in recorder.title_updates if u.session_id == "A" and u.kind == "activity"]
+        assert len(a_acts) == 1
+        assert "A" not in pipeline._title_streams
+        assert "A" not in pipeline._session_locks
+        assert "A" not in pipeline._session_order
+
+    async def test_concurrent_finalize_distinct_sessions(self):
+        import asyncio
+
+        recorder = RecordingSink()
+        pipeline = _title_pipeline([recorder.sink])
+        await pipeline.push(_fev("A", "A0"))
+        await pipeline.push(_fev("B", "B0"))
+
+        await asyncio.gather(pipeline.finalize_session("A"), pipeline.finalize_session("B"))
+        a_acts = [u for u in recorder.title_updates if u.session_id == "A" and u.kind == "activity"]
+        b_acts = [u for u in recorder.title_updates if u.session_id == "B" and u.kind == "activity"]
+        assert len(a_acts) == 1 and a_acts[0].segment_id == "A0"
+        assert len(b_acts) == 1 and b_acts[0].segment_id == "B0"
+        assert not pipeline._session_order and not pipeline._title_streams
+
+    async def test_finalize_serializes_with_push_on_the_session_lock(self):
+        # finalize runs under the session lock, so it cannot interleave into an
+        # in-flight push: while the push's lock is held, finalize is blocked; it
+        # proceeds and reclaims the session only after the lock is released.
+        import asyncio
+
+        pipeline = EventPipeline(
+            sinks=[],
+            enable_phase=False,
+            enable_boundary=False,
+            enable_turn_summary=False,
+            max_sessions=None,
+        )
+        await pipeline.push(make_event(session_id="s", id="s0"))
+        lock = pipeline._session_lock("s")
+        await lock.acquire()  # stand in for an in-flight push holding the lock
+
+        fin = asyncio.create_task(pipeline.finalize_session("s"))
+        await asyncio.sleep(0.02)
+        assert not fin.done()  # blocked on the held session lock
+        assert "s" in pipeline._session_order  # not yet reclaimed
+
+        lock.release()
+        await fin
+        assert "s" not in pipeline._session_order  # reclaimed once the lock frees
+        assert "s" not in pipeline._session_locks
+
+    async def test_concurrent_push_and_finalize_same_session_is_safe(self):
+        # push holds the session lock across event ingestion, so a finalize racing
+        # the same session's push always runs AFTER the event is ingested (never
+        # mid-push): the activity is titled exactly once and the stream reclaimed.
+        import asyncio
+
+        recorder = RecordingSink()
+        pipeline = _title_pipeline([recorder.sink])
+        await asyncio.gather(pipeline.push(_fev("A", "A0")), pipeline.finalize_session("A"))
+        a_acts = [u for u in recorder.title_updates if u.session_id == "A" and u.kind == "activity"]
+        assert len(a_acts) == 1 and a_acts[0].segment_id == "A0"
+        assert "A" not in pipeline._title_streams
+
+    async def test_awaited_refinement_cannot_clobber_a_fresh_incarnation(self):
+        # Regression: a slow refinement scheduled by the FIRST incarnation must be
+        # delivered before a late same-session push can start a fresh incarnation
+        # and emit a newer title — otherwise the stale refine would clobber it.
+        # finalize awaits refinements UNDER the session lock, so a late same-session
+        # push is deterministically blocked until the old refinement has landed.
+        import asyncio
+        import threading
+
+        release = threading.Event()
+
+        def heuristic(text: str) -> str:
+            return "Heuristic " + text.split()[0]
+
+        def refiner(text: str) -> str:
+            release.wait(timeout=5)  # keep the first incarnation's refine in-flight
+            return "Refined " + text.split()[0]
+
+        recorder = RecordingSink()
+        pipeline = _title_pipeline(
+            [recorder.sink], session_titler=heuristic, session_refiner=refiner
+        )
+        await pipeline.push(_fmsg("A", "A0", _FINALIZE_TEXT))
+        assert pipeline._refine_tasks.get("A")  # first incarnation's refine blocked
+
+        fin = asyncio.create_task(pipeline.finalize_session("A"))
+        await asyncio.sleep(0.05)  # finalize drains, then blocks awaiting the refine
+        assert not fin.done()
+
+        # A late same-session push must wait behind the finalization-held lock. It
+        # is blocked *indefinitely* until the refinement is released — a generous
+        # wait that a free push would finish in ~1ms, so this reliably separates
+        # "blocked on the lock" (fixed) from "raced ahead" (the bug).
+        push2 = asyncio.create_task(
+            pipeline.push(_fmsg("A", "A1", "Beta build the pagination endpoint for the users API"))
+        )
+        await asyncio.sleep(0.1)
+        assert not push2.done()  # blocked — cannot start the fresh incarnation yet
+        assert "Heuristic Beta" not in [
+            u.title for u in recorder.title_updates if u.kind == "session"
+        ]
+
+        release.set()
+        await asyncio.gather(fin, push2)
+        # The first incarnation's refinement landed BEFORE the fresh incarnation's
+        # heuristic — correct order, no stale clobber.
+        sess = [u.title for u in recorder.title_updates if u.kind == "session"]
+        assert sess.index("Refined Alpha") < sess.index("Heuristic Beta")
+
+    async def test_push_after_finalize_starts_a_fresh_session(self):
+        # A push that lands after finalization starts the session fresh from cold
+        # state (new stream + lock), exactly like the post-eviction contract.
+        recorder = RecordingSink()
+        pipeline = _title_pipeline([recorder.sink])
+
+        await pipeline.push(_fev("A", "A0"))
+        await pipeline.finalize_session("A")
+        assert "A" not in pipeline._title_streams
+
+        await pipeline.push(_fev("A", "A1"))  # fresh incarnation
+        assert "A" in pipeline._title_streams and "A" in pipeline._session_locks
+        await pipeline.finalize_session("A")
+
+        a_acts = [u for u in recorder.title_updates if u.session_id == "A" and u.kind == "activity"]
+        # Two independent activities were titled — the first and second lives —
+        # with no cross-contamination between incarnations.
+        assert {u.segment_id for u in a_acts} == {"A0", "A1"}
+
+    async def test_flush_after_finalize_is_compatible(self):
+        # finalize + global flush coexist: flush finalizes the sessions finalize
+        # did not, flushes the sinks, and never re-emits an already-finalized one.
+        recorder = RecordingSink()
+        flush_sink = FlushTrackingSink()
+        pipeline = _title_pipeline([recorder.sink, flush_sink])
+
+        await pipeline.push(_fev("A", "A0"))
+        await pipeline.push(_fev("B", "B0"))
+        await pipeline.finalize_session("A")
+
+        await pipeline.flush()
+        a_acts = [u for u in recorder.title_updates if u.session_id == "A" and u.kind == "activity"]
+        b_acts = [u for u in recorder.title_updates if u.session_id == "B" and u.kind == "activity"]
+        assert len(a_acts) == 1  # not re-emitted by flush
+        assert len(b_acts) == 1 and b_acts[0].segment_id == "B0"  # flush titled B
+        assert flush_sink.flushed  # sinks flushed exactly by the global flush
+        assert not pipeline._session_order  # all per-session state reclaimed
+        assert not pipeline._title_streams and not pipeline._session_locks

--- a/uv.lock
+++ b/uv.lock
@@ -4174,7 +4174,7 @@ source = { editable = "packages/traceforge-title-model" }
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Why

CodePlane (and any daemon) shares one `EventPipeline` + `Enricher` across concurrent jobs. The only per-session lifecycle hooks were **private** (`EventPipeline._finalize_session`, `Enricher._flush_session`), and the **global** `flush()` finalizes/clears *every* active session. So when one job ends, calling global flush prematurely emits/wipes the other in-flight sessions. This PR exposes two supported public per-session primitives so a caller can retire one finished session without disturbing the others — no private-API calls, no re-implementation of the deterministic pipeline logic.

## What

### `EventPipeline.finalize_session(session_id: str) -> None`
The per-session analogue of `flush()`:
- Drains the session's held leading plumbing (phase), titles its trailing open activity (title-stream flush), and delivers that session's off-hot-path **API title refinements**.
- Reclaims **only** that session's phase/boundary/title/progress/turn-summary/lock/order state. Every other active session is byte-for-byte unaffected; the sinks are **not** flushed or closed.
- **Serialisation:** runs under the session's own lock (`_acquire_session`), so it serialises with a concurrent `push()` for the *same* session; distinct sessions never contend.
- **Stale-title safety:** refinements are awaited *while holding the session lock* (after dropping the session from the recency order), so a late same-session push cannot start a fresh incarnation and emit a newer title before the old incarnation's slow refine lands — and eviction cannot cancel a task we must deliver. This upholds the repo's existing stale-refinement-clobber invariant.
- **Idempotent**; unknown/never-seen session is a no-op.
- Eviction's private `_finalize_session` and `flush()` now reuse a shared `_finalize_session_streams` primitive, so global and per-session finalization can't drift.

### `Enricher.flush_session(session_id: str) -> list[SessionEvent]`
A public wrapper over the private `_flush_session`:
- Drains and returns **only** that session's buffered unpaired tool-starts as orphan completions (`duration_ms=None`); other sessions' buffers untouched.
- Synchronous and atomic w.r.t. the event loop, **idempotent** (repeat / unknown session → `[]`, no duplicate orphans). The global `flush()` and the `SESSION_ENDED` internal drain are unchanged.

## Tests
- **13** `finalize_session` cases + **6** `flush_session` cases, all using ≥2 interleaved session ids: isolation, exactly-once attribution, idempotent repeat, unknown session, concurrent same/distinct sessions, `push`+`finalize` serialization, refinement await + task cleanup, a **deterministic stale-clobber regression** (verified it fails against an await-outside-lock variant and passes with the fix), progress/turn-summary per-session reclamation, id-collision isolation, fresh-incarnation-after-finalize, and global-`flush()` compatibility.
- Full suite: **3735 passed / 10 skipped**. `ruff check` + `ruff format --check` (pinned 0.15.20) clean. Wheel + sdist build as `0.1.5`, LFS integrity guard passes, package metadata verified.

## Release
Patch release `traceforge-toolkit` **0.1.4 → 0.1.5**: `pyproject.toml` + `uv.lock` bumped, `CHANGELOG.md` `[0.1.5]` documents both contracts. The independent `traceforge-title-model` **0.2.0** is unchanged.

## Public API surface
Both are methods on already-public classes (`EventPipeline`, `Enricher`), fully type-hinted and documented. No CodePlane-specific types or behavior.

Do not tag/release from this PR — it only lands the code + version metadata.