### PR TITLE
Test: finalize_session refinement cannot clobber a fresh incarnation

### DIFF
--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -941,6 +941,56 @@ class TestPipelineFinalizeSession:
         await pipeline.flush()
         assert titles("B") == ["Heuristic Bravo", "Refined Bravo"]
 
+    async def test_finalize_refinement_cannot_clobber_a_fresh_incarnation(self):
+        # Stronger than the await test above: finalize awaits the refinement *under
+        # the session lock*, so a late same-session push cannot start a fresh
+        # incarnation (and emit a newer session title) until the prior
+        # incarnation's refinement has landed. Were the refinement awaited outside
+        # the lock, the fresh "Heuristic Beta" could be emitted first and then be
+        # overwritten by the stale "Refined Alpha" on the same session segment.
+        import asyncio
+        import threading
+
+        release = threading.Event()
+
+        def heuristic(text: str) -> str:
+            return "Heuristic " + text.split()[0]
+
+        def refiner(text: str) -> str:
+            release.wait(timeout=5)  # keep the first incarnation's refine in-flight
+            return "Refined " + text.split()[0]
+
+        recorder = RecordingSink()
+        pipeline = self._titled([recorder.sink], session_titler=heuristic, session_refiner=refiner)
+        await pipeline.push(self._umsg("A", "Alpha add retry logic to the HTTP client"))
+        assert pipeline._refine_tasks.get("A")  # first incarnation's refine in-flight
+
+        fin = asyncio.create_task(pipeline.finalize_session("A"))
+        await asyncio.sleep(0.05)  # finalize drains, then blocks awaiting the refine
+        assert not fin.done()
+
+        # A late same-session push must wait behind the finalization-held lock: it
+        # stays blocked until the refine is released (a free push would finish in
+        # ~1ms), cleanly separating "serialized after delivery" from "raced ahead".
+        push2 = asyncio.create_task(
+            pipeline.push(self._umsg("A", "Beta build the pagination endpoint for the users API"))
+        )
+        await asyncio.sleep(0.1)
+        assert not push2.done()  # blocked — the fresh incarnation cannot start yet
+        assert "Heuristic Beta" not in [
+            u.title for u in recorder.title_updates if u.kind == "session"
+        ]
+
+        release.set()
+        await asyncio.wait_for(asyncio.gather(fin, push2), timeout=5)
+
+        sess = [
+            u.title for u in recorder.title_updates if u.session_id == "A" and u.kind == "session"
+        ]
+        # The first incarnation's refinement landed BEFORE the fresh incarnation's
+        # heuristic — no stale clobber.
+        assert sess.index("Refined Alpha") < sess.index("Heuristic Beta")
+
     async def test_finalize_drains_only_that_sessions_held_plumbing(self):
         # Phase inference holds contiguous *leading* plumbing until the session's
         # first content event; finalizing one session must release only its hold.


### PR DESCRIPTION
## What

A test-only follow-up to #239 (per-session finalization APIs). #239 tests that `EventPipeline.finalize_session` **awaits** a session's in-flight title refinement instead of cancelling it. This adds the stronger, deterministic **ordering** guarantee that the await-under-the-lock design provides:

> A late same-session `push` cannot start a fresh incarnation (and emit a newer session title) until the prior incarnation's refinement has landed — so a slow `Refined Alpha` can never clobber a fresh `Heuristic Beta` on the same session segment.

## The test

`test_finalize_refinement_cannot_clobber_a_fresh_incarnation` blocks a session refiner, starts `finalize_session` (which parks awaiting it under the session lock), then starts a same-session `push` and asserts it stays **blocked** and emits nothing until the refine is released — then that `Refined Alpha` is recorded **before** the fresh incarnation's `Heuristic Beta`.

## Teeth

I verified it **fails** when `finalize_session`'s `_await_session_refinements` is moved *outside* the lock (the `push2` races ahead and completes), and **passes** on `main` as-is. So it guards the exact regression, not a tautology. All 12 `TestPipelineFinalizeSession` cases pass; `ruff check` + `format` clean.

## Scope

Test-only — no product changes (`pipeline.py`/`enricher.py` untouched). No version bump. Complements #239's suite; safe to merge or decline.